### PR TITLE
Add idiomatic-Go agent rules to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,12 +116,40 @@ go run ./cmd/ocifactory serve \
 ## Code conventions
 
 - **Languages:** Go is the only implementation language. Avoid pulling in shell scripts when a Go test will do.
-- **Style:** `gofmt -s` clean. Follow [Effective Go](https://go.dev/doc/effective_go) and the [Google Go style guide](https://google.github.io/styleguide/go/) where it doesn't conflict. Prefer explicit and boring over clever.
-- **Errors:** wrap with `fmt.Errorf("...: %w", err)`. Use `errors.Is` / `errors.As` to check. The `pkg/oci` package already exposes `oci.HasCode(err, statusCode)` for translating ORAS HTTP errors — use it in handlers rather than re-deriving status codes.
+- **Style:** Write idiomatic Go. Follow [Effective Go](https://go.dev/doc/effective_go) and the Google Go style guide — [overview](https://google.github.io/styleguide/go/), [style decisions](https://google.github.io/styleguide/go/decisions), [best practices](https://google.github.io/styleguide/go/best-practices). Prefer explicit and boring over clever. `gofmt -s` and `go vet` must be clean before every commit.
+- **Errors:** wrap with `fmt.Errorf("doing X: %w", err)`. Use `errors.Is` / `errors.As` to check. The `pkg/oci` package already exposes `oci.HasCode(err, statusCode)` for translating ORAS HTTP errors — use it in handlers rather than re-deriving status codes.
 - **Logging:** `github.com/abcxyz/pkg/logging`. Read with `logging.FromContext(ctx)`; configure via `OCIFACTORY_LOG_LEVEL`, `OCIFACTORY_LOG_FORMAT`, `OCIFACTORY_LOG_DEBUG`.
-- **Tests:** table-driven where it fits. Use the in-memory `oci.fake` backend for handler tests. Don't mock `handler.Registry` itself — exercise the real `pkg/oci` code with the fake backend underneath, so we test integration of layers.
 - **Routing:** gorilla/mux (already adopted, see commit `26f36de`). Don't reach for stdlib `http.ServeMux` for new format handlers.
 - **Public API surface:** anything in `pkg/` is public. Don't expose internals you wouldn't want to support — when in doubt, lowercase it.
+
+### Testing rules
+
+These are non-negotiable. Apply them to every test in the repo:
+
+1. **`t.Parallel()`** at the top of every test function and every subtest. The only exception is when a test mutates process-global state and a comment says so. Tests must be safe to run in parallel.
+2. **`t.Context()`** (Go 1.24+) for the test's `context.Context` — it's auto-cancelled on test cleanup. Don't reach for `context.Background()` or hand-roll a cancel.
+3. **Table-driven tests** wherever a function has more than one interesting input. Even for small N, the structure makes adding cases trivial:
+   ```go
+   tests := []struct{
+       name string
+       // inputs...
+       // wants...
+   }{ /* ... */ }
+   for _, tc := range tests {
+       t.Run(tc.name, func(t *testing.T) {
+           t.Parallel()
+           // ...
+       })
+   }
+   ```
+4. **Compare whole values with `cmp.Diff`** (`github.com/google/go-cmp/cmp`):
+   ```go
+   if diff := cmp.Diff(want, got); diff != "" {
+       t.Errorf("Foo() mismatch (-want +got):\n%s", diff)
+   }
+   ```
+   Don't compare field-by-field with `==` or `reflect.DeepEqual` when `cmp.Diff` will work — the diff output is what makes failures debuggable. The argument order is `(want, got)` so the diff legend reads correctly.
+5. **Fakes, not mocks.** No `gomock`, no `testify/mock`, no codegen mock libraries. Write a small fake of the interface in a `_test.go` file (or `pkg/<x>/fake.go` if reused across packages). For handler tests, don't mock `handler.Registry` — exercise the real `pkg/oci` code on top of the in-memory backend in `pkg/oci/fake.go`, so the layers are tested together.
 
 ## Adding a new repo type — checklist
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,7 @@ go run ./cmd/ocifactory serve \
 
 - **Languages:** Go is the only implementation language. Avoid pulling in shell scripts when a Go test will do.
 - **Style:** Write idiomatic Go. Follow [Effective Go](https://go.dev/doc/effective_go) and the Google Go style guide — [overview](https://google.github.io/styleguide/go/), [style decisions](https://google.github.io/styleguide/go/decisions), [best practices](https://google.github.io/styleguide/go/best-practices). Prefer explicit and boring over clever. `gofmt -s` and `go vet` must be clean before every commit.
-- **Errors:** wrap with `fmt.Errorf("doing X: %w", err)`. Use `errors.Is` / `errors.As` to check. The `pkg/oci` package already exposes `oci.HasCode(err, statusCode)` for translating ORAS HTTP errors — use it in handlers rather than re-deriving status codes.
+- **Errors:** wrap with `fmt.Errorf("...: %w", err)`. Use `errors.Is` / `errors.As` to check. The `pkg/oci` package already exposes `oci.HasCode(err, statusCode)` for translating ORAS HTTP errors — use it in handlers rather than re-deriving status codes.
 - **Logging:** `github.com/abcxyz/pkg/logging`. Read with `logging.FromContext(ctx)`; configure via `OCIFACTORY_LOG_LEVEL`, `OCIFACTORY_LOG_FORMAT`, `OCIFACTORY_LOG_DEBUG`.
 - **Routing:** gorilla/mux (already adopted, see commit `26f36de`). Don't reach for stdlib `http.ServeMux` for new format handlers.
 - **Public API surface:** anything in `pkg/` is public. Don't expose internals you wouldn't want to support — when in doubt, lowercase it.

--- a/pkg/commands/serve_test.go
+++ b/pkg/commands/serve_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestServeFlagsValidate(t *testing.T) {
+	t.Parallel()
 
 	cases := []struct {
 		name    string

--- a/pkg/cred/context_test.go
+++ b/pkg/cred/context_test.go
@@ -45,8 +45,7 @@ func TestWithCred(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
-			gotCtx := WithCred(ctx, tt.cred)
+			gotCtx := WithCred(t.Context(), tt.cred)
 			gotCred, ok := FromContext(gotCtx)
 
 			if tt.wantCred == nil {
@@ -74,8 +73,7 @@ func TestFromContext(t *testing.T) {
 	t.Run("missing cred", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
-		gotCred, ok := FromContext(ctx)
+		gotCred, ok := FromContext(t.Context())
 
 		if ok {
 			t.Errorf("FromContext() ok = true, want false")
@@ -89,7 +87,7 @@ func TestFromContext(t *testing.T) {
 	t.Run("incorrect value type", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.WithValue(context.Background(), credKey, "not a cred")
+		ctx := context.WithValue(t.Context(), credKey, "not a cred")
 		gotCred, ok := FromContext(ctx)
 
 		if ok {

--- a/pkg/handler/maven/handler_test.go
+++ b/pkg/handler/maven/handler_test.go
@@ -1,7 +1,6 @@
 package maven
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -241,7 +240,7 @@ func TestHandleGet(t *testing.T) {
 
 			registry := oci.NewFakeRegistry()
 			if tc.setupFile != nil {
-				_, err := registry.AddFile(context.Background(), tc.setupFile, strings.NewReader(tc.setupData))
+				_, err := registry.AddFile(t.Context(), tc.setupFile, strings.NewReader(tc.setupData))
 				if err != nil {
 					t.Fatalf("Failed to set up file: %v", err)
 				}

--- a/pkg/handler/python/hander_test.go
+++ b/pkg/handler/python/hander_test.go
@@ -2,7 +2,6 @@ package python
 
 import (
 	"bytes"
-	"context"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -260,7 +259,7 @@ func TestHandleGet(t *testing.T) {
 
 			registry := oci.NewFakeRegistry()
 			if tc.setupFile != nil {
-				_, err := registry.AddFile(context.Background(), tc.setupFile, strings.NewReader(tc.setupData))
+				_, err := registry.AddFile(t.Context(), tc.setupFile, strings.NewReader(tc.setupData))
 				if err != nil {
 					t.Fatalf("Failed to set up file: %v", err)
 				}

--- a/pkg/oci/fake_test.go
+++ b/pkg/oci/fake_test.go
@@ -1,8 +1,8 @@
 package oci
 
 import (
-	"context"
 	"io"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -85,11 +85,11 @@ func TestFakeRegistry_AddFile(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		file       *RepoFile
-		content    string
-		wantErr    bool
-		wantDigest string
+		name     string
+		file     *RepoFile
+		content  string
+		wantErr  bool
+		wantFile ocispec.Descriptor
 	}{
 		{
 			name: "add simple file",
@@ -99,9 +99,15 @@ func TestFakeRegistry_AddFile(t *testing.T) {
 				Name:       "test.txt",
 				MediaType:  "text/plain",
 			},
-			content:    "test content",
-			wantErr:    false,
-			wantDigest: "sha256:6ae8a75555209fd6c44157c0aed8016e763ff435a19cf186f76863140143ff72",
+			content: "test content",
+			wantFile: ocispec.Descriptor{
+				MediaType: "text/plain",
+				Digest:    "sha256:6ae8a75555209fd6c44157c0aed8016e763ff435a19cf186f76863140143ff72",
+				Size:      12,
+				Annotations: map[string]string{
+					FileNameAnnotation: "test.txt",
+				},
+			},
 		},
 	}
 
@@ -110,60 +116,31 @@ func TestFakeRegistry_AddFile(t *testing.T) {
 			t.Parallel()
 
 			registry := NewFakeRegistry()
-			ctx := context.Background()
 
-			desc, err := registry.AddFile(ctx, tt.file, strings.NewReader(tt.content))
+			desc, err := registry.AddFile(t.Context(), tt.file, strings.NewReader(tt.content))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("AddFile() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-
 			if err != nil {
 				return
 			}
 
-			// Check if file was stored correctly
+			if diff := cmp.Diff(tt.wantFile, desc.File); diff != "" {
+				t.Errorf("AddFile() desc.File mismatch (-want +got):\n%s", diff)
+			}
+
 			key := tt.file.OwningRepo + "/" + tt.file.OwningTag + "/" + tt.file.Name
-			content, ok := registry.Files[key]
+			gotContent, ok := registry.Files[key]
 			if !ok {
-				t.Errorf("File not found in registry: %s", key)
-				return
+				t.Errorf("File not stored at key %q", key)
+			} else if string(gotContent) != tt.content {
+				t.Errorf("Stored content = %q, want %q", string(gotContent), tt.content)
 			}
 
-			if string(content) != tt.content {
-				t.Errorf("File content = %q, want %q", string(content), tt.content)
-			}
-
-			// Check if tag was added
-			tags, ok := registry.Tags[tt.file.OwningRepo]
-			if !ok {
-				t.Errorf("Repo not found in tags: %s", tt.file.OwningRepo)
-				return
-			}
-
-			found := false
-			for _, tag := range tags {
-				if tag == tt.file.OwningTag {
-					found = true
-					break
-				}
-			}
-			if !found {
-				t.Errorf("Tag %q not found for repo %q", tt.file.OwningTag, tt.file.OwningRepo)
-			}
-
-			// Check descriptor
-			if desc.File.Digest.String() != tt.wantDigest {
-				t.Errorf("Descriptor digest = %q, want %q", desc.File.Digest.String(), tt.wantDigest)
-			}
-
-			if desc.File.MediaType != tt.file.MediaType {
-				t.Errorf("Descriptor media type = %q, want %q", desc.File.MediaType, tt.file.MediaType)
-			}
-
-			if desc.File.Annotations[FileNameAnnotation] != tt.file.Name {
-				t.Errorf("Descriptor filename annotation = %q, want %q",
-					desc.File.Annotations[FileNameAnnotation], tt.file.Name)
+			gotTags := registry.Tags[tt.file.OwningRepo]
+			if !slices.Contains(gotTags, tt.file.OwningTag) {
+				t.Errorf("Tag %q not found for repo %q (got tags: %v)", tt.file.OwningTag, tt.file.OwningRepo, gotTags)
 			}
 		})
 	}
@@ -219,7 +196,7 @@ func TestFakeRegistry_ReadFile(t *testing.T) {
 			t.Parallel()
 
 			registry := NewFakeRegistry()
-			ctx := context.Background()
+			ctx := t.Context()
 
 			// Setup file if needed
 			if tt.setupFile != nil {
@@ -297,8 +274,7 @@ func TestFakeRegistry_ListTags(t *testing.T) {
 			registry := NewFakeRegistry()
 			registry.Tags = tt.setupTags
 
-			ctx := context.Background()
-			got, err := registry.ListTags(ctx, tt.repo)
+			got, err := registry.ListTags(t.Context(), tt.repo)
 			if err != nil {
 				t.Errorf("ListTags() error = %v", err)
 				return
@@ -344,21 +320,8 @@ func Test_generateDescriptor(t *testing.T) {
 
 			got := generateDescriptor(tt.content, tt.file)
 
-			if got.MediaType != tt.want.MediaType {
-				t.Errorf("MediaType = %q, want %q", got.MediaType, tt.want.MediaType)
-			}
-
-			if got.Digest != tt.want.Digest {
-				t.Errorf("Digest = %q, want %q", got.Digest, tt.want.Digest)
-			}
-
-			if got.Size != tt.want.Size {
-				t.Errorf("Size = %d, want %d", got.Size, tt.want.Size)
-			}
-
-			if got.Annotations[FileNameAnnotation] != tt.want.Annotations[FileNameAnnotation] {
-				t.Errorf("Filename annotation = %q, want %q",
-					got.Annotations[FileNameAnnotation], tt.want.Annotations[FileNameAnnotation])
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("generateDescriptor() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -415,7 +378,7 @@ func TestFakeRegistry_ListFiles(t *testing.T) {
 				Tags:  make(map[string][]string),
 			}
 
-			got, err := registry.ListFiles(context.Background(), tt.repo)
+			got, err := registry.ListFiles(t.Context(), tt.repo)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("FakeRegistry.ListFiles() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/oci/registry_test.go
+++ b/pkg/oci/registry_test.go
@@ -83,8 +83,8 @@ func TestNewRegistry(t *testing.T) {
 				t.Errorf("NewRegistry() artifactType = %v, want %v", got.artifactType, tt.wantArtifactType)
 			}
 
-			if !cmp.Equal(got.baseURL, tt.baseURL) {
-				t.Errorf("NewRegistry() baseURL diff = %v", cmp.Diff(tt.baseURL, got.baseURL))
+			if diff := cmp.Diff(tt.baseURL, got.baseURL); diff != "" {
+				t.Errorf("NewRegistry() baseURL mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -335,9 +335,13 @@ func (r *inMemoryRepo) Resolve(ctx context.Context, reference string) (ocispec.D
 	return target, nil
 }
 
+// TestAddReadRoundtrip exercises the full add → read → ref → list → delete
+// lifecycle in sequence. It is intentionally a single non-subtest function:
+// each phase depends on state established by the previous one (the in-memory
+// backend, the recorded wantDesc), so subtests with t.Parallel would race.
 func TestAddReadRoundtrip(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	r, err := NewRegistry(
 		&url.URL{Scheme: "https", Host: "example.com"},
@@ -360,112 +364,91 @@ func TestAddReadRoundtrip(t *testing.T) {
 		Digest:     "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
 	}
 
-	t.Run("read file not found", func(t *testing.T) {
-		_, _, err := r.ReadFile(ctx, f0)
-		if diff := testutil.DiffErrString(err, "not found"); diff != "" {
-			t.Errorf("ReadFile() error diff: %s", diff)
-		}
-	})
+	// Read missing file -> ErrNotFound.
+	if _, _, err := r.ReadFile(ctx, f0); err == nil {
+		t.Errorf("ReadFile() before AddFile: got nil error, want not-found")
+	} else if diff := testutil.DiffErrString(err, "not found"); diff != "" {
+		t.Errorf("ReadFile() error diff: %s", diff)
+	}
 
-	var wantDesc *FileDescriptor
-	content := "hello world"
+	// Add file.
+	const content = "hello world"
+	wantDesc, err := r.AddFile(ctx, f0, strings.NewReader(content))
+	if err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
 
-	t.Run("add file", func(t *testing.T) {
-		desc, err := r.AddFile(ctx, f0, strings.NewReader(content))
-		if diff := testutil.DiffErrString(err, ""); diff != "" {
-			t.Errorf("AddFile() error diff: %s", diff)
-		}
-		wantDesc = desc
-	})
-
-	t.Run("read file", func(t *testing.T) {
-		gotDesc, r, err := r.ReadFile(ctx, f0)
-		if diff := testutil.DiffErrString(err, ""); diff != "" {
-			t.Errorf("ReadFile() error diff: %s", diff)
-		}
-		defer r.Close()
-
+	// Read by owning tag.
+	if gotDesc, body, err := r.ReadFile(ctx, f0); err != nil {
+		t.Errorf("ReadFile() by owning tag: %v", err)
+	} else {
+		defer body.Close()
 		if diff := cmp.Diff(wantDesc, gotDesc); diff != "" {
-			t.Errorf("ReadFile() desc diff: %s", diff)
+			t.Errorf("ReadFile() desc mismatch (-want +got):\n%s", diff)
 		}
-
-		gotContent, err := io.ReadAll(r)
+		gotContent, err := io.ReadAll(body)
 		if err != nil {
 			t.Errorf("ReadAll() unexpected error = %v", err)
 		}
-
-		if got, want := string(gotContent), content; got != want {
-			t.Errorf("ReadAll() content = %v, want %v", got, want)
+		if string(gotContent) != content {
+			t.Errorf("ReadAll() content = %q, want %q", string(gotContent), content)
 		}
-	})
+	}
 
-	t.Run("append tags", func(t *testing.T) {
-		err := r.AppendRefs(ctx, "foobar", "v0", "tag1", "tag2")
-		if diff := testutil.DiffErrString(err, ""); diff != "" {
-			t.Errorf("AppendTags() error diff: %s", diff)
-		}
-	})
+	// Append ref tags.
+	if err := r.AppendRefs(ctx, "foobar", "v0", "tag1", "tag2"); err != nil {
+		t.Fatalf("AppendRefs() error = %v", err)
+	}
 
-	t.Run("read file by ref", func(t *testing.T) {
-		gotDesc, r, err := r.ReadFile(ctx, &RepoFile{
-			OwningRepo: "foobar",
-			RefTag:     "tag1",
-			Name:       "test.txt",
-			Digest:     "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
-		})
-		if diff := testutil.DiffErrString(err, ""); diff != "" {
-			t.Errorf("ReadFile() error diff: %s", diff)
-		}
-		defer r.Close()
-
+	// Read by ref tag.
+	if gotDesc, body, err := r.ReadFile(ctx, &RepoFile{
+		OwningRepo: "foobar",
+		RefTag:     "tag1",
+		Name:       "test.txt",
+		Digest:     "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+	}); err != nil {
+		t.Errorf("ReadFile() by ref tag: %v", err)
+	} else {
+		defer body.Close()
 		if diff := cmp.Diff(wantDesc, gotDesc); diff != "" {
-			t.Errorf("ReadFile() desc diff: %s", diff)
+			t.Errorf("ReadFile() by ref tag desc mismatch (-want +got):\n%s", diff)
 		}
-
-		gotContent, err := io.ReadAll(r)
+		gotContent, err := io.ReadAll(body)
 		if err != nil {
 			t.Errorf("ReadAll() unexpected error = %v", err)
 		}
+		if string(gotContent) != content {
+			t.Errorf("ReadAll() content = %q, want %q", string(gotContent), content)
+		}
+	}
 
-		if got, want := string(gotContent), content; got != want {
-			t.Errorf("ReadAll() content = %v, want %v", got, want)
-		}
-	})
+	// List tags.
+	gotTags, err := r.ListTags(ctx, "foobar")
+	if err != nil {
+		t.Errorf("ListTags() error = %v", err)
+	}
+	if diff := cmp.Diff([]string{"v0"}, gotTags); diff != "" {
+		t.Errorf("ListTags() mismatch (-want +got):\n%s", diff)
+	}
 
-	t.Run("list tags", func(t *testing.T) {
-		wantTags := []string{"v0"}
-		gotTags, err := r.ListTags(ctx, "foobar")
-		if diff := testutil.DiffErrString(err, ""); diff != "" {
-			t.Errorf("ListTags() error diff: %s", diff)
-		}
-		if diff := cmp.Diff(wantTags, gotTags); diff != "" {
-			t.Errorf("ListTags() tags diff: %s", diff)
-		}
-	})
+	// List files.
+	gotFiles, err := r.ListFiles(ctx, "foobar")
+	if err != nil {
+		t.Errorf("ListFiles() error = %v", err)
+	}
+	if diff := cmp.Diff([]*RepoFile{f0}, gotFiles); diff != "" {
+		t.Errorf("ListFiles() mismatch (-want +got):\n%s", diff)
+	}
 
-	t.Run("list files", func(t *testing.T) {
-		wantFiles := []*RepoFile{f0}
-		gotFiles, err := r.ListFiles(ctx, "foobar")
-		if diff := testutil.DiffErrString(err, ""); diff != "" {
-			t.Errorf("ListFiles() error diff: %s", diff)
-		}
-		if diff := cmp.Diff(wantFiles, gotFiles); diff != "" {
-			t.Errorf("ListFiles() files diff: %s", diff)
-		}
-	})
-
-	t.Run("delete tag files", func(t *testing.T) {
-		err := r.DeleteTagFiles(ctx, "foobar", "v0")
-		if diff := testutil.DiffErrString(err, ""); diff != "" {
-			t.Errorf("DeleteTagFiles() error diff: %s", diff)
-		}
-
-		gotFiles, err := r.ListFiles(ctx, "foobar")
-		if diff := testutil.DiffErrString(err, ""); diff != "" {
-			t.Errorf("ListFiles() error diff: %s", diff)
-		}
-		if len(gotFiles) != 0 {
-			t.Errorf("ListFiles() files = %v, want %v", gotFiles, []*RepoFile{})
-		}
-	})
+	// Delete tag files, then re-list.
+	if err := r.DeleteTagFiles(ctx, "foobar", "v0"); err != nil {
+		t.Errorf("DeleteTagFiles() error = %v", err)
+	}
+	gotFiles, err = r.ListFiles(ctx, "foobar")
+	if err != nil {
+		t.Errorf("ListFiles() after delete: %v", err)
+	}
+	if len(gotFiles) != 0 {
+		t.Errorf("ListFiles() after delete = %v, want empty", gotFiles)
+	}
 }


### PR DESCRIPTION
## Summary

This PR has two commits:

1. **`Add idiomatic-Go agent rules to AGENTS.md`** — strengthens the Style bullet (links the Google Go style guide overview, decisions, and best practices pages; requires `gofmt -s` + `go vet` clean) and adds a new **Testing rules** subsection codifying five non-negotiables: `t.Parallel`, `t.Context`, table-driven, `cmp.Diff(want, got)` on whole values, fakes (not mocks).
2. **`Migrate existing tests to comply with the new rules`** — pre-review caught that the existing tests violated the new rules in several places. Rather than ship rules the codebase already breaks, this commit migrates the tests so the suite is self-consistent on merge.

### Test migration details

- `context.Background()` → `t.Context()` in `pkg/cred`, `pkg/oci`, `pkg/handler/{python,maven}` test files.
- `TestAddReadRoundtrip` refactored from sequential `t.Run` subtests (which couldn't call `t.Parallel` because they share `memRepo`/`wantDesc`) into a single function with comment-marked phases — a doc comment explains the choice.
- `TestNewRegistry` baseURL: replaced the awkward `cmp.Equal(...)` + `cmp.Diff(...)` pattern with the standard `cmp.Diff(want, got)` idiom.
- `Test_generateDescriptor`: collapsed four field-by-field `!=` checks into one `cmp.Diff` on the whole `ocispec.Descriptor`.
- `TestFakeRegistry_AddFile`: replaced `wantDigest string` + three field checks with a `wantFile ocispec.Descriptor` and one `cmp.Diff`. Used `slices.Contains` for the tag-presence check.

Also reverted the AGENTS.md error-wrapping example back to the neutral `fmt.Errorf("...: %w", err)` (it briefly read `"doing X: %w"`, which would have diverged from the codebase's existing `"failed to <verb>: %w"` convention).

Closes #21

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` passes
- [x] `go test -race ./...` passes
- [x] `gofmt -s -l .` empty
- [x] No remaining `context.Background()`, `cmp.Equal`, or `reflect.DeepEqual` in test files
- [ ] CI green