### PR TITLE
Stream AddFile uploads directly to the OCI backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ pip install --index-url http://localhost:8080/simple/ requests
 ```
 
 Runtime config is also available via env vars: `PORT`, `OCIFACTORY_REPO_TYPE`,
-`OCIFACTORY_BACKEND_REGISTRY`, `OCIFACTORY_LANDING_DIR`,
-`OCIFACTORY_LOG_LEVEL`, `OCIFACTORY_LOG_FORMAT`.
+`OCIFACTORY_BACKEND_REGISTRY`, `OCIFACTORY_LOG_LEVEL`, `OCIFACTORY_LOG_FORMAT`.
 
 ## Architecture
 

--- a/pkg/commands/serve.go
+++ b/pkg/commands/serve.go
@@ -25,7 +25,6 @@ type serveFlags struct {
 	port           string
 	repoType       string
 	registryURLStr string
-	landingDir     string
 
 	registryURL *url.URL
 }
@@ -58,10 +57,6 @@ func (f *serveFlags) Validate() error {
 			f.registryURL = u
 		}
 	}
-	// This default is implicit because temp dir will be different each time.
-	if f.landingDir == "" {
-		f.landingDir = os.TempDir()
-	}
 	return merr
 }
 
@@ -85,8 +80,6 @@ func newServeCmd() *cobra.Command {
 		fmt.Sprintf("Type of repository to serve. Allowed: %v", supportedRepoTypes))
 	cmd.Flags().StringVar(&flags.registryURLStr, "backend-registry", os.Getenv("OCIFACTORY_BACKEND_REGISTRY"),
 		"The URL to the backend OCI registry.")
-	cmd.Flags().StringVar(&flags.landingDir, "landing-dir", os.Getenv("OCIFACTORY_LANDING_DIR"),
-		"The directory to store the temporary artifact files. If not set, a temp dir will be created each time.")
 
 	return cmd
 }
@@ -104,7 +97,6 @@ func runServe(ctx context.Context, flags *serveFlags) error {
 	case maven.RepoType:
 		reg, err := oci.NewRegistry(
 			flags.registryURL,
-			oci.WithLandingDir(flags.landingDir),
 			oci.WithArtifactType(maven.ArtifactType),
 		)
 		if err != nil {
@@ -118,7 +110,6 @@ func runServe(ctx context.Context, flags *serveFlags) error {
 	case python.RepoType:
 		reg, err := oci.NewRegistry(
 			flags.registryURL,
-			oci.WithLandingDir(flags.landingDir),
 			oci.WithArtifactType(python.ArtifactType),
 		)
 		if err != nil {

--- a/pkg/commands/serve_test.go
+++ b/pkg/commands/serve_test.go
@@ -105,7 +105,6 @@ func TestServeCmd_Flags(t *testing.T) {
 		{name: "port", flagName: "port"},
 		{name: "repo-type", flagName: "repo-type", shorthand: "t"},
 		{name: "backend-registry", flagName: "backend-registry"},
-		{name: "landing-dir", flagName: "landing-dir"},
 	}
 
 	for _, tc := range tests {

--- a/pkg/oci/registry.go
+++ b/pkg/oci/registry.go
@@ -1,6 +1,7 @@
 package oci
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -11,11 +12,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/yolocs/ocifactory/pkg/cred"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
-	"oras.land/oras-go/v2/content/file"
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/registry"
 	"oras.land/oras-go/v2/registry/remote"
@@ -26,7 +27,19 @@ import (
 const (
 	DefaultArtifactType = "application/vnd.ocifactory.generic"
 	FileNameAnnotation  = "ocifactory.file.title"
+
+	// uploadMemThreshold is the largest upload body that AddFile will buffer
+	// fully in memory. Anything larger spills to a single temp file before
+	// being pushed to the backend. Sized to keep typical package metadata and
+	// small wheels fully in memory while still allowing multi-tenant Cloud
+	// Run instances comfortable headroom.
+	uploadMemThreshold = 4 * 1024 * 1024
 )
+
+// ErrDigestMismatch is returned by AddFile when the caller-supplied
+// RepoFile.Digest does not match the digest computed from the uploaded body.
+// It is returned before any data is pushed to the backend.
+var ErrDigestMismatch = errors.New("file digest mismatch")
 
 type destRepo interface {
 	oras.Target
@@ -37,23 +50,17 @@ type destRepo interface {
 
 type Registry struct {
 	baseURL      *url.URL
-	landingDir   string
 	artifactType string
+
+	// uploadMemThreshold is the in-memory staging cap for AddFile bodies.
+	// Initialised to the package default; overridable from tests.
+	uploadMemThreshold int64
 
 	// Used in unit test to stub with in memory backend.
 	newBackendFunc func(ctx context.Context, f *RepoFile) (destRepo, error)
 }
 
 type RegistryOption func(*Registry) error
-
-// WithLandingDir sets the directory where files are stored before being uploaded.
-// The provided dir must already exist. The default is the current directory.
-func WithLandingDir(dir string) RegistryOption {
-	return func(r *Registry) error {
-		r.landingDir = dir
-		return nil
-	}
-}
 
 func WithArtifactType(artifactType string) RegistryOption {
 	return func(r *Registry) error {
@@ -79,9 +86,9 @@ type FileDescriptor struct {
 
 func NewRegistry(baseURL *url.URL, opt ...RegistryOption) (*Registry, error) {
 	r := &Registry{
-		baseURL:      baseURL,
-		landingDir:   os.TempDir(), // Default to the system tmp directory.
-		artifactType: DefaultArtifactType,
+		baseURL:            baseURL,
+		artifactType:       DefaultArtifactType,
+		uploadMemThreshold: uploadMemThreshold,
 	}
 	r.newBackendFunc = r.newBackend
 
@@ -168,32 +175,63 @@ func (r *Registry) AppendRefs(ctx context.Context, repo string, canonicalTag str
 }
 
 // AddFile adds a file to the registry.
-// The file is first uploaded to the landing zone, then to the OCI store, and finally to the backend repository.
-// If the file already exists in the backend repository, it will be updated if and only if the digest has changed.
-// Returns the updated manifest descriptor and the file descriptor.
+//
+// The body is streamed exactly once: bytes are simultaneously hashed and
+// staged into either an in-memory buffer (for bodies up to uploadMemThreshold)
+// or a single temp file (for larger bodies). The staged content is then
+// pushed directly to the backend repository — no intermediate OCI file store
+// or multi-hop disk copy.
+//
+// If RepoFile.Digest is set and disagrees with the digest computed from the
+// body, AddFile returns ErrDigestMismatch before any data is sent to the
+// backend.
+//
+// If the layer with the same digest already exists in the backend, the blob
+// upload is skipped. If the file is unchanged in the manifest for
+// RepoFile.OwningTag, the manifest is left untouched. Otherwise the manifest
+// is repacked and re-tagged.
 func (r *Registry) AddFile(ctx context.Context, f *RepoFile, ro io.Reader) (*FileDescriptor, error) {
 	if strings.HasPrefix(f.OwningTag, "ref_") {
 		return nil, fmt.Errorf("canonical tag cannot be prefixed with ref_; got %q", f.OwningTag)
 	}
 
-	// Load the file in the landing zone.
-	tmpFile, err := r.landFile(ro)
+	staged, err := stageUploadWithThreshold(ro, r.uploadMemThreshold)
 	if err != nil {
 		return nil, err
 	}
-	defer os.Remove(tmpFile)
+	defer staged.cleanup()
 
-	// Load the file in the OCI store.
-	fs, fileDesc, err := r.loadFile(ctx, tmpFile, f)
-	if err != nil {
-		return nil, err
+	if f.Digest != "" && string(staged.digest) != f.Digest {
+		return nil, fmt.Errorf("%w: %q != %q", ErrDigestMismatch, staged.digest, f.Digest)
 	}
-	defer fs.Close()
 
-	// Create the backend repository for the file.
+	fileDesc := ocispec.Descriptor{
+		MediaType: detectFileMediaType(f),
+		Digest:    staged.digest,
+		Size:      staged.size,
+		Annotations: map[string]string{
+			FileNameAnnotation:      f.Name,
+			ocispec.AnnotationTitle: f.Name,
+		},
+	}
+
 	backendRepo, err := r.newBackendFunc(ctx, f)
 	if err != nil {
 		return nil, err
+	}
+
+	exists, err := backendRepo.Exists(ctx, fileDesc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if file blob exists: %w", err)
+	}
+	if !exists {
+		blobReader, err := staged.reader()
+		if err != nil {
+			return nil, err
+		}
+		if err := backendRepo.Push(ctx, fileDesc, blobReader); err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
+			return nil, fmt.Errorf("failed to push file blob: %w", err)
+		}
 	}
 
 	manifestDesc, err := backendRepo.Resolve(ctx, f.OwningTag)
@@ -210,19 +248,13 @@ func (r *Registry) AddFile(ctx context.Context, f *RepoFile, ro io.Reader) (*Fil
 		return &FileDescriptor{Manifest: manifestDesc, File: fileDesc}, nil
 	}
 
-	// Pack the updated manifest
 	packOpts := oras.PackManifestOptions{Layers: layers}
-	newManifestDesc, err := oras.PackManifest(ctx, fs, oras.PackManifestVersion1_1, r.artifactType, packOpts)
+	newManifestDesc, err := oras.PackManifest(ctx, backendRepo, oras.PackManifestVersion1_1, r.artifactType, packOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to pack new manifest: %w", err)
 	}
-	if err := fs.Tag(ctx, newManifestDesc, f.OwningTag); err != nil {
+	if err := backendRepo.Tag(ctx, newManifestDesc, f.OwningTag); err != nil {
 		return nil, fmt.Errorf("failed to tag new manifest: %w", err)
-	}
-
-	// Push the manifest and tag it
-	if _, err := oras.Copy(ctx, fs, f.OwningTag, backendRepo, f.OwningTag, oras.DefaultCopyOptions); err != nil {
-		return nil, fmt.Errorf("failed to copy manifest to backend repo: %w", err)
 	}
 
 	return &FileDescriptor{Manifest: newManifestDesc, File: fileDesc}, nil
@@ -338,36 +370,79 @@ func (r *Registry) ListFiles(ctx context.Context, repo string) ([]*RepoFile, err
 	return files, nil
 }
 
-func (r *Registry) landFile(ro io.Reader) (string, error) {
-	tmpFile, err := os.CreateTemp(r.landingDir, "oci-upload-")
-	if err != nil {
-		return "", fmt.Errorf("failed to create temporary file in the landing zone: %w", err)
-	}
-
-	if _, err := io.Copy(tmpFile, ro); err != nil {
-		return "", fmt.Errorf("failed to copy reader to the landing zone: %w", err)
-	}
-
-	return tmpFile.Name(), nil
+// stagedUpload is the result of staging an upload body for a single push.
+// reader() returns a fresh io.Reader positioned at the start of the staged
+// content; it may be called at most once. cleanup releases any temp file
+// and is safe to call multiple times.
+type stagedUpload struct {
+	digest  digest.Digest
+	size    int64
+	reader  func() (io.Reader, error)
+	cleanup func()
 }
 
-func (r *Registry) loadFile(ctx context.Context, fileLanded string, f *RepoFile) (*file.Store, ocispec.Descriptor, error) {
-	fs, err := file.New(r.landingDir) // The OCI file store is not used for writing files.
+// stageUploadWithThreshold reads ro to completion, computing its sha256
+// digest as it goes. Bodies up to memThreshold are buffered in memory;
+// larger bodies spill to a single temp file. Either way, the returned
+// stagedUpload exposes a rewindable reader and a cleanup callback for any
+// spilled state. Production callers thread the per-Registry threshold so
+// tests can dial it down to small sizes.
+func stageUploadWithThreshold(ro io.Reader, memThreshold int64) (*stagedUpload, error) {
+	digester := digest.SHA256.Digester()
+
+	buf := &bytes.Buffer{}
+	// Read at most memThreshold+1 bytes into memory so we can decide whether
+	// to spill without losing the byte that pushed us over.
+	headLimit := memThreshold + 1
+	headTee := io.TeeReader(io.LimitReader(ro, headLimit), digester.Hash())
+	headN, err := io.Copy(buf, headTee)
 	if err != nil {
-		return nil, ocispec.Descriptor{}, fmt.Errorf("failed to create local OCI store: %w", err)
+		return nil, fmt.Errorf("failed to stage upload: %w", err)
 	}
 
-	fileDesc, err := fs.Add(ctx, fileLanded, detectFileMediaType(f), "")
-	if err != nil {
-		return nil, ocispec.Descriptor{}, fmt.Errorf("failed to add file to local OCI store: %w", err)
+	if headN <= memThreshold {
+		// Whole body fit in memory.
+		data := buf.Bytes()
+		return &stagedUpload{
+			digest:  digester.Digest(),
+			size:    int64(len(data)),
+			reader:  func() (io.Reader, error) { return bytes.NewReader(data), nil },
+			cleanup: func() {},
+		}, nil
 	}
-	if f.Digest != "" && string(fileDesc.Digest) != f.Digest {
-		return nil, ocispec.Descriptor{}, fmt.Errorf("file digest mismatch: %q != %q", fileDesc.Digest, f.Digest)
-	}
-	fileDesc.Annotations[FileNameAnnotation] = f.Name
-	fileDesc.Annotations[ocispec.AnnotationTitle] = f.Name // The 'Add' method by default sets the title to the full path.
 
-	return fs, fileDesc, nil
+	// Spill: dump what we already buffered into a temp file, then drain the
+	// rest of the body into the same file (and the digester) in one pass.
+	tmp, err := os.CreateTemp("", "ocifactory-upload-")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp file for upload: %w", err)
+	}
+	cleanup := func() {
+		tmp.Close()
+		os.Remove(tmp.Name())
+	}
+
+	if _, err := tmp.Write(buf.Bytes()); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("failed to write head buffer to temp file: %w", err)
+	}
+	tailN, err := io.Copy(io.MultiWriter(tmp, digester.Hash()), ro)
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("failed to stage upload tail to temp file: %w", err)
+	}
+
+	return &stagedUpload{
+		digest: digester.Digest(),
+		size:   headN + tailN,
+		reader: func() (io.Reader, error) {
+			if _, err := tmp.Seek(0, io.SeekStart); err != nil {
+				return nil, fmt.Errorf("failed to rewind staged upload: %w", err)
+			}
+			return tmp, nil
+		},
+		cleanup: cleanup,
+	}, nil
 }
 
 func (r *Registry) newBackend(ctx context.Context, f *RepoFile) (destRepo, error) {

--- a/pkg/oci/registry_test.go
+++ b/pkg/oci/registry_test.go
@@ -1,16 +1,20 @@
 package oci
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
 	"io"
 	"maps"
 	"net/url"
-	"os"
 	"slices"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/yolocs/ocifactory/pkg/testutil"
 	"oras.land/oras-go/v2/content/memory"
@@ -25,7 +29,6 @@ func TestNewRegistry(t *testing.T) {
 		baseURL          *url.URL
 		opts             []RegistryOption
 		wantErr          bool
-		wantLandingDir   string
 		wantArtifactType string
 	}{
 		{
@@ -33,15 +36,6 @@ func TestNewRegistry(t *testing.T) {
 			baseURL:          &url.URL{Scheme: "https", Host: "example.com"},
 			opts:             nil,
 			wantErr:          false,
-			wantLandingDir:   os.TempDir(),
-			wantArtifactType: DefaultArtifactType,
-		},
-		{
-			name:             "with landing dir",
-			baseURL:          &url.URL{Scheme: "https", Host: "example.com"},
-			opts:             []RegistryOption{WithLandingDir("/tmp")},
-			wantErr:          false,
-			wantLandingDir:   "/tmp",
 			wantArtifactType: DefaultArtifactType,
 		},
 		{
@@ -49,15 +43,6 @@ func TestNewRegistry(t *testing.T) {
 			baseURL:          &url.URL{Scheme: "https", Host: "example.com"},
 			opts:             []RegistryOption{WithArtifactType("application/custom")},
 			wantErr:          false,
-			wantLandingDir:   os.TempDir(),
-			wantArtifactType: "application/custom",
-		},
-		{
-			name:             "with both options",
-			baseURL:          &url.URL{Scheme: "https", Host: "example.com"},
-			opts:             []RegistryOption{WithLandingDir("/tmp"), WithArtifactType("application/custom")},
-			wantErr:          false,
-			wantLandingDir:   "/tmp",
 			wantArtifactType: "application/custom",
 		},
 	}
@@ -73,10 +58,6 @@ func TestNewRegistry(t *testing.T) {
 			}
 			if err != nil {
 				return
-			}
-
-			if got.landingDir != tt.wantLandingDir {
-				t.Errorf("NewRegistry() landingDir = %v, want %v", got.landingDir, tt.wantLandingDir)
 			}
 
 			if got.artifactType != tt.wantArtifactType {
@@ -345,7 +326,6 @@ func TestAddReadRoundtrip(t *testing.T) {
 
 	r, err := NewRegistry(
 		&url.URL{Scheme: "https", Host: "example.com"},
-		WithLandingDir(t.TempDir()),
 	)
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
@@ -450,5 +430,248 @@ func TestAddReadRoundtrip(t *testing.T) {
 	}
 	if len(gotFiles) != 0 {
 		t.Errorf("ListFiles() after delete = %v, want empty", gotFiles)
+	}
+}
+
+// countingRepo wraps inMemoryRepo to record blob/manifest pushes and
+// optionally inject a Push error. The recorded counts let tests assert that
+// the streaming AddFile path performs a single backend push for the file
+// blob (plus the empty config + manifest pushes from oras.PackManifest).
+type countingRepo struct {
+	*inMemoryRepo
+
+	pushCalls    int            // total Push calls observed
+	pushedBytes  map[string]int // digest → length of pushed body
+	failOnDigest digest.Digest  // when set, Push for this digest returns failErr
+	failErr      error
+}
+
+func (r *countingRepo) Push(ctx context.Context, expected ocispec.Descriptor, content io.Reader) error {
+	r.pushCalls++
+	body, err := io.ReadAll(content)
+	if err != nil {
+		return fmt.Errorf("countingRepo.Push read body: %w", err)
+	}
+	if r.pushedBytes == nil {
+		r.pushedBytes = map[string]int{}
+	}
+	r.pushedBytes[expected.Digest.String()] = len(body)
+	if r.failErr != nil && expected.Digest == r.failOnDigest {
+		return r.failErr
+	}
+	return r.inMemoryRepo.Store.Push(ctx, expected, bytes.NewReader(body))
+}
+
+func sha256Digest(b []byte) digest.Digest {
+	sum := sha256.Sum256(b)
+	return digest.NewDigestFromBytes(digest.SHA256, sum[:])
+}
+
+func TestAddFile_Streaming(t *testing.T) {
+	t.Parallel()
+
+	// Tiny in-memory threshold so the spill path runs on a few-KB body
+	// instead of multi-MB. AddFile's behaviour is identical at any
+	// threshold; the production default is exercised by the
+	// TestStageUpload table below.
+	const testMemThreshold = 1024
+
+	smallContent := []byte("hello world")
+	largeContent := bytes.Repeat([]byte("x"), testMemThreshold+128)
+
+	tests := []struct {
+		name           string
+		content        []byte
+		repoFile       *RepoFile
+		failPush       bool
+		wantErrSubstr  string
+		wantTargetErr  error
+		wantFileDigest digest.Digest
+		wantFileSize   int64
+	}{
+		{
+			name:    "small file under threshold",
+			content: smallContent,
+			repoFile: &RepoFile{
+				OwningRepo: "pkg",
+				OwningTag:  "v1",
+				Name:       "test.txt",
+			},
+			wantFileDigest: sha256Digest(smallContent),
+			wantFileSize:   int64(len(smallContent)),
+		},
+		{
+			name:    "large file spills to temp file",
+			content: largeContent,
+			repoFile: &RepoFile{
+				OwningRepo: "pkg",
+				OwningTag:  "v1",
+				Name:       "big.bin",
+			},
+			wantFileDigest: sha256Digest(largeContent),
+			wantFileSize:   int64(len(largeContent)),
+		},
+		{
+			name:    "supplied digest matches",
+			content: smallContent,
+			repoFile: &RepoFile{
+				OwningRepo: "pkg",
+				OwningTag:  "v1",
+				Name:       "test.txt",
+				Digest:     string(sha256Digest(smallContent)),
+			},
+			wantFileDigest: sha256Digest(smallContent),
+			wantFileSize:   int64(len(smallContent)),
+		},
+		{
+			name:    "supplied digest mismatch returns ErrDigestMismatch",
+			content: smallContent,
+			repoFile: &RepoFile{
+				OwningRepo: "pkg",
+				OwningTag:  "v1",
+				Name:       "test.txt",
+				Digest:     "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+			},
+			wantErrSubstr: "file digest mismatch",
+			wantTargetErr: ErrDigestMismatch,
+		},
+		{
+			name:    "backend Push failure is wrapped and skips manifest update",
+			content: smallContent,
+			repoFile: &RepoFile{
+				OwningRepo: "pkg",
+				OwningTag:  "v1",
+				Name:       "test.txt",
+			},
+			failPush:      true,
+			wantErrSubstr: "failed to push file blob",
+		},
+		{
+			name:    "ref_ owning tag rejected",
+			content: smallContent,
+			repoFile: &RepoFile{
+				OwningRepo: "pkg",
+				OwningTag:  "ref_latest",
+				Name:       "test.txt",
+			},
+			wantErrSubstr: "canonical tag cannot be prefixed with ref_",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+
+			memRepo := &inMemoryRepo{Store: memory.New(), allTags: map[string]string{}}
+			counting := &countingRepo{inMemoryRepo: memRepo}
+			if tc.failPush {
+				counting.failOnDigest = sha256Digest(tc.content)
+				counting.failErr = errors.New("backend down")
+			}
+
+			r, err := NewRegistry(&url.URL{Scheme: "https", Host: "example.com"})
+			if err != nil {
+				t.Fatalf("NewRegistry() error = %v", err)
+			}
+			r.uploadMemThreshold = testMemThreshold
+			r.newBackendFunc = func(_ context.Context, _ *RepoFile) (destRepo, error) {
+				return counting, nil
+			}
+
+			desc, err := r.AddFile(ctx, tc.repoFile, bytes.NewReader(tc.content))
+			if tc.wantErrSubstr != "" {
+				if diff := testutil.DiffErrString(err, tc.wantErrSubstr); diff != "" {
+					t.Fatalf("AddFile() error: %s", diff)
+				}
+				if tc.wantTargetErr != nil && !errors.Is(err, tc.wantTargetErr) {
+					t.Fatalf("AddFile() errors.Is(%v, %v) = false", err, tc.wantTargetErr)
+				}
+				// On any error (validation, mismatch, push failure) the
+				// manifest must not have been tagged.
+				if _, ok := memRepo.allTags[tc.repoFile.OwningTag]; ok {
+					t.Errorf("AddFile() tagged manifest despite error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("AddFile() unexpected error = %v", err)
+			}
+
+			if got, want := desc.File.Digest, tc.wantFileDigest; got != want {
+				t.Errorf("AddFile() file digest = %s, want %s", got, want)
+			}
+			if got, want := desc.File.Size, tc.wantFileSize; got != want {
+				t.Errorf("AddFile() file size = %d, want %d", got, want)
+			}
+
+			// File blob should have been pushed exactly once with the full body.
+			gotBytes, ok := counting.pushedBytes[string(tc.wantFileDigest)]
+			if !ok {
+				t.Fatalf("AddFile() did not push file blob with digest %s; pushed = %v", tc.wantFileDigest, counting.pushedBytes)
+			}
+			if int64(gotBytes) != tc.wantFileSize {
+				t.Errorf("AddFile() pushed blob size = %d, want %d", gotBytes, tc.wantFileSize)
+			}
+
+			// Re-adding the same content must not re-push the blob: the
+			// Exists check should short-circuit it, and the unchanged
+			// manifest path should skip the manifest re-pack as well.
+			pushesAfterFirst := counting.pushCalls
+			if _, err := r.AddFile(ctx, tc.repoFile, bytes.NewReader(tc.content)); err != nil {
+				t.Fatalf("AddFile() second call error = %v", err)
+			}
+			if counting.pushCalls != pushesAfterFirst {
+				t.Errorf("AddFile() second call pushed %d more times, want 0", counting.pushCalls-pushesAfterFirst)
+			}
+		})
+	}
+}
+
+func TestStageUploadWithThreshold(t *testing.T) {
+	t.Parallel()
+
+	const threshold int64 = 1024
+
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{name: "empty body", body: []byte{}},
+		{name: "small body", body: []byte("hello, world")},
+		{name: "exactly threshold", body: bytes.Repeat([]byte("a"), int(threshold))},
+		{name: "one over threshold", body: bytes.Repeat([]byte("b"), int(threshold)+1)},
+		{name: "well over threshold", body: bytes.Repeat([]byte("c"), int(threshold)*4+17)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			staged, err := stageUploadWithThreshold(bytes.NewReader(tc.body), threshold)
+			if err != nil {
+				t.Fatalf("stageUploadWithThreshold() error = %v", err)
+			}
+			t.Cleanup(staged.cleanup)
+
+			if got, want := staged.size, int64(len(tc.body)); got != want {
+				t.Errorf("size = %d, want %d", got, want)
+			}
+			if got, want := staged.digest, sha256Digest(tc.body); got != want {
+				t.Errorf("digest = %s, want %s", got, want)
+			}
+
+			rd, err := staged.reader()
+			if err != nil {
+				t.Fatalf("reader() error = %v", err)
+			}
+			gotBody, err := io.ReadAll(rd)
+			if err != nil {
+				t.Fatalf("ReadAll(reader) error = %v", err)
+			}
+			if diff := cmp.Diff(tc.body, gotBody); diff != "" {
+				t.Errorf("staged body mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
AddFile previously routed every upload through three disk hops: a temp
file in the landing zone, an ORAS file.Store that re-read the file to
compute its digest, and finally oras.Copy which read it once more on
push. For a 200 MB jar that's 2 reads + 2 writes against local disk
before any byte hits the backend; on Cloud Run /tmp is RAM-backed and
counts against the memory limit, so it directly capped artifact size.

Replace the multi-hop dance with a single-pass stream:

  - stageUploadWithThreshold tees the body into a SHA256 digester and
    a spillover buffer (bytes.Buffer up to 4 MiB; spills to a single
    os.CreateTemp file beyond that).
  - AddFile builds the descriptor from the streamed digest+size,
    cross-checks RepoFile.Digest before any backend call (returns the
    new typed ErrDigestMismatch on disagreement), short-circuits the
    blob upload via backendRepo.Exists, and pushes the manifest
    directly via oras.PackManifest against the backend repo.

Drop the now-unused landingDir field, WithLandingDir option, file.Store
import, --landing-dir flag, OCIFACTORY_LANDING_DIR env, and the
landing-dir flag check in serve_test.go and the README env list.

Tests:

  - TestAddFile_Streaming covers small/large/digest-match/digest-
    mismatch/push-failure/ref_-rejected, asserts a single blob push
    per call, and verifies a second AddFile of the same content makes
    zero pushes (Exists short-circuit + unchanged-manifest skip).
  - TestStageUploadWithThreshold covers the in-memory and spill-to-
    temp-file branches (empty / small / =threshold / +1 / >>threshold).
  - The threshold is plumbed through Registry so tests stage on a few
    KB instead of multi-MB bodies.

Closes #25

Signed-off-by: Claude <noreply@anthropic.com>