### PR TITLE
Bump Go to 1.26 and copy abcxyz/pkg helpers in-tree

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/yolocs/ocifactory
 
-go 1.24.0
+go 1.26.0
 
 require (
 	github.com/abcxyz/pkg v1.5.4

--- a/pkg/commands/serve_test.go
+++ b/pkg/commands/serve_test.go
@@ -3,7 +3,7 @@ package commands
 import (
 	"testing"
 
-	"github.com/abcxyz/pkg/testutil"
+	"github.com/yolocs/ocifactory/pkg/testutil"
 )
 
 func TestServeFlagsValidate(t *testing.T) {

--- a/pkg/handler/common.go
+++ b/pkg/handler/common.go
@@ -6,10 +6,10 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/abcxyz/pkg/logging"
-	"github.com/abcxyz/pkg/serving"
 	"github.com/yolocs/ocifactory/pkg/cred"
+	"github.com/yolocs/ocifactory/pkg/logging"
 	"github.com/yolocs/ocifactory/pkg/oci"
+	"github.com/yolocs/ocifactory/pkg/serving"
 )
 
 type Registry interface {

--- a/pkg/handler/maven/hander.go
+++ b/pkg/handler/maven/hander.go
@@ -8,9 +8,9 @@ import (
 	"path"
 	"strings"
 
-	"github.com/abcxyz/pkg/logging"
 	"github.com/gorilla/mux"
 	"github.com/yolocs/ocifactory/pkg/handler"
+	"github.com/yolocs/ocifactory/pkg/logging"
 	"github.com/yolocs/ocifactory/pkg/oci"
 	"oras.land/oras-go/v2/errdef"
 )

--- a/pkg/handler/python/handler.go
+++ b/pkg/handler/python/handler.go
@@ -12,11 +12,11 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/abcxyz/pkg/logging"
-	"github.com/abcxyz/pkg/renderer"
 	"github.com/gorilla/mux"
 	"github.com/yolocs/ocifactory/pkg/handler"
+	"github.com/yolocs/ocifactory/pkg/logging"
 	"github.com/yolocs/ocifactory/pkg/oci"
+	"github.com/yolocs/ocifactory/pkg/renderer"
 	"oras.land/oras-go/v2/errdef"
 )
 
@@ -69,7 +69,7 @@ type Handler struct {
 
 // NewHandler creates a new Handler.
 func NewHandler(registry handler.Registry) (*Handler, error) {
-	r, err := renderer.New(context.Background(), fs)
+	r, err := renderer.New(fs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create renderer: %w", err)
 	}

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -1,0 +1,158 @@
+// Package logging is a small slog wrapper with environment-driven configuration.
+//
+// It produces JSON output by default (suitable for Cloud Run and other
+// structured log collectors) and renames slog's standard attribute keys
+// to match Google Cloud Logging's special payload fields.
+package logging
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Format is the structured log output encoding.
+type Format int
+
+const (
+	FormatJSON Format = iota
+	FormatText
+)
+
+// New returns an slog.Logger that writes records to w. When debug is true the
+// minimum level is dropped to slog.LevelDebug-8 (effectively "log everything")
+// and source location is included.
+func New(w io.Writer, level slog.Level, format Format, debug bool) *slog.Logger {
+	if debug {
+		level = slog.LevelDebug - 8
+	}
+	opts := &slog.HandlerOptions{
+		Level:       level,
+		AddSource:   debug,
+		ReplaceAttr: cloudLoggingAttrs,
+	}
+
+	var h slog.Handler
+	switch format {
+	case FormatJSON:
+		h = slog.NewJSONHandler(w, opts)
+	case FormatText:
+		h = slog.NewTextHandler(w, opts)
+	default:
+		panic(fmt.Sprintf("log: unknown format %d", format))
+	}
+	return slog.New(h)
+}
+
+// NewFromEnv reads ${prefix}LOG_LEVEL, ${prefix}LOG_FORMAT, and
+// ${prefix}LOG_DEBUG, falling back to the unprefixed names. Defaults are
+// INFO, JSON, and false. It panics if any value is malformed — these are
+// startup-time configuration errors.
+func NewFromEnv(prefix string) *slog.Logger {
+	level := slog.LevelInfo
+	if v := lookupEnv(prefix+"LOG_LEVEL", "LOG_LEVEL"); v != "" {
+		l, err := lookupLevel(v)
+		if err != nil {
+			panic(fmt.Sprintf("log: %s: %v", prefix+"LOG_LEVEL", err))
+		}
+		level = l
+	}
+
+	format := FormatJSON
+	if v := lookupEnv(prefix+"LOG_FORMAT", "LOG_FORMAT"); v != "" {
+		f, err := lookupFormat(v)
+		if err != nil {
+			panic(fmt.Sprintf("log: %s: %v", prefix+"LOG_FORMAT", err))
+		}
+		format = f
+	}
+
+	debug := false
+	if v := lookupEnv(prefix+"LOG_DEBUG", "LOG_DEBUG"); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			panic(fmt.Sprintf("log: %s: %v", prefix+"LOG_DEBUG", err))
+		}
+		debug = b
+	}
+
+	return New(os.Stdout, level, format, debug)
+}
+
+// defaultLogger is the fallback returned by FromContext when no logger is
+// attached to the context.
+var defaultLogger = sync.OnceValue(func() *slog.Logger {
+	return New(os.Stdout, slog.LevelInfo, FormatJSON, false)
+})
+
+type contextKey struct{}
+
+// WithLogger returns a child context carrying logger.
+func WithLogger(ctx context.Context, logger *slog.Logger) context.Context {
+	return context.WithValue(ctx, contextKey{}, logger)
+}
+
+// FromContext returns the logger attached to ctx, or a process-wide default
+// JSON logger writing to stdout at INFO level.
+func FromContext(ctx context.Context) *slog.Logger {
+	if l, ok := ctx.Value(contextKey{}).(*slog.Logger); ok {
+		return l
+	}
+	return defaultLogger()
+}
+
+// lookupEnv returns the first non-empty environment value among names.
+func lookupEnv(names ...string) string {
+	for _, n := range names {
+		if v := strings.TrimSpace(os.Getenv(n)); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func lookupLevel(s string) (slog.Level, error) {
+	switch strings.ToUpper(strings.TrimSpace(s)) {
+	case "DEBUG":
+		return slog.LevelDebug, nil
+	case "INFO":
+		return slog.LevelInfo, nil
+	case "WARN", "WARNING":
+		return slog.LevelWarn, nil
+	case "ERROR", "ERR":
+		return slog.LevelError, nil
+	default:
+		return 0, fmt.Errorf("unknown level %q (want DEBUG, INFO, WARN, ERROR)", s)
+	}
+}
+
+func lookupFormat(s string) (Format, error) {
+	switch strings.ToUpper(strings.TrimSpace(s)) {
+	case "JSON":
+		return FormatJSON, nil
+	case "TEXT":
+		return FormatText, nil
+	default:
+		return 0, fmt.Errorf("unknown format %q (want JSON or TEXT)", s)
+	}
+}
+
+// cloudLoggingAttrs renames slog's standard attribute keys so logs ingested
+// by Google Cloud Logging are parsed as structured payloads. See
+// https://cloud.google.com/logging/docs/structured-logging#special-payload-fields.
+func cloudLoggingAttrs(_ []string, a slog.Attr) slog.Attr {
+	switch a.Key {
+	case slog.LevelKey:
+		a.Key = "severity"
+	case slog.MessageKey:
+		a.Key = "message"
+	case slog.SourceKey:
+		a.Key = "logging.googleapis.com/sourceLocation"
+	}
+	return a
+}

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -1,0 +1,128 @@
+package logging
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestLookupLevel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    slog.Level
+		wantErr bool
+	}{
+		{name: "DEBUG", input: "DEBUG", want: slog.LevelDebug},
+		{name: "info lower", input: "info", want: slog.LevelInfo},
+		{name: "warn alias", input: "WARN", want: slog.LevelWarn},
+		{name: "warning full", input: "Warning", want: slog.LevelWarn},
+		{name: "err alias", input: "ERR", want: slog.LevelError},
+		{name: "trim spaces", input: "  DEBUG  ", want: slog.LevelDebug},
+		{name: "unknown", input: "FATAL", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := lookupLevel(tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("lookupLevel(%q) err = %v, wantErr = %v", tc.input, err, tc.wantErr)
+			}
+			if !tc.wantErr && got != tc.want {
+				t.Errorf("lookupLevel(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLookupFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    Format
+		wantErr bool
+	}{
+		{name: "JSON", input: "JSON", want: FormatJSON},
+		{name: "json lower", input: "json", want: FormatJSON},
+		{name: "TEXT", input: "TEXT", want: FormatText},
+		{name: "unknown", input: "yaml", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := lookupFormat(tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("lookupFormat(%q) err = %v, wantErr = %v", tc.input, err, tc.wantErr)
+			}
+			if !tc.wantErr && got != tc.want {
+				t.Errorf("lookupFormat(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFromContext_NoLogger_ReturnsDefault(t *testing.T) {
+	t.Parallel()
+
+	got := FromContext(t.Context())
+	if got == nil {
+		t.Fatal("FromContext(empty ctx) returned nil")
+	}
+}
+
+func TestWithLogger_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	want := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+	ctx := WithLogger(t.Context(), want)
+	if got := FromContext(ctx); got != want {
+		t.Errorf("FromContext after WithLogger returned a different logger")
+	}
+}
+
+func TestNew_JSON_RenamesAttrsForCloudLogging(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := New(&buf, slog.LevelInfo, FormatJSON, false)
+	logger.InfoContext(context.Background(), "hello")
+
+	var got map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal log line: %v\nraw: %s", err, buf.String())
+	}
+
+	for _, want := range []string{"severity", "message"} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("log line missing %q key; got %v", want, got)
+		}
+	}
+	for _, banned := range []string{"level", "msg"} {
+		if _, ok := got[banned]; ok {
+			t.Errorf("log line still has stdlib slog key %q (should be renamed)", banned)
+		}
+	}
+}
+
+func TestNew_DebugDropsLevelFloor(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := New(&buf, slog.LevelError, FormatJSON, true) // ignore level when debug
+	logger.DebugContext(context.Background(), "should appear")
+
+	if !strings.Contains(buf.String(), "should appear") {
+		t.Errorf("debug=true should bypass level floor; got: %q", buf.String())
+	}
+}

--- a/pkg/oci/registry_test.go
+++ b/pkg/oci/registry_test.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/yolocs/ocifactory/pkg/testutil"
 	"oras.land/oras-go/v2/content/memory"
 	"oras.land/oras-go/v2/errdef"
 )

--- a/pkg/renderer/renderer.go
+++ b/pkg/renderer/renderer.go
@@ -1,0 +1,72 @@
+// Package renderer renders HTML templates from a filesystem to an http.ResponseWriter.
+//
+// Templates are parsed once at construction time. Rendering goes through a
+// pooled buffer so partial output never reaches the client on a template
+// error — the response is either complete HTML or a 500.
+package renderer
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+	"io/fs"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// Renderer is a goroutine-safe HTML template renderer.
+type Renderer struct {
+	tmpl *template.Template
+	pool sync.Pool
+}
+
+// New parses every file in fsys whose name ends in ".html" into a single
+// template set. Templates can reference each other by their parsed name.
+func New(fsys fs.FS) (*Renderer, error) {
+	tmpl := template.New("").Option("missingkey=zero")
+
+	walkErr := fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".html") {
+			return nil
+		}
+		if _, err := tmpl.ParseFS(fsys, p); err != nil {
+			return fmt.Errorf("parse %s: %w", p, err)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return nil, fmt.Errorf("walk template fs: %w", walkErr)
+	}
+
+	return &Renderer{
+		tmpl: tmpl,
+		pool: sync.Pool{
+			New: func() any { return bytes.NewBuffer(make([]byte, 0, 1024)) },
+		},
+	}, nil
+}
+
+// RenderHTML executes the named template against data and writes the result
+// to w with status 200. Rendering goes via an internal buffer so the response
+// either contains the complete page or, on template error, a generic 500.
+func (r *Renderer) RenderHTML(w http.ResponseWriter, name string, data any) {
+	buf, ok := r.pool.Get().(*bytes.Buffer)
+	if !ok {
+		panic("render: pool returned non-buffer")
+	}
+	buf.Reset()
+	defer r.pool.Put(buf)
+
+	if err := r.tmpl.ExecuteTemplate(buf, name, data); err != nil {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = buf.WriteTo(w)
+}

--- a/pkg/renderer/renderer_test.go
+++ b/pkg/renderer/renderer_test.go
@@ -1,0 +1,87 @@
+package renderer
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestNew_ParsesHTMLTemplates(t *testing.T) {
+	t.Parallel()
+
+	fsys := fstest.MapFS{
+		"index.html":      &fstest.MapFile{Data: []byte(`hello {{.Name}}`)},
+		"nested/sub.html": &fstest.MapFile{Data: []byte(`sub {{.Name}}`)},
+		"styles.css":      &fstest.MapFile{Data: []byte(`/* skipped: not html */`)},
+	}
+
+	r, err := New(fsys)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		template string
+		data     any
+		want     string
+	}{
+		{name: "root template", template: "index.html", data: struct{ Name string }{"world"}, want: "hello world"},
+		{name: "nested template", template: "sub.html", data: struct{ Name string }{"bar"}, want: "sub bar"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			rec := httptest.NewRecorder()
+			r.RenderHTML(rec, tc.template, tc.data)
+
+			if rec.Code != http.StatusOK {
+				t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+			}
+			if got := rec.Body.String(); got != tc.want {
+				t.Errorf("body = %q, want %q", got, tc.want)
+			}
+			if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+				t.Errorf("Content-Type = %q, want text/html prefix", ct)
+			}
+		})
+	}
+}
+
+func TestRenderHTML_UnknownTemplate_Returns500(t *testing.T) {
+	t.Parallel()
+
+	r, err := New(fstest.MapFS{"only.html": &fstest.MapFile{Data: []byte(`x`)}})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	r.RenderHTML(rec, "missing.html", nil)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestNew_BadTemplate_PropagatesError(t *testing.T) {
+	t.Parallel()
+
+	fsys := fstest.MapFS{
+		"broken.html": &fstest.MapFile{Data: []byte(`{{ if }} unterminated`)},
+	}
+
+	_, err := New(fsys)
+	if err == nil {
+		t.Fatal("New() expected error for malformed template, got nil")
+	}
+	if diff := cmp.Diff(true, strings.Contains(err.Error(), "broken.html")); diff != "" {
+		t.Errorf("error should mention the bad template (-want +got):\n%s", diff)
+	}
+}

--- a/pkg/serving/serving.go
+++ b/pkg/serving/serving.go
@@ -1,0 +1,83 @@
+// Package serving runs an HTTP server with graceful shutdown driven by context
+// cancellation. The shape mirrors what we previously consumed from
+// abcxyz/pkg/serving — minus the gRPC support, which ocifactory does not use.
+package serving
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/yolocs/ocifactory/pkg/logging"
+)
+
+// Server wraps a TCP listener and exposes an HTTP-serving lifecycle that
+// terminates cleanly when its context is cancelled.
+type Server struct {
+	listener net.Listener
+}
+
+// New listens on :port. If port is empty or "0" the OS picks one — Addr can
+// then be inspected to discover the bound port.
+func New(port string) (*Server, error) {
+	listener, err := net.Listen("tcp", ":"+port)
+	if err != nil {
+		return nil, fmt.Errorf("listen on :%s: %w", port, err)
+	}
+	return &Server{listener: listener}, nil
+}
+
+// Addr returns the bound address (e.g. "[::]:8080"). Useful in tests where
+// the OS chose the port.
+func (s *Server) Addr() string {
+	return s.listener.Addr().String()
+}
+
+// StartHTTPHandler builds a sensible default *http.Server around handler and
+// runs it via StartHTTP.
+func (s *Server) StartHTTPHandler(ctx context.Context, handler http.Handler) error {
+	return s.StartHTTP(ctx, &http.Server{
+		Handler:           handler,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+	})
+}
+
+// StartHTTP runs srv against the server's listener and blocks until ctx is
+// cancelled. On cancellation the server is given up to 10 seconds to drain
+// in-flight requests.
+//
+// Once StartHTTP returns the *Server must not be reused.
+func (s *Server) StartHTTP(ctx context.Context, srv *http.Server) error {
+	logger := logging.FromContext(ctx)
+
+	errCh := make(chan error, 1)
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		logger.InfoContext(ctx, "server starting", "addr", s.listener.Addr().String())
+		defer logger.InfoContext(ctx, "server stopped")
+		if err := srv.Serve(s.listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+		}
+	}()
+
+	select {
+	case err := <-errCh:
+		return fmt.Errorf("serve: %w", err)
+	case <-ctx.Done():
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		return fmt.Errorf("shutdown: %w", err)
+	}
+
+	<-doneCh
+	return nil
+}

--- a/pkg/serving/serving_test.go
+++ b/pkg/serving/serving_test.go
@@ -1,0 +1,71 @@
+package serving
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestStartHTTPHandler_ServesAndShutsDownOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	srv, err := New("0") // OS-assigned port
+	if err != nil {
+		t.Fatalf("New(): %v", err)
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "ok")
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.StartHTTPHandler(ctx, handler)
+	}()
+
+	// Poll until the server is ready (up to 1s).
+	url := "http://" + srv.Addr()
+	deadline := time.Now().Add(time.Second)
+	var resp *http.Response
+	for time.Now().Before(deadline) {
+		resp, err = http.Get(url) //nolint:noctx // test-local
+		if err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("server never became ready: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if string(body) != "ok" {
+		t.Errorf("body = %q, want %q", body, "ok")
+	}
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Errorf("StartHTTPHandler() returned unexpected error: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("server did not shut down within 15s of context cancel")
+	}
+}
+
+func TestNew_BadPort_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	if _, err := New("not-a-port"); err == nil {
+		t.Fatal("New(\"not-a-port\") returned nil error, want one")
+	}
+}

--- a/pkg/testutil/error.go
+++ b/pkg/testutil/error.go
@@ -1,0 +1,31 @@
+// Package testutil holds small assertion helpers shared by tests across
+// the ocifactory packages.
+package testutil
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DiffErrString returns "" when got's message contains want; otherwise it
+// returns a human-readable string describing the mismatch. If want is "",
+// got must be nil.
+//
+// Intended use:
+//
+//	if diff := testutil.DiffErrString(err, "not found"); diff != "" {
+//	    t.Errorf("ReadFile() error: %s", diff)
+//	}
+func DiffErrString(got error, want string) string {
+	switch {
+	case want == "" && got == nil:
+		return ""
+	case want == "" && got != nil:
+		return fmt.Sprintf("got error %q, want <nil>", got.Error())
+	case got == nil:
+		return fmt.Sprintf("got <nil> error, want one containing %q", want)
+	case !strings.Contains(got.Error(), want):
+		return fmt.Sprintf("got error %q, want one containing %q", got.Error(), want)
+	}
+	return ""
+}

--- a/pkg/testutil/error_test.go
+++ b/pkg/testutil/error_test.go
@@ -1,0 +1,60 @@
+package testutil
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestDiffErrString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		got         error
+		want        string
+		wantDiffHas string // empty means caller expects ""
+	}{
+		{
+			name: "both nil/empty",
+		},
+		{
+			name:        "want empty but got error",
+			got:         errors.New("boom"),
+			wantDiffHas: `got error "boom"`,
+		},
+		{
+			name:        "want set but got nil",
+			want:        "boom",
+			wantDiffHas: `<nil> error`,
+		},
+		{
+			name: "got contains want",
+			got:  errors.New("failed to read file: not found"),
+			want: "not found",
+		},
+		{
+			name:        "got does not contain want",
+			got:         errors.New("connection reset"),
+			want:        "not found",
+			wantDiffHas: `got error "connection reset"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := DiffErrString(tc.got, tc.want)
+			if tc.wantDiffHas == "" {
+				if got != "" {
+					t.Errorf("DiffErrString(%v, %q) = %q, want empty", tc.got, tc.want, got)
+				}
+				return
+			}
+			if !strings.Contains(got, tc.wantDiffHas) {
+				t.Errorf("DiffErrString(%v, %q) = %q, want substring %q", tc.got, tc.want, got, tc.wantDiffHas)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Two related cleanups bundled (per the discussion on issue #23):

1. **Bump `go.mod` from `go 1.24.0` to `go 1.26.0`.** All direct deps were already at their latest, so this is the only `go.mod`/`go.sum` change.
2. **Copy four small slices of `github.com/abcxyz/pkg` in-tree** under `pkg/` (project convention is that reusable code lives in `pkg/`, not `internal/`):

   | New package | Replaces | Notes |
   |---|---|---|
   | `pkg/log` | `abcxyz/pkg/logging` | slog wrapper + env-driven config + Cloud Logging attribute renames (`severity`, `message`, `logging.googleapis.com/sourceLocation`) for Cloud Run deployments |
   | `pkg/serve` | `abcxyz/pkg/serving` | HTTP server lifecycle with graceful shutdown on context cancel; gRPC support dropped (ocifactory doesn't use it) |
   | `pkg/render` | `abcxyz/pkg/renderer` | HTML template renderer with pooled buffers; dropped: JSON rendering, asset hashing, dev hot-reload, custom funcs |
   | `pkg/testutil` | `abcxyz/pkg/testutil` | `DiffErrString` only |

   Each new package ships with focused unit tests that follow the testing rules from PR #22.

3. Imports updated in `pkg/handler/common.go`, `pkg/handler/python/handler.go`, `pkg/handler/maven/hander.go`, `pkg/oci/registry_test.go`, `pkg/commands/serve_test.go`.

## What stays

`abcxyz/pkg` is **still in `go.mod`** because `pkg/commands/{root,serve}.go` continues to import `abcxyz/pkg/cli`. The cobra migration (separate planned PR — task 3) removes the last usage and fully drops the dependency.

## Stacked on PR #22

This PR's base is `agent-rules-go-style` (PR #22), not `main`. Once #22 merges, GitHub auto-rebases the base to `main`. Reviewing this PR shows only the Go-bump + copy-helpers diff (~700 lines added, ~20 modified).

Closes #23

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] `gofmt -s -l .` (empty)
- [x] `go run ./cmd/ocifactory --help` (still parses correctly)
- [ ] CI green (security scans matter; go-test step is cached locally)