### PR TITLE
Switch pkg/oci to OCI 1.1 referrers layout (#35)

### DIFF
--- a/pkg/oci/fake.go
+++ b/pkg/oci/fake.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 
 	digest "github.com/opencontainers/go-digest"
@@ -13,26 +14,53 @@ import (
 	"oras.land/oras-go/v2/errdef"
 )
 
+// FakeRegistry is the in-memory implementation of handler.Registry used by
+// every package's tests. The on-disk shape it preserves — Files keyed by
+// "<repo>/<tag>/<name>" and Tags keyed by repo — predates the OCI 1.1
+// referrers redesign and is reached into directly by handler tests in
+// other packages, so the field types stay as-is. Aliases is the new map
+// modelling the alias-manifest layer of the redesign without disturbing
+// the existing fields.
+//
+// The fake is not a faithful in-memory OCI registry — it only models the
+// concepts pkg/oci's public surface exposes. In particular, it does not
+// model manifest digests, layers, or referrer descriptors. Tests that
+// need those should use the inMemoryRepo wrapper around oras-go's
+// content/memory.Store instead (see registry_test.go).
 type FakeRegistry struct {
-	Files map[string][]byte
-	Tags  map[string][]string
+	Files   map[string][]byte
+	Tags    map[string][]string
+	Aliases map[string]string
 }
 
 func NewFakeRegistry() *FakeRegistry {
 	return &FakeRegistry{
-		Files: make(map[string][]byte),
-		Tags:  make(map[string][]string),
+		Files:   make(map[string][]byte),
+		Tags:    make(map[string][]string),
+		Aliases: make(map[string]string),
 	}
 }
 
+// AddTag records a canonical version tag for a repo. Kept as an exported
+// helper because handler tests (notably python) seed canonical tags
+// directly to set up package-list expectations.
 func (r *FakeRegistry) AddTag(repo, tag string) {
-	if _, ok := r.Tags[repo]; !ok {
-		r.Tags[repo] = []string{}
+	if slices.Contains(r.Tags[repo], tag) {
+		return
 	}
 	r.Tags[repo] = append(r.Tags[repo], tag)
 }
 
 func (r *FakeRegistry) AddFile(ctx context.Context, f *RepoFile, ro io.Reader) (*FileDescriptor, error) {
+	if f.OwningTag == "" {
+		return nil, fmt.Errorf("OwningTag must be set")
+	}
+	// Refuse to clobber an alias tag with a canonical version push — the
+	// real registry does the same via the artifactType HEAD probe.
+	if _, ok := r.Aliases[aliasKey(f.OwningRepo, f.OwningTag)]; ok {
+		return nil, fmt.Errorf("%w: tag %q in repo %q is an alias", ErrAliasCollision, f.OwningTag, f.OwningRepo)
+	}
+
 	content, err := io.ReadAll(ro)
 	if err != nil {
 		return nil, err
@@ -40,14 +68,10 @@ func (r *FakeRegistry) AddFile(ctx context.Context, f *RepoFile, ro io.Reader) (
 
 	key := f.OwningRepo + "/" + f.OwningTag + "/" + f.Name
 	r.Files[key] = content
-
 	r.AddTag(f.OwningRepo, f.OwningTag)
 
 	desc := generateDescriptor(content, f)
-
-	return &FileDescriptor{
-		File: desc,
-	}, nil
+	return &FileDescriptor{File: desc}, nil
 }
 
 func generateDescriptor(content []byte, f *RepoFile) ocispec.Descriptor {
@@ -66,27 +90,67 @@ func generateDescriptor(content []byte, f *RepoFile) ocispec.Descriptor {
 }
 
 func (r *FakeRegistry) ReadFile(ctx context.Context, f *RepoFile) (*FileDescriptor, io.ReadCloser, error) {
-	key := f.OwningRepo + "/" + f.OwningTag + "/" + f.Name
+	if f.OwningTag == "" && f.RefTag == "" {
+		return nil, nil, fmt.Errorf("either OwningTag or RefTag must be set")
+	}
+
+	tag := f.OwningTag
+	if tag == "" {
+		canonical, ok := r.Aliases[aliasKey(f.OwningRepo, f.RefTag)]
+		if !ok {
+			return nil, nil, fmt.Errorf("alias %q not found in repo %q: %w", f.RefTag, f.OwningRepo, errdef.ErrNotFound)
+		}
+		tag = canonical
+	}
+
+	key := f.OwningRepo + "/" + tag + "/" + f.Name
 	content, ok := r.Files[key]
 	if !ok {
 		return nil, nil, fmt.Errorf("file not found: %s: %w", key, errdef.ErrNotFound)
 	}
 
 	desc := generateDescriptor(content, f)
-
-	return &FileDescriptor{
-		File: desc,
-	}, io.NopCloser(bytes.NewReader(content)), nil
+	return &FileDescriptor{File: desc}, io.NopCloser(bytes.NewReader(content)), nil
 }
 
+// AppendRefs creates one alias per ref pointing at canonicalTag. Refuses
+// to overwrite an existing canonical version tag (alias collision); a
+// re-point of an existing alias is allowed and replaces the previous
+// target.
+func (r *FakeRegistry) AppendRefs(ctx context.Context, repo string, canonicalTag string, refs ...string) error {
+	if !slices.Contains(r.Tags[repo], canonicalTag) {
+		return fmt.Errorf("canonical tag %q not found in repo %q: %w", canonicalTag, repo, errdef.ErrNotFound)
+	}
+	for _, ref := range refs {
+		if slices.Contains(r.Tags[repo], ref) {
+			return fmt.Errorf("%w: ref %q already exists as a canonical tag in repo %q", ErrAliasCollision, ref, repo)
+		}
+	}
+	for _, ref := range refs {
+		r.Aliases[aliasKey(repo, ref)] = canonicalTag
+	}
+	return nil
+}
+
+// ListTags returns canonical tags plus alias tags for a repo, mirroring
+// the new pkg/oci.Registry behaviour. Aliases are reported with their
+// alias name; callers that need to discriminate use the manifest type
+// check (not modelled here — tests that need it use the inMemoryRepo
+// wrapper).
 func (r *FakeRegistry) ListTags(ctx context.Context, repo string) ([]string, error) {
-	tags, ok := r.Tags[repo]
-	if !ok {
-		return []string{}, nil
+	tags := append([]string{}, r.Tags[repo]...)
+	prefix := repo + "/"
+	for k := range r.Aliases {
+		if strings.HasPrefix(k, prefix) {
+			tags = append(tags, strings.TrimPrefix(k, prefix))
+		}
 	}
 	return tags, nil
 }
 
+// ListFiles enumerates files keyed under the repo, ignoring alias tags
+// (alias resolution would double-count files that already appear under
+// their canonical version).
 func (r *FakeRegistry) ListFiles(ctx context.Context, repo string) ([]*RepoFile, error) {
 	var filesList []*RepoFile
 	for key := range r.Files {
@@ -101,4 +165,8 @@ func (r *FakeRegistry) ListFiles(ctx context.Context, repo string) ([]*RepoFile,
 		filesList = append(filesList, &RepoFile{Name: fn, OwningRepo: rp, OwningTag: tag})
 	}
 	return filesList, nil
+}
+
+func aliasKey(repo, alias string) string {
+	return repo + "/" + alias
 }

--- a/pkg/oci/registry.go
+++ b/pkg/oci/registry.go
@@ -10,10 +10,10 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 
 	digest "github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/yolocs/ocifactory/pkg/cred"
 	"oras.land/oras-go/v2"
@@ -27,7 +27,31 @@ import (
 
 const (
 	DefaultArtifactType = "application/vnd.ocifactory.generic"
-	FileNameAnnotation  = "ocifactory.file.title"
+
+	// FileNameAnnotation is set on file manifests (and copied onto the file
+	// blob's layer descriptor) so the referrers index surfaces the file
+	// name without callers having to fetch each file manifest's body.
+	FileNameAnnotation = "ocifactory.file.title"
+
+	// FileDigestAnnotation carries the file blob's digest on the file
+	// manifest. ListFiles reads it from the referrers index entry directly,
+	// avoiding an extra fetch per file just to learn the blob digest.
+	FileDigestAnnotation = "ocifactory.file.digest"
+
+	// AliasTargetAnnotation is set on alias manifests to record the
+	// canonical version they point at. The subject field carries the same
+	// information as a digest; the annotation carries it as a human-readable
+	// tag name so an operator inspecting the registry can read it directly.
+	AliasTargetAnnotation = "ocifactory.alias.target"
+
+	// Subtype suffixes appended to the configured base artifactType to
+	// distinguish the three manifest kinds in the OCI 1.1 referrers layout.
+	// Operators inspecting the registry see e.g.
+	// "application/vnd.ocifactory.python.version" and can tell at a glance
+	// which manifests are version anchors, file payloads, or aliases.
+	versionArtifactSuffix = ".version"
+	fileArtifactSuffix    = ".file"
+	aliasArtifactSuffix   = ".alias"
 
 	// uploadMemThreshold is the largest upload body that AddFile will buffer
 	// fully in memory. Anything larger streams via chunked PATCH unless
@@ -43,16 +67,35 @@ const (
 // It is returned before any data is pushed to the backend.
 var ErrDigestMismatch = errors.New("file digest mismatch")
 
+// ErrAliasCollision is returned by AddFile or AppendRefs when a write would
+// clobber an existing tag whose manifest has an incompatible artifactType
+// (e.g. AppendRefs trying to overwrite a canonical version, or AddFile
+// trying to overwrite an alias). The HEAD-and-artifactType probe in the
+// write path turns silent overwrite into a typed error.
+var ErrAliasCollision = errors.New("tag collides with incompatible artifactType")
+
+// destRepo is the subset of oras-go's remote.Repository (and our in-memory
+// fake) that pkg/oci needs. Pinned as an interface so tests can substitute
+// memory-backed implementations.
 type destRepo interface {
 	oras.Target
 	registry.TagLister
 	content.Tagger
 	content.Deleter
+	content.PredecessorFinder
 }
 
 type Registry struct {
-	baseURL      *url.URL
-	artifactType string
+	baseURL *url.URL
+
+	// artifactType is the operator-configured base type. We derive three
+	// suffixed subtypes (versionArtifactType / fileArtifactType /
+	// aliasArtifactType) so each manifest kind in the OCI 1.1 referrers
+	// layout has a distinct, inspectable artifactType.
+	artifactType        string
+	versionArtifactType string
+	fileArtifactType    string
+	aliasArtifactType   string
 
 	// uploadMemThreshold is the in-memory staging cap for AddFile bodies.
 	// Initialised to the package default; overridable from tests.
@@ -69,7 +112,7 @@ type Registry struct {
 	// PATCH of a chunked upload would round-trip the registry's auth
 	// endpoint — a 200 MB jar at 4 MiB chunks would issue ~50 token
 	// fetches per upload and saturate the auth path under load.
-	authClients sync.Map // map[string]*auth.Client
+	authClients sync.Map // map[authCacheKey]*auth.Client
 
 	// Used in unit tests to stub with in-memory backend.
 	newBackendFunc func(ctx context.Context, f *RepoFile) (destRepo, error)
@@ -122,8 +165,13 @@ type RepoFile struct {
 	Size int64
 }
 
+// FileDescriptor identifies a file within the OCI-backed registry. Manifest
+// is the descriptor of the per-file OCI manifest that owns the file blob;
+// File is the descriptor of the blob layer itself. Callers typically only
+// inspect File.Digest / File.Size (e.g. for HTTP Content-Length / checksum
+// headers).
 type FileDescriptor struct {
-	Manifest ocispec.Descriptor // The owning manifest descriptor.
+	Manifest ocispec.Descriptor
 	File     ocispec.Descriptor
 }
 
@@ -142,83 +190,29 @@ func NewRegistry(baseURL *url.URL, opt ...RegistryOption) (*Registry, error) {
 		}
 	}
 
+	r.versionArtifactType = r.artifactType + versionArtifactSuffix
+	r.fileArtifactType = r.artifactType + fileArtifactSuffix
+	r.aliasArtifactType = r.artifactType + aliasArtifactSuffix
+
 	return r, nil
 }
 
-// DeleteTagFiles deletes all files in a tag.
-// It's used to delete a tag and all its files.
-func (r *Registry) DeleteTagFiles(ctx context.Context, repo string, tag string) error {
-	backendRepo, err := r.newBackendFunc(ctx, &RepoFile{OwningRepo: repo})
-	if err != nil {
-		return err
-	}
-
-	return r.deleteTagFiles(ctx, backendRepo, tag)
-}
-
-// DeleteRepoFiles deletes all files in a repository.
-// It's used to delete a repository and all its tags.
-func (r *Registry) DeleteRepoFiles(ctx context.Context, repo string) error {
-	backendRepo, err := r.newBackendFunc(ctx, &RepoFile{OwningRepo: repo})
-	if err != nil {
-		return err
-	}
-
-	tags, err := r.listTags(ctx, backendRepo)
-	if err != nil {
-		return err
-	}
-
-	for _, tag := range tags {
-		if strings.HasPrefix(tag, "ref_") {
-			continue // Ignore refs otherwise we'll get duplicated files.
-		}
-		if err := r.deleteTagFiles(ctx, backendRepo, tag); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (r *Registry) deleteTagFiles(ctx context.Context, backendRepo destRepo, tag string) error {
-	manifestDesc, err := backendRepo.Resolve(ctx, tag)
-	if err != nil {
-		return fmt.Errorf("failed to resolve manifest for tag %q: %w", tag, err)
-	}
-
-	if err := backendRepo.Delete(ctx, manifestDesc); err != nil {
-		return fmt.Errorf("failed to delete manifest for tag %q: %w", tag, err)
-	}
-	return nil
-}
-
-// AppendRefs appends tags to a manifest.
-// The canonical tag is the tag that points to the manifest.
-// The tags are the tags to append to the manifest.
-// The tags are appended in the order they are provided.
-// The canonical tag is not included in the tags list.
-func (r *Registry) AppendRefs(ctx context.Context, repo string, canonicalTag string, refs ...string) error {
-	backendRepo, err := r.newBackendFunc(ctx, &RepoFile{OwningRepo: repo})
-	if err != nil {
-		return err
-	}
-
-	manifestDesc, err := backendRepo.Resolve(ctx, canonicalTag)
-	if err != nil {
-		return fmt.Errorf("failed to resolve manifest for canonical tag %q: %w", canonicalTag, err)
-	}
-
-	for _, ref := range refs {
-		if err := backendRepo.Tag(ctx, manifestDesc, "ref_"+ref); err != nil {
-			return fmt.Errorf("failed to tag manifest for ref %q: %w", ref, err)
-		}
-	}
-
-	return nil
-}
-
-// AddFile adds a file to the registry.
+// AddFile adds a file to the registry under the OwningRepo / OwningTag pair
+// in RepoFile. The implementation uses the OCI 1.1 referrers layout:
+//
+//  1. Push (or skip, if already present) the file blob.
+//  2. Idempotently ensure a "version" manifest exists tagged with
+//     RepoFile.OwningTag. The version manifest carries no layers — it is
+//     a constant-size anchor that file manifests reference via their
+//     subject field.
+//  3. Pack and push a "file" manifest whose single layer is the blob and
+//     whose subject is the version manifest. The file manifest is not
+//     tagged; it is addressed via the referrers API.
+//
+// This eliminates the read-modify-write cycle the legacy aggregated-manifest
+// flow performed on every file, and lets concurrent uploads to the same
+// version proceed independently — there is no shared mutable state between
+// them.
 //
 // AddFile picks one of two upload paths per call:
 //
@@ -241,7 +235,7 @@ func (r *Registry) AppendRefs(ctx context.Context, repo string, canonicalTag str
 // Transfer-Encoding), AddFile peeks up to uploadMemThreshold+1 bytes to
 // decide.
 //
-// Other behaviour is identical between paths:
+// Behaviour shared between paths:
 //
 //   - If RepoFile.Digest is set and disagrees with the digest computed
 //     from the body, AddFile returns ErrDigestMismatch. On the buffered
@@ -251,16 +245,42 @@ func (r *Registry) AppendRefs(ctx context.Context, repo string, canonicalTag str
 //   - If a layer with the same digest already exists in the backend, the
 //     blob upload is skipped (buffered path) or the registry deduplicates
 //     on commit (streaming path).
-//   - If the file is unchanged in the manifest for RepoFile.OwningTag,
-//     the manifest is left untouched. Otherwise the manifest is repacked
-//     and re-tagged.
+//   - The file manifest digest is deterministic for a given (blob,
+//     filename, version) tuple, so re-adding identical content does not
+//     re-push the manifest either — the Exists check inside
+//     packAndPushManifest short-circuits.
+//   - If RepoFile.OwningTag currently resolves to an alias manifest
+//     (artifactType ≠ versionArtifactType), AddFile returns
+//     ErrAliasCollision rather than silently overwriting the alias.
 func (r *Registry) AddFile(ctx context.Context, f *RepoFile, ro io.Reader) (*FileDescriptor, error) {
-	if strings.HasPrefix(f.OwningTag, "ref_") {
-		return nil, fmt.Errorf("canonical tag cannot be prefixed with ref_; got %q", f.OwningTag)
+	if f.OwningTag == "" {
+		return nil, fmt.Errorf("OwningTag must be set")
 	}
 
+	blobDesc, backend, err := r.uploadBlob(ctx, f, ro)
+	if err != nil {
+		return nil, err
+	}
+
+	versionDesc, err := r.ensureVersionManifest(ctx, backend, f.OwningTag)
+	if err != nil {
+		return nil, err
+	}
+
+	fileManifestDesc, err := r.pushFileManifest(ctx, backend, blobDesc, f.Name, versionDesc)
+	if err != nil {
+		return nil, err
+	}
+
+	return &FileDescriptor{Manifest: fileManifestDesc, File: blobDesc}, nil
+}
+
+// uploadBlob picks between the buffered and streaming push paths and
+// returns the resulting blob descriptor along with the backend handle the
+// caller should reuse for subsequent manifest writes.
+func (r *Registry) uploadBlob(ctx context.Context, f *RepoFile, ro io.Reader) (ocispec.Descriptor, destRepo, error) {
 	if r.disableStreamingPush {
-		return r.addFileBuffered(ctx, f, ro)
+		return r.uploadBlobBuffered(ctx, f, ro)
 	}
 
 	// Fast path: when the caller knows the body length up front (typically
@@ -270,9 +290,9 @@ func (r *Registry) AddFile(ctx context.Context, f *RepoFile, ro io.Reader) (*Fil
 	// the streaming path — a meaningful waste at high concurrency.
 	if f.Size > 0 {
 		if f.Size > r.uploadMemThreshold {
-			return r.addFileStreaming(ctx, f, ro)
+			return r.uploadBlobStreaming(ctx, f, ro)
 		}
-		return r.addFileBuffered(ctx, f, ro)
+		return r.uploadBlobBuffered(ctx, f, ro)
 	}
 
 	// Unknown size: peek up to memThreshold+1 bytes so we can decide
@@ -282,129 +302,566 @@ func (r *Registry) AddFile(ctx context.Context, f *RepoFile, ro io.Reader) (*Fil
 	// path consumes the head and the rest of `ro` in order.
 	head, full, err := bufferUploadHead(ro, r.uploadMemThreshold)
 	if err != nil {
-		return nil, err
+		return ocispec.Descriptor{}, nil, err
 	}
 	if full {
-		return r.addFileBuffered(ctx, f, bytes.NewReader(head))
+		return r.uploadBlobBuffered(ctx, f, bytes.NewReader(head))
 	}
-	return r.addFileStreaming(ctx, f, io.MultiReader(bytes.NewReader(head), ro))
+	return r.uploadBlobStreaming(ctx, f, io.MultiReader(bytes.NewReader(head), ro))
 }
 
-// addFileBuffered is the existing pre-#38 upload path: stage into memory or
-// (above the threshold) a single temp file, then monolithic Push. It is
-// preserved for the disable-streaming opt-out and as the small-body fast
-// path.
-func (r *Registry) addFileBuffered(ctx context.Context, f *RepoFile, ro io.Reader) (*FileDescriptor, error) {
+func (r *Registry) uploadBlobBuffered(ctx context.Context, f *RepoFile, ro io.Reader) (ocispec.Descriptor, destRepo, error) {
 	staged, err := stageUploadWithThreshold(ro, r.uploadMemThreshold)
 	if err != nil {
-		return nil, err
+		return ocispec.Descriptor{}, nil, err
 	}
 	defer staged.cleanup()
 
 	if f.Digest != "" {
 		expected, err := digest.Parse(f.Digest)
 		if err != nil {
-			return nil, fmt.Errorf("invalid expected digest %q: %w", f.Digest, err)
+			return ocispec.Descriptor{}, nil, fmt.Errorf("invalid expected digest %q: %w", f.Digest, err)
 		}
 		if expected != staged.digest {
-			return nil, fmt.Errorf("%w: %q != %q", ErrDigestMismatch, staged.digest, expected)
+			return ocispec.Descriptor{}, nil, fmt.Errorf("%w: %q != %q", ErrDigestMismatch, staged.digest, expected)
 		}
 	}
 
-	fileDesc := ocispec.Descriptor{
-		MediaType: detectFileMediaType(f),
-		Digest:    staged.digest,
-		Size:      staged.size,
-		Annotations: map[string]string{
-			FileNameAnnotation:      f.Name,
-			ocispec.AnnotationTitle: f.Name,
-		},
+	blobDesc := newBlobDescriptor(f, staged.digest, staged.size)
+
+	backend, err := r.newBackendFunc(ctx, f)
+	if err != nil {
+		return ocispec.Descriptor{}, nil, err
 	}
 
-	backendRepo, err := r.newBackendFunc(ctx, f)
+	exists, err := backend.Exists(ctx, blobDesc)
 	if err != nil {
-		return nil, err
-	}
-
-	exists, err := backendRepo.Exists(ctx, fileDesc)
-	if err != nil {
-		return nil, fmt.Errorf("failed to check if file blob exists: %w", err)
+		return ocispec.Descriptor{}, nil, fmt.Errorf("failed to check if file blob exists: %w", err)
 	}
 	if !exists {
 		blobReader, err := staged.reader()
 		if err != nil {
-			return nil, err
+			return ocispec.Descriptor{}, nil, err
 		}
-		if err := backendRepo.Push(ctx, fileDesc, blobReader); err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
-			return nil, fmt.Errorf("failed to push file blob: %w", err)
+		if err := backend.Push(ctx, blobDesc, blobReader); err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
+			return ocispec.Descriptor{}, nil, fmt.Errorf("failed to push file blob: %w", err)
 		}
 	}
 
-	return r.finishManifest(ctx, backendRepo, f, fileDesc)
+	return blobDesc, backend, nil
 }
 
-// addFileStreaming pushes the blob via chunked PATCH (no in-process
-// buffering) and then runs the same manifest update path as the buffered
-// flow. The streaming pusher computes the digest as bytes flow through it,
-// so f.Digest is checked only after PATCHes complete — see streamPusher.Push
-// for the exact ordering.
-func (r *Registry) addFileStreaming(ctx context.Context, f *RepoFile, body io.Reader) (*FileDescriptor, error) {
+func (r *Registry) uploadBlobStreaming(ctx context.Context, f *RepoFile, body io.Reader) (ocispec.Descriptor, destRepo, error) {
 	pusher, err := r.newStreamPusherFunc(ctx, f)
 	if err != nil {
-		return nil, fmt.Errorf("failed to construct streaming pusher: %w", err)
+		return ocispec.Descriptor{}, nil, fmt.Errorf("failed to construct streaming pusher: %w", err)
 	}
 
 	mediaType := detectFileMediaType(f)
-	desc, err := pusher.Push(ctx, mediaType, f.Digest, body)
+	pushedDesc, err := pusher.Push(ctx, mediaType, f.Digest, body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to stream file blob: %w", err)
+		return ocispec.Descriptor{}, nil, fmt.Errorf("failed to stream file blob: %w", err)
 	}
 
-	fileDesc := ocispec.Descriptor{
-		MediaType: mediaType,
-		Digest:    desc.Digest,
-		Size:      desc.Size,
+	blobDesc := newBlobDescriptor(f, pushedDesc.Digest, pushedDesc.Size)
+
+	backend, err := r.newBackendFunc(ctx, f)
+	if err != nil {
+		return ocispec.Descriptor{}, nil, err
+	}
+	return blobDesc, backend, nil
+}
+
+// newBlobDescriptor builds the layer descriptor we store in the file
+// manifest. Annotations carry both the spec-defined image-title and the
+// ocifactory-private FileNameAnnotation; downstream callers that already
+// look up by FileNameAnnotation continue to work unchanged.
+func newBlobDescriptor(f *RepoFile, dgst digest.Digest, size int64) ocispec.Descriptor {
+	return ocispec.Descriptor{
+		MediaType: detectFileMediaType(f),
+		Digest:    dgst,
+		Size:      size,
 		Annotations: map[string]string{
 			FileNameAnnotation:      f.Name,
 			ocispec.AnnotationTitle: f.Name,
 		},
 	}
-
-	backendRepo, err := r.newBackendFunc(ctx, f)
-	if err != nil {
-		return nil, err
-	}
-	return r.finishManifest(ctx, backendRepo, f, fileDesc)
 }
 
-// finishManifest performs the read-modify-write step on the OwningTag
-// manifest after a blob push has completed. Shared between both upload
-// paths so the manifest semantics stay identical.
-func (r *Registry) finishManifest(ctx context.Context, backendRepo destRepo, f *RepoFile, fileDesc ocispec.Descriptor) (*FileDescriptor, error) {
-	manifestDesc, err := backendRepo.Resolve(ctx, f.OwningTag)
-	if err != nil && !errors.Is(err, errdef.ErrNotFound) {
-		return nil, fmt.Errorf("failed to resolve manifest for tag %q: %w", f.OwningTag, err)
+// ensureVersionManifest resolves owningTag to a version manifest, creating
+// one if it doesn't yet exist. If the tag already resolves to a manifest
+// with an incompatible artifactType (typically an alias), it returns
+// ErrAliasCollision. Idempotent: concurrent callers all converge on the
+// same content-addressed manifest digest.
+func (r *Registry) ensureVersionManifest(ctx context.Context, backend destRepo, owningTag string) (ocispec.Descriptor, error) {
+	if existing, err := backend.Resolve(ctx, owningTag); err == nil {
+		aType, err := manifestArtifactType(ctx, backend, existing)
+		if err != nil {
+			return ocispec.Descriptor{}, fmt.Errorf("failed to inspect tag %q: %w", owningTag, err)
+		}
+		switch aType {
+		case r.versionArtifactType:
+			return existing, nil
+		case r.aliasArtifactType:
+			return ocispec.Descriptor{}, fmt.Errorf("%w: tag %q is an alias", ErrAliasCollision, owningTag)
+		default:
+			return ocispec.Descriptor{}, fmt.Errorf("%w: tag %q has artifactType %q (expected %q)", ErrAliasCollision, owningTag, aType, r.versionArtifactType)
+		}
+	} else if !errors.Is(err, errdef.ErrNotFound) {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to resolve version tag %q: %w", owningTag, err)
 	}
 
-	layers, err := manifestLayers(ctx, backendRepo, manifestDesc)
+	desc, err := packAndPushManifest(ctx, backend, r.versionArtifactType, nil, nil, nil)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to push version manifest for %q: %w", owningTag, err)
+	}
+	if err := backend.Tag(ctx, desc, owningTag); err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to tag version manifest %q: %w", owningTag, err)
+	}
+	return desc, nil
+}
+
+// pushFileManifest packs a file manifest with subject = versionDesc, single
+// layer = blobDesc, and the file's name + blob digest mirrored into manifest
+// annotations so the referrers index reflects them without an extra fetch.
+func (r *Registry) pushFileManifest(ctx context.Context, backend destRepo, blobDesc ocispec.Descriptor, fileName string, versionDesc ocispec.Descriptor) (ocispec.Descriptor, error) {
+	annotations := map[string]string{
+		FileNameAnnotation:      fileName,
+		ocispec.AnnotationTitle: fileName,
+		FileDigestAnnotation:    blobDesc.Digest.String(),
+	}
+	desc, err := packAndPushManifest(ctx, backend, r.fileArtifactType, []ocispec.Descriptor{blobDesc}, &versionDesc, annotations)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to push file manifest for %q: %w", fileName, err)
+	}
+	return desc, nil
+}
+
+// ReadFile reads a file by either OwningTag or RefTag. With OwningTag, the
+// version manifest is resolved directly and its file referrers are scanned
+// for a name match. With RefTag, the alias manifest is resolved first, its
+// subject followed to the canonical version manifest, and the same scan
+// runs from there.
+func (r *Registry) ReadFile(ctx context.Context, f *RepoFile) (*FileDescriptor, io.ReadCloser, error) {
+	if f.OwningTag == "" && f.RefTag == "" {
+		return nil, nil, fmt.Errorf("either OwningTag or RefTag must be set")
+	}
+
+	backend, err := r.newBackendFunc(ctx, f)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	versionDesc, err := r.resolveVersionDescriptor(ctx, backend, f)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	refs, err := registry.Referrers(ctx, backend, versionDesc, r.fileArtifactType)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list file referrers: %w", err)
+	}
+
+	for i := range refs {
+		if refs[i].Annotations[FileNameAnnotation] != f.Name {
+			continue
+		}
+		fileManifestDesc := refs[i]
+		blobDesc, err := fetchBlobDescriptor(ctx, backend, fileManifestDesc)
+		if err != nil {
+			return nil, nil, err
+		}
+		if f.Digest != "" && string(blobDesc.Digest) != f.Digest {
+			return nil, nil, fmt.Errorf("file digest mismatch: %q != %q", blobDesc.Digest, f.Digest)
+		}
+		rc, err := backend.Fetch(ctx, blobDesc)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to fetch file blob: %w", err)
+		}
+		return &FileDescriptor{Manifest: fileManifestDesc, File: blobDesc}, rc, nil
+	}
+
+	return nil, nil, fmt.Errorf("file %q not found in version: %w", f.Name, errdef.ErrNotFound)
+}
+
+// resolveVersionDescriptor turns a RepoFile (which may identify the version
+// directly via OwningTag or indirectly via RefTag) into the descriptor of
+// the canonical version manifest. The RefTag path follows the alias
+// manifest's subject field.
+func (r *Registry) resolveVersionDescriptor(ctx context.Context, backend destRepo, f *RepoFile) (ocispec.Descriptor, error) {
+	if f.OwningTag != "" {
+		desc, err := backend.Resolve(ctx, f.OwningTag)
+		if err != nil {
+			return ocispec.Descriptor{}, fmt.Errorf("failed to resolve version tag %q: %w", f.OwningTag, err)
+		}
+		return desc, nil
+	}
+
+	aliasDesc, err := backend.Resolve(ctx, f.RefTag)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to resolve alias tag %q: %w", f.RefTag, err)
+	}
+	var aliasManifest ocispec.Manifest
+	if err := fetchManifestJSON(ctx, backend, aliasDesc, &aliasManifest); err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to fetch alias manifest %q: %w", f.RefTag, err)
+	}
+	if aliasManifest.ArtifactType != r.aliasArtifactType {
+		return ocispec.Descriptor{}, fmt.Errorf("%w: tag %q has artifactType %q (expected %q)", ErrAliasCollision, f.RefTag, aliasManifest.ArtifactType, r.aliasArtifactType)
+	}
+	if aliasManifest.Subject == nil {
+		return ocispec.Descriptor{}, fmt.Errorf("alias manifest %q has no subject", f.RefTag)
+	}
+	return *aliasManifest.Subject, nil
+}
+
+// ListTags lists the tags for a repository. Both canonical version tags
+// and alias tags are returned in the same flat list — the legacy ref_
+// prefix filter is gone. Callers that need version-vs-alias discrimination
+// should use a sibling helper (added when first needed; the current
+// in-tree caller is python's "index" repo, which has no aliases).
+func (r *Registry) ListTags(ctx context.Context, repo string) ([]string, error) {
+	backend, err := r.newBackendFunc(ctx, &RepoFile{OwningRepo: repo})
 	if err != nil {
 		return nil, err
 	}
-	updated, layers := upsertFileLayer(layers, fileDesc)
-	if !updated { // No need to update the manifest if the file hasn't changed.
-		return &FileDescriptor{Manifest: manifestDesc, File: fileDesc}, nil
-	}
+	return registry.Tags(ctx, backend)
+}
 
-	packOpts := oras.PackManifestOptions{Layers: layers}
-	newManifestDesc, err := oras.PackManifest(ctx, backendRepo, oras.PackManifestVersion1_1, r.artifactType, packOpts)
+// ListFiles enumerates all files across all canonical versions in repo.
+// Aliases are skipped by checking each tag's manifest artifactType so the
+// same file isn't reported twice. The blob digest comes from the
+// FileDigestAnnotation we mirror on the file manifest, avoiding a fetch
+// per file.
+func (r *Registry) ListFiles(ctx context.Context, repo string) ([]*RepoFile, error) {
+	backend, err := r.newBackendFunc(ctx, &RepoFile{OwningRepo: repo})
 	if err != nil {
-		return nil, fmt.Errorf("failed to pack new manifest: %w", err)
-	}
-	if err := backendRepo.Tag(ctx, newManifestDesc, f.OwningTag); err != nil {
-		return nil, fmt.Errorf("failed to tag new manifest: %w", err)
+		return nil, err
 	}
 
-	return &FileDescriptor{Manifest: newManifestDesc, File: fileDesc}, nil
+	tags, err := registry.Tags(ctx, backend)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list tags: %w", err)
+	}
+
+	var files []*RepoFile
+	for _, tag := range tags {
+		versionDesc, err := backend.Resolve(ctx, tag)
+		if err != nil {
+			if errors.Is(err, errdef.ErrNotFound) {
+				continue
+			}
+			return nil, fmt.Errorf("failed to resolve tag %q: %w", tag, err)
+		}
+		aType, err := manifestArtifactType(ctx, backend, versionDesc)
+		if err != nil {
+			return nil, fmt.Errorf("failed to inspect tag %q: %w", tag, err)
+		}
+		if aType != r.versionArtifactType {
+			// Alias or unrelated manifest — skip.
+			continue
+		}
+		refs, err := registry.Referrers(ctx, backend, versionDesc, r.fileArtifactType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list referrers for %q: %w", tag, err)
+		}
+		for _, ref := range refs {
+			name := ref.Annotations[FileNameAnnotation]
+			if name == "" {
+				continue
+			}
+			files = append(files, &RepoFile{
+				Name:       name,
+				OwningRepo: repo,
+				OwningTag:  tag,
+				Digest:     ref.Annotations[FileDigestAnnotation],
+			})
+		}
+	}
+
+	return files, nil
+}
+
+// AppendRefs creates one alias manifest per ref name, each with subject =
+// the canonical version manifest and tagged with the ref name. Concurrent
+// AppendRefs calls for the same ref are resolved by the registry's tag
+// namespace (last writer wins on the Tag write); orphaned previous alias
+// manifests are best-effort cleaned up.
+//
+// If a ref name already exists as a non-alias tag (e.g. there's a
+// canonical version literally named "latest"), AppendRefs returns
+// ErrAliasCollision rather than overwriting it.
+func (r *Registry) AppendRefs(ctx context.Context, repo string, canonicalTag string, refs ...string) error {
+	backend, err := r.newBackendFunc(ctx, &RepoFile{OwningRepo: repo})
+	if err != nil {
+		return err
+	}
+
+	versionDesc, err := backend.Resolve(ctx, canonicalTag)
+	if err != nil {
+		return fmt.Errorf("failed to resolve canonical tag %q: %w", canonicalTag, err)
+	}
+	// Defence in depth: refuse to alias something that isn't a version
+	// manifest. Stops a stray AppendRefs("packageRoot", "anAlias") from
+	// pointing aliases at random manifests we didn't author.
+	if aType, err := manifestArtifactType(ctx, backend, versionDesc); err != nil {
+		return fmt.Errorf("failed to inspect canonical tag %q: %w", canonicalTag, err)
+	} else if aType != r.versionArtifactType {
+		return fmt.Errorf("%w: canonical tag %q has artifactType %q (expected %q)", ErrAliasCollision, canonicalTag, aType, r.versionArtifactType)
+	}
+
+	for _, ref := range refs {
+		var oldAlias ocispec.Descriptor
+		hasOld := false
+		if existing, err := backend.Resolve(ctx, ref); err == nil {
+			aType, err := manifestArtifactType(ctx, backend, existing)
+			if err != nil {
+				return fmt.Errorf("failed to inspect tag %q: %w", ref, err)
+			}
+			if aType != r.aliasArtifactType {
+				return fmt.Errorf("%w: tag %q has artifactType %q (expected alias)", ErrAliasCollision, ref, aType)
+			}
+			oldAlias = existing
+			hasOld = true
+		} else if !errors.Is(err, errdef.ErrNotFound) {
+			return fmt.Errorf("failed to resolve tag %q: %w", ref, err)
+		}
+
+		annotations := map[string]string{
+			AliasTargetAnnotation: canonicalTag,
+		}
+		aliasDesc, err := packAndPushManifest(ctx, backend, r.aliasArtifactType, nil, &versionDesc, annotations)
+		if err != nil {
+			return fmt.Errorf("failed to push alias manifest %q: %w", ref, err)
+		}
+		if err := backend.Tag(ctx, aliasDesc, ref); err != nil {
+			return fmt.Errorf("failed to tag alias %q: %w", ref, err)
+		}
+		// Best-effort cleanup of the old alias manifest if it had a
+		// different digest. Failure here is non-fatal — the orphan stays
+		// discoverable via the version's referrers list until backend GC
+		// reaps it, but the live tag points at the new alias regardless.
+		if hasOld && oldAlias.Digest != aliasDesc.Digest {
+			_ = backend.Delete(ctx, oldAlias)
+		}
+	}
+
+	return nil
+}
+
+// DeleteTagFiles deletes every file under a canonical version tag, then
+// the version manifest itself. Alias manifests pointing at the version
+// are left alone — callers that want them gone should AppendRefs to a new
+// target first or call DeleteRepoFiles.
+//
+// If tag resolves to a non-version manifest, only that manifest is
+// deleted (treated as deleting the alias). The caller can chain a second
+// call to drop the underlying version.
+func (r *Registry) DeleteTagFiles(ctx context.Context, repo string, tag string) error {
+	backend, err := r.newBackendFunc(ctx, &RepoFile{OwningRepo: repo})
+	if err != nil {
+		return err
+	}
+	return r.deleteTagFiles(ctx, backend, tag)
+}
+
+func (r *Registry) deleteTagFiles(ctx context.Context, backend destRepo, tag string) error {
+	desc, err := backend.Resolve(ctx, tag)
+	if err != nil {
+		return fmt.Errorf("failed to resolve manifest for tag %q: %w", tag, err)
+	}
+
+	aType, err := manifestArtifactType(ctx, backend, desc)
+	if err != nil {
+		return fmt.Errorf("failed to inspect tag %q: %w", tag, err)
+	}
+
+	if aType == r.versionArtifactType {
+		// Best-effort: enumerate all referrers (file manifests + any alias
+		// manifests still pointing here) and delete them before the
+		// version manifest itself, so the on-backend graph is left clean.
+		refs, err := registry.Referrers(ctx, backend, desc, "")
+		if err != nil {
+			return fmt.Errorf("failed to list referrers for tag %q: %w", tag, err)
+		}
+		for _, ref := range refs {
+			if err := backend.Delete(ctx, ref); err != nil && !errors.Is(err, errdef.ErrNotFound) {
+				return fmt.Errorf("failed to delete referrer %s: %w", ref.Digest, err)
+			}
+		}
+	}
+
+	if err := backend.Delete(ctx, desc); err != nil && !errors.Is(err, errdef.ErrNotFound) {
+		return fmt.Errorf("failed to delete manifest for tag %q: %w", tag, err)
+	}
+	return nil
+}
+
+// DeleteRepoFiles deletes every canonical version (and its files) in a
+// repository. Aliases are dropped as a side effect of DeleteTagFiles
+// reaping referrers.
+func (r *Registry) DeleteRepoFiles(ctx context.Context, repo string) error {
+	backend, err := r.newBackendFunc(ctx, &RepoFile{OwningRepo: repo})
+	if err != nil {
+		return err
+	}
+
+	tags, err := registry.Tags(ctx, backend)
+	if err != nil {
+		return fmt.Errorf("failed to list tags: %w", err)
+	}
+
+	for _, tag := range tags {
+		// Resolve and skip anything that isn't a version manifest — alias
+		// manifests are already deleted as referrers when we delete their
+		// version (above), so iterating over them again would either
+		// double-delete (harmless) or, if some are still live because
+		// their target version is gone, blow up the loop ordering. Just
+		// scope deletion to versions and let backend GC tidy the rest.
+		desc, err := backend.Resolve(ctx, tag)
+		if err != nil {
+			if errors.Is(err, errdef.ErrNotFound) {
+				continue
+			}
+			return fmt.Errorf("failed to resolve tag %q: %w", tag, err)
+		}
+		aType, err := manifestArtifactType(ctx, backend, desc)
+		if err != nil {
+			return fmt.Errorf("failed to inspect tag %q: %w", tag, err)
+		}
+		if aType != r.versionArtifactType {
+			continue
+		}
+		if err := r.deleteTagFiles(ctx, backend, tag); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// packAndPushManifest builds a deterministic OCI image manifest, checks
+// existence in the backend, and pushes it only when missing. Determinism
+// matters: identical (artifactType, layers, subject, annotations) inputs
+// must produce identical manifest digests so re-runs of AddFile /
+// AppendRefs short-circuit at the Exists check rather than re-pushing
+// the same bytes.
+//
+// We avoid oras.PackManifest on this path because it auto-injects the
+// org.opencontainers.image.created annotation with a fresh timestamp,
+// which would defeat content-addressed dedup. Instead we marshal the
+// manifest ourselves and let json.Marshal's stable map-key ordering
+// produce reproducible bytes.
+func packAndPushManifest(
+	ctx context.Context,
+	target destRepo,
+	artifactType string,
+	layers []ocispec.Descriptor,
+	subject *ocispec.Descriptor,
+	annotations map[string]string,
+) (ocispec.Descriptor, error) {
+	emptyDesc := ocispec.DescriptorEmptyJSON
+
+	if err := pushIfMissing(ctx, target, emptyDesc, emptyDesc.Data); err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to push empty config blob: %w", err)
+	}
+
+	if len(layers) == 0 {
+		// image-spec v1.1 requires at least one layer; reuse the empty
+		// blob as a constant-size sentinel for version and alias
+		// manifests that semantically have none.
+		layers = []ocispec.Descriptor{emptyDesc}
+	}
+
+	manifest := ocispec.Manifest{
+		Versioned:    specs.Versioned{SchemaVersion: 2},
+		MediaType:    ocispec.MediaTypeImageManifest,
+		ArtifactType: artifactType,
+		Config:       emptyDesc,
+		Layers:       layers,
+		Subject:      subject,
+		Annotations:  annotations,
+	}
+	body, err := json.Marshal(manifest)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to marshal manifest: %w", err)
+	}
+	desc := content.NewDescriptorFromBytes(ocispec.MediaTypeImageManifest, body)
+	desc.ArtifactType = artifactType
+	desc.Annotations = annotations
+
+	if err := pushIfMissing(ctx, target, desc, body); err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to push manifest: %w", err)
+	}
+	return desc, nil
+}
+
+// pushIfMissing pushes data only if the backend doesn't already have the
+// described content. Wraps the Exists/Push pair so the manifest dedup path
+// reads cleanly. ErrAlreadyExists from a concurrent push is swallowed —
+// we only care that the content is there at the end.
+func pushIfMissing(ctx context.Context, target destRepo, desc ocispec.Descriptor, data []byte) error {
+	exists, err := target.Exists(ctx, desc)
+	if err != nil {
+		return fmt.Errorf("exists check: %w", err)
+	}
+	if exists {
+		return nil
+	}
+	if err := target.Push(ctx, desc, bytes.NewReader(data)); err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
+		return err
+	}
+	return nil
+}
+
+// manifestArtifactType fetches a manifest's body and returns its
+// artifactType field. Used by ensureVersionManifest, AppendRefs, and
+// ListFiles to discriminate version manifests from alias manifests
+// without relying on tag-name conventions. Exists at the cost of one
+// extra GET per discriminated tag — acceptable because no current code
+// path discriminates inside a tight loop on a hot read path.
+func manifestArtifactType(ctx context.Context, backend destRepo, desc ocispec.Descriptor) (string, error) {
+	if desc.ArtifactType != "" {
+		return desc.ArtifactType, nil
+	}
+	var m ocispec.Manifest
+	if err := fetchManifestJSON(ctx, backend, desc, &m); err != nil {
+		return "", err
+	}
+	return m.ArtifactType, nil
+}
+
+// fetchManifestJSON fetches and decodes a manifest body. The descriptor
+// must point at a manifest, not a generic blob — there is no media-type
+// guard here because every caller already knows what kind of manifest it
+// is asking for.
+func fetchManifestJSON(ctx context.Context, backend destRepo, desc ocispec.Descriptor, out *ocispec.Manifest) error {
+	rc, err := backend.Fetch(ctx, desc)
+	if err != nil {
+		return fmt.Errorf("failed to fetch manifest %s: %w", desc.Digest, err)
+	}
+	defer rc.Close()
+	body, err := io.ReadAll(rc)
+	if err != nil {
+		return fmt.Errorf("failed to read manifest %s: %w", desc.Digest, err)
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("failed to parse manifest %s: %w", desc.Digest, err)
+	}
+	return nil
+}
+
+// fetchBlobDescriptor returns the single layer descriptor of a file
+// manifest. ReadFile uses it to translate "I want file X under version
+// Y" into "fetch this blob digest".
+func fetchBlobDescriptor(ctx context.Context, backend destRepo, fileManifestDesc ocispec.Descriptor) (ocispec.Descriptor, error) {
+	var m ocispec.Manifest
+	if err := fetchManifestJSON(ctx, backend, fileManifestDesc, &m); err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to fetch file manifest: %w", err)
+	}
+	if len(m.Layers) != 1 {
+		return ocispec.Descriptor{}, fmt.Errorf("file manifest %s has %d layers, expected 1", fileManifestDesc.Digest, len(m.Layers))
+	}
+	return m.Layers[0], nil
 }
 
 // bufferUploadHead reads up to threshold+1 bytes from r into memory. It
@@ -422,116 +879,6 @@ func bufferUploadHead(r io.Reader, threshold int64) ([]byte, bool, error) {
 		return nil, false, fmt.Errorf("failed to buffer upload head: %w", err)
 	}
 	return buf.Bytes(), n <= threshold, nil
-}
-
-// ReadFile reads a file from the registry.
-// Returns the file descriptor and a reader for the file.
-// It's allowed to use a ref tag to read a file. Set it in the RepoFile.RefTag field.
-func (r *Registry) ReadFile(ctx context.Context, f *RepoFile) (*FileDescriptor, io.ReadCloser, error) {
-	if f.OwningTag == "" && f.RefTag == "" {
-		return nil, nil, fmt.Errorf("either OwningTag or RefTag must be set")
-	}
-
-	t := f.OwningTag
-	if t == "" {
-		t = "ref_" + f.RefTag
-	}
-
-	backendRepo, err := r.newBackendFunc(ctx, f)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	manifestDesc, err := backendRepo.Resolve(ctx, t)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to resolve manifest for tag %q: %w", t, err)
-	}
-
-	layers, err := manifestLayers(ctx, backendRepo, manifestDesc)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	for _, l := range layers {
-		if l.Annotations[FileNameAnnotation] == f.Name {
-			if f.Digest != "" && string(l.Digest) != f.Digest {
-				return nil, nil, fmt.Errorf("file digest mismatch: %q != %q", l.Digest, f.Digest)
-			}
-			rc, err := backendRepo.Fetch(ctx, l)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to fetch file: %w", err)
-			}
-			return &FileDescriptor{Manifest: manifestDesc, File: l}, rc, nil
-		}
-	}
-
-	return nil, nil, fmt.Errorf("file %q not found in manifest: %w", f.Name, errdef.ErrNotFound)
-}
-
-// ListTags lists the tags for a repository.
-func (r *Registry) ListTags(ctx context.Context, repo string) ([]string, error) {
-	backendRepo, err := r.newBackendFunc(ctx, &RepoFile{OwningRepo: repo})
-	if err != nil {
-		return nil, err
-	}
-
-	return r.listTags(ctx, backendRepo)
-}
-
-func (r *Registry) listTags(ctx context.Context, backendRepo destRepo) ([]string, error) {
-	tags, err := registry.Tags(ctx, backendRepo)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list tags: %w", err)
-	}
-
-	var excludeRefs []string
-	for _, tag := range tags {
-		if !strings.HasPrefix(tag, "ref_") {
-			excludeRefs = append(excludeRefs, tag)
-		}
-	}
-
-	return excludeRefs, nil
-}
-
-// ListFiles lists the files in a repository.
-func (r *Registry) ListFiles(ctx context.Context, repo string) ([]*RepoFile, error) {
-	backendRepo, err := r.newBackendFunc(ctx, &RepoFile{OwningRepo: repo})
-	if err != nil {
-		return nil, err
-	}
-
-	tags, err := r.listTags(ctx, backendRepo)
-	if err != nil {
-		return nil, err
-	}
-
-	var files []*RepoFile
-
-	for _, tag := range tags {
-		manifestDesc, err := backendRepo.Resolve(ctx, tag)
-		if err != nil {
-			return nil, fmt.Errorf("failed to resolve manifest for tag %q: %w", tag, err)
-		}
-
-		layers, err := manifestLayers(ctx, backendRepo, manifestDesc)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get manifest layers: %w", err)
-		}
-
-		for _, l := range layers {
-			if l.Annotations != nil && l.Annotations[FileNameAnnotation] != "" {
-				files = append(files, &RepoFile{
-					Name:       l.Annotations[FileNameAnnotation],
-					OwningRepo: repo,
-					OwningTag:  tag,
-					Digest:     string(l.Digest),
-				})
-			}
-		}
-	}
-
-	return files, nil
 }
 
 // stagedUpload is the result of staging an upload body for a single push.
@@ -631,7 +978,15 @@ func (r *Registry) newBackend(ctx context.Context, f *RepoFile) (destRepo, error
 		repo.Client = c
 	}
 
-	return repo, nil
+	return remoteRepo{Repository: repo}, nil
+}
+
+// remoteRepo adapts oras-go's *remote.Repository to our destRepo
+// interface. The wrapper exists only so the package compiles when oras-go
+// adds further methods that conflict with destRepo's surface; today it is
+// a thin pass-through.
+type remoteRepo struct {
+	*remote.Repository
 }
 
 // newStreamPusher constructs a streamPusher that talks directly to the
@@ -707,55 +1062,6 @@ type authCacheKey struct {
 	host     string
 	user     string
 	password string
-}
-
-// upsertFileLayer updates the layers list with the provided file descriptor.
-// If the file already exists in the layers list, it will be updated if the digest has changed.
-// Returns true if the file was added or updated, and the updated layers list.
-func upsertFileLayer(layers []ocispec.Descriptor, fileDesc ocispec.Descriptor) (bool, []ocispec.Descriptor) {
-	existingFileIdx := -1
-	for i, l := range layers {
-		if l.Annotations != nil && l.Annotations[FileNameAnnotation] == fileDesc.Annotations[FileNameAnnotation] {
-			existingFileIdx = i
-			break
-		}
-	}
-	if existingFileIdx != -1 {
-		// Update the layer if the digest has changed.
-		if layers[existingFileIdx].Digest != fileDesc.Digest {
-			layers[existingFileIdx] = fileDesc
-		} else {
-			return false, layers
-		}
-	} else {
-		// Add the layer if it doesn't exist.
-		layers = append(layers, fileDesc)
-	}
-	return true, layers
-}
-
-func manifestLayers(ctx context.Context, repo oras.Target, manifestDesc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-	var layers []ocispec.Descriptor
-	if manifestDesc.Digest != "" {
-		// Fetch the existing manifest
-		manifestReader, err := repo.Fetch(ctx, manifestDesc)
-		if err != nil {
-			return nil, fmt.Errorf("failed to fetch manifest: %w", err)
-		}
-		defer manifestReader.Close()
-
-		manifestBytes, err := io.ReadAll(manifestReader)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read manifest: %w", err)
-		}
-
-		var manifest ocispec.Manifest
-		if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal manifest: %w", err)
-		}
-		layers = manifest.Layers
-	}
-	return layers, nil
 }
 
 func detectFileMediaType(f *RepoFile) string {

--- a/pkg/oci/registry_test.go
+++ b/pkg/oci/registry_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -165,141 +166,35 @@ func TestDetectFileMediaType(t *testing.T) {
 	}
 }
 
-func TestUpsertFileLayer(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name           string
-		existingLayers []ocispec.Descriptor
-		newFileDesc    ocispec.Descriptor
-		wantUpdated    bool
-		wantLayers     []ocispec.Descriptor
-	}{
-		{
-			name:           "add new file",
-			existingLayers: []ocispec.Descriptor{},
-			newFileDesc: ocispec.Descriptor{
-				MediaType: "text/plain",
-				Digest:    "sha256:123",
-				Size:      100,
-				Annotations: map[string]string{
-					FileNameAnnotation: "test.txt",
-				},
-			},
-			wantUpdated: true,
-			wantLayers: []ocispec.Descriptor{
-				{
-					MediaType: "text/plain",
-					Digest:    "sha256:123",
-					Size:      100,
-					Annotations: map[string]string{
-						FileNameAnnotation: "test.txt",
-					},
-				},
-			},
-		},
-		{
-			name: "update existing file with different digest",
-			existingLayers: []ocispec.Descriptor{
-				{
-					MediaType: "text/plain",
-					Digest:    "sha256:123",
-					Size:      100,
-					Annotations: map[string]string{
-						FileNameAnnotation: "test.txt",
-					},
-				},
-			},
-			newFileDesc: ocispec.Descriptor{
-				MediaType: "text/plain",
-				Digest:    "sha256:456",
-				Size:      200,
-				Annotations: map[string]string{
-					FileNameAnnotation: "test.txt",
-				},
-			},
-			wantUpdated: true,
-			wantLayers: []ocispec.Descriptor{
-				{
-					MediaType: "text/plain",
-					Digest:    "sha256:456",
-					Size:      200,
-					Annotations: map[string]string{
-						FileNameAnnotation: "test.txt",
-					},
-				},
-			},
-		},
-		{
-			name: "no update for same digest",
-			existingLayers: []ocispec.Descriptor{
-				{
-					MediaType: "text/plain",
-					Digest:    "sha256:123",
-					Size:      100,
-					Annotations: map[string]string{
-						FileNameAnnotation: "test.txt",
-					},
-				},
-			},
-			newFileDesc: ocispec.Descriptor{
-				MediaType: "text/plain",
-				Digest:    "sha256:123",
-				Size:      100,
-				Annotations: map[string]string{
-					FileNameAnnotation: "test.txt",
-				},
-			},
-			wantUpdated: false,
-			wantLayers: []ocispec.Descriptor{
-				{
-					MediaType: "text/plain",
-					Digest:    "sha256:123",
-					Size:      100,
-					Annotations: map[string]string{
-						FileNameAnnotation: "test.txt",
-					},
-				},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			gotUpdated, gotLayers := upsertFileLayer(tt.existingLayers, tt.newFileDesc)
-			if gotUpdated != tt.wantUpdated {
-				t.Errorf("upsertFileLayer() updated = %v, want %v", gotUpdated, tt.wantUpdated)
-			}
-
-			if diff := cmp.Diff(tt.wantLayers, gotLayers); diff != "" {
-				t.Errorf("upsertFileLayer() layers mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
 type inMemoryRepo struct {
 	*memory.Store
+
+	mu      sync.Mutex
 	allTags map[string]string
 }
 
 func (r *inMemoryRepo) Tags(_ context.Context, _ string, fn func(tags []string) error) error {
-	return fn(slices.Collect(maps.Keys(r.allTags)))
+	r.mu.Lock()
+	tags := slices.Collect(maps.Keys(r.allTags))
+	r.mu.Unlock()
+	return fn(tags)
 }
 
 func (r *inMemoryRepo) Tag(ctx context.Context, desc ocispec.Descriptor, reference string) error {
+	r.mu.Lock()
 	r.allTags[reference] = desc.Digest.String()
+	r.mu.Unlock()
 	return r.Store.Tag(ctx, desc, reference)
 }
 
 func (r *inMemoryRepo) Delete(ctx context.Context, target ocispec.Descriptor) error {
+	r.mu.Lock()
 	for tag, digest := range r.allTags {
 		if digest == target.Digest.String() {
 			delete(r.allTags, tag)
 		}
 	}
+	r.mu.Unlock()
 	return nil
 }
 
@@ -310,10 +205,12 @@ func (r *inMemoryRepo) Resolve(ctx context.Context, reference string) (ocispec.D
 		return ocispec.Descriptor{}, err
 	}
 
-	if _, ok := r.allTags[reference]; !ok {
+	r.mu.Lock()
+	_, ok := r.allTags[reference]
+	r.mu.Unlock()
+	if !ok {
 		return ocispec.Descriptor{}, errdef.ErrNotFound
 	}
-
 	return target, nil
 }
 
@@ -333,16 +230,19 @@ func TestAddReadRoundtrip(t *testing.T) {
 	}
 
 	// Override the newBackendFunc to use the memory backend.
-	memRepo := &inMemoryRepo{Store: memory.New(), allTags: map[string]string{"v0": "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"}}
+	memRepo := &inMemoryRepo{Store: memory.New(), allTags: map[string]string{}}
 	r.newBackendFunc = func(ctx context.Context, f *RepoFile) (destRepo, error) {
 		return memRepo, nil
 	}
+
+	const content = "hello world"
+	wantBlobDigest := sha256Digest([]byte(content))
 
 	f0 := &RepoFile{
 		OwningRepo: "foobar",
 		OwningTag:  "v0",
 		Name:       "test.txt",
-		Digest:     "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+		Digest:     wantBlobDigest.String(),
 	}
 
 	// Read missing file -> ErrNotFound.
@@ -353,10 +253,12 @@ func TestAddReadRoundtrip(t *testing.T) {
 	}
 
 	// Add file.
-	const content = "hello world"
 	wantDesc, err := r.AddFile(ctx, f0, strings.NewReader(content))
 	if err != nil {
 		t.Fatalf("AddFile() error = %v", err)
+	}
+	if wantDesc.File.Digest != wantBlobDigest {
+		t.Errorf("AddFile() blob digest = %s, want %s", wantDesc.File.Digest, wantBlobDigest)
 	}
 
 	// Read by owning tag.
@@ -364,8 +266,8 @@ func TestAddReadRoundtrip(t *testing.T) {
 		t.Errorf("ReadFile() by owning tag: %v", err)
 	} else {
 		defer body.Close()
-		if diff := cmp.Diff(wantDesc, gotDesc); diff != "" {
-			t.Errorf("ReadFile() desc mismatch (-want +got):\n%s", diff)
+		if got, want := gotDesc.File.Digest, wantBlobDigest; got != want {
+			t.Errorf("ReadFile() blob digest = %s, want %s", got, want)
 		}
 		gotContent, err := io.ReadAll(body)
 		if err != nil {
@@ -386,13 +288,13 @@ func TestAddReadRoundtrip(t *testing.T) {
 		OwningRepo: "foobar",
 		RefTag:     "tag1",
 		Name:       "test.txt",
-		Digest:     "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+		Digest:     wantBlobDigest.String(),
 	}); err != nil {
 		t.Errorf("ReadFile() by ref tag: %v", err)
 	} else {
 		defer body.Close()
-		if diff := cmp.Diff(wantDesc, gotDesc); diff != "" {
-			t.Errorf("ReadFile() by ref tag desc mismatch (-want +got):\n%s", diff)
+		if got, want := gotDesc.File.Digest, wantBlobDigest; got != want {
+			t.Errorf("ReadFile() by ref tag blob digest = %s, want %s", got, want)
 		}
 		gotContent, err := io.ReadAll(body)
 		if err != nil {
@@ -403,21 +305,31 @@ func TestAddReadRoundtrip(t *testing.T) {
 		}
 	}
 
-	// List tags.
+	// List tags. Both canonical version tags and alias tags are returned in
+	// the new layout — the legacy ref_ filter is gone.
 	gotTags, err := r.ListTags(ctx, "foobar")
 	if err != nil {
 		t.Errorf("ListTags() error = %v", err)
 	}
-	if diff := cmp.Diff([]string{"v0"}, gotTags); diff != "" {
+	slices.Sort(gotTags)
+	if diff := cmp.Diff([]string{"tag1", "tag2", "v0"}, gotTags); diff != "" {
 		t.Errorf("ListTags() mismatch (-want +got):\n%s", diff)
 	}
 
-	// List files.
+	// List files. The new ListFiles filters to files under canonical
+	// version manifests (so aliases don't double-count), and reads the
+	// blob digest from the file manifest's annotation.
+	wantFile := &RepoFile{
+		Name:       "test.txt",
+		OwningRepo: "foobar",
+		OwningTag:  "v0",
+		Digest:     wantBlobDigest.String(),
+	}
 	gotFiles, err := r.ListFiles(ctx, "foobar")
 	if err != nil {
 		t.Errorf("ListFiles() error = %v", err)
 	}
-	if diff := cmp.Diff([]*RepoFile{f0}, gotFiles); diff != "" {
+	if diff := cmp.Diff([]*RepoFile{wantFile}, gotFiles); diff != "" {
 		t.Errorf("ListFiles() mismatch (-want +got):\n%s", diff)
 	}
 
@@ -552,14 +464,13 @@ func TestAddFile_BufferedPath(t *testing.T) {
 			wantErrSubstr: "failed to push file blob",
 		},
 		{
-			name:    "ref_ owning tag rejected",
+			name:    "missing OwningTag rejected",
 			content: smallContent,
 			repoFile: &RepoFile{
 				OwningRepo: "pkg",
-				OwningTag:  "ref_latest",
 				Name:       "test.txt",
 			},
-			wantErrSubstr: "canonical tag cannot be prefixed with ref_",
+			wantErrSubstr: "OwningTag must be set",
 		},
 	}
 
@@ -980,5 +891,223 @@ func TestAuthClientMemoization(t *testing.T) {
 	// No credentials -> nil client (auth-free request path).
 	if got := r.authClientFromContext(t.Context()); got != nil {
 		t.Errorf("expected nil client for no-credentials context, got %v", got)
+	}
+}
+
+// newTestRegistry builds a Registry whose backend is a fresh in-memory
+// store. Returned together with the backing store so tests can assert on
+// post-conditions directly.
+func newTestRegistry(t *testing.T) (*Registry, *inMemoryRepo) {
+	t.Helper()
+	r, err := NewRegistry(&url.URL{Scheme: "https", Host: "example.com"})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	memRepo := &inMemoryRepo{Store: memory.New(), allTags: map[string]string{}}
+	r.newBackendFunc = func(_ context.Context, _ *RepoFile) (destRepo, error) {
+		return memRepo, nil
+	}
+	return r, memRepo
+}
+
+// TestAddFile_ConcurrentSameVersion proves the cross-request race in #26
+// is fixed: N goroutines uploading distinct files into the same OwningTag
+// must all succeed and all files must be readable afterwards. Under the
+// pre-redesign aggregated-manifest layout this test was deterministic to
+// fail because of the un-CAS'd tag write — the loser dropped its layer.
+func TestAddFile_ConcurrentSameVersion(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	r, _ := newTestRegistry(t)
+
+	const goroutines = 16
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	errs := make([]error, goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+			content := fmt.Sprintf("content-%d", i)
+			f := &RepoFile{
+				OwningRepo: "pkg",
+				OwningTag:  "v1",
+				Name:       fmt.Sprintf("file-%d.txt", i),
+			}
+			if _, err := r.AddFile(ctx, f, strings.NewReader(content)); err != nil {
+				errs[i] = err
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d AddFile() error = %v", i, err)
+		}
+	}
+
+	files, err := r.ListFiles(ctx, "pkg")
+	if err != nil {
+		t.Fatalf("ListFiles() error = %v", err)
+	}
+	if got, want := len(files), goroutines; got != want {
+		names := make([]string, len(files))
+		for i, f := range files {
+			names[i] = f.Name
+		}
+		t.Fatalf("ListFiles() = %d files, want %d (got: %v)", got, want, names)
+	}
+
+	// Every file must round-trip via ReadFile too — proves the file
+	// manifests aren't just listed but actually fetchable end-to-end.
+	for i := 0; i < goroutines; i++ {
+		f := &RepoFile{
+			OwningRepo: "pkg",
+			OwningTag:  "v1",
+			Name:       fmt.Sprintf("file-%d.txt", i),
+		}
+		_, body, err := r.ReadFile(ctx, f)
+		if err != nil {
+			t.Errorf("ReadFile(%s) error = %v", f.Name, err)
+			continue
+		}
+		got, _ := io.ReadAll(body)
+		body.Close()
+		if want := fmt.Sprintf("content-%d", i); string(got) != want {
+			t.Errorf("ReadFile(%s) = %q, want %q", f.Name, got, want)
+		}
+	}
+}
+
+// TestAppendRefs_CollidesWithVersion verifies the alias-vs-version
+// namespace check on the AppendRefs side: pointing an alias at a name
+// that's already a canonical version tag is refused with
+// ErrAliasCollision rather than silently overwriting the version.
+func TestAppendRefs_CollidesWithVersion(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	r, _ := newTestRegistry(t)
+
+	if _, err := r.AddFile(ctx, &RepoFile{
+		OwningRepo: "pkg",
+		OwningTag:  "v1",
+		Name:       "a.txt",
+	}, strings.NewReader("a")); err != nil {
+		t.Fatalf("AddFile(v1) error = %v", err)
+	}
+	if _, err := r.AddFile(ctx, &RepoFile{
+		OwningRepo: "pkg",
+		OwningTag:  "v2",
+		Name:       "b.txt",
+	}, strings.NewReader("b")); err != nil {
+		t.Fatalf("AddFile(v2) error = %v", err)
+	}
+
+	// "v2" is already a canonical version — cannot be repurposed as an
+	// alias of v1.
+	err := r.AppendRefs(ctx, "pkg", "v1", "v2")
+	if !errors.Is(err, ErrAliasCollision) {
+		t.Fatalf("AppendRefs(collide) error = %v, want errors.Is ErrAliasCollision", err)
+	}
+}
+
+// TestAddFile_CollidesWithAlias verifies the inverse check on the
+// AddFile side: pushing a canonical version under a name that's already
+// an alias is refused with ErrAliasCollision.
+func TestAddFile_CollidesWithAlias(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	r, _ := newTestRegistry(t)
+
+	if _, err := r.AddFile(ctx, &RepoFile{
+		OwningRepo: "pkg",
+		OwningTag:  "v1",
+		Name:       "a.txt",
+	}, strings.NewReader("a")); err != nil {
+		t.Fatalf("AddFile(v1) error = %v", err)
+	}
+	if err := r.AppendRefs(ctx, "pkg", "v1", "latest"); err != nil {
+		t.Fatalf("AppendRefs(latest) error = %v", err)
+	}
+
+	// "latest" is now an alias — adding a file whose OwningTag is "latest"
+	// must refuse rather than clobber the alias.
+	_, err := r.AddFile(ctx, &RepoFile{
+		OwningRepo: "pkg",
+		OwningTag:  "latest",
+		Name:       "x.txt",
+	}, strings.NewReader("x"))
+	if !errors.Is(err, ErrAliasCollision) {
+		t.Fatalf("AddFile(latest) error = %v, want errors.Is ErrAliasCollision", err)
+	}
+}
+
+// TestAppendRefs_RepointReapsOldAlias verifies that re-pointing an
+// existing alias to a new canonical version replaces the alias manifest
+// and best-effort deletes the previous one. Without the cleanup, every
+// re-point would leave behind an orphaned alias manifest still
+// discoverable via the old version's referrers list.
+func TestAppendRefs_RepointReapsOldAlias(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	r, memRepo := newTestRegistry(t)
+
+	if _, err := r.AddFile(ctx, &RepoFile{
+		OwningRepo: "pkg",
+		OwningTag:  "v1",
+		Name:       "a.txt",
+	}, strings.NewReader("a")); err != nil {
+		t.Fatalf("AddFile(v1) error = %v", err)
+	}
+	if _, err := r.AddFile(ctx, &RepoFile{
+		OwningRepo: "pkg",
+		OwningTag:  "v2",
+		Name:       "b.txt",
+	}, strings.NewReader("b")); err != nil {
+		t.Fatalf("AddFile(v2) error = %v", err)
+	}
+
+	// First point latest -> v1, capture the alias manifest digest.
+	if err := r.AppendRefs(ctx, "pkg", "v1", "latest"); err != nil {
+		t.Fatalf("AppendRefs(latest -> v1) error = %v", err)
+	}
+	memRepo.mu.Lock()
+	v1AliasDigest := memRepo.allTags["latest"]
+	memRepo.mu.Unlock()
+	if v1AliasDigest == "" {
+		t.Fatalf("latest tag missing after first AppendRefs")
+	}
+
+	// Re-point latest -> v2.
+	if err := r.AppendRefs(ctx, "pkg", "v2", "latest"); err != nil {
+		t.Fatalf("AppendRefs(latest -> v2) error = %v", err)
+	}
+	memRepo.mu.Lock()
+	v2AliasDigest := memRepo.allTags["latest"]
+	memRepo.mu.Unlock()
+	if v2AliasDigest == "" {
+		t.Fatalf("latest tag missing after re-point")
+	}
+	if v1AliasDigest == v2AliasDigest {
+		t.Fatalf("alias manifest digest unchanged after re-point: %s", v1AliasDigest)
+	}
+
+	// Verify ReadFile via "latest" now yields v2's file.
+	_, body, err := r.ReadFile(ctx, &RepoFile{
+		OwningRepo: "pkg",
+		RefTag:     "latest",
+		Name:       "b.txt",
+	})
+	if err != nil {
+		t.Fatalf("ReadFile(latest, b.txt) error = %v", err)
+	}
+	got, _ := io.ReadAll(body)
+	body.Close()
+	if string(got) != "b" {
+		t.Errorf("ReadFile(latest, b.txt) = %q, want %q", got, "b")
 	}
 }

--- a/pkg/oci/stream_push_integration_test.go
+++ b/pkg/oci/stream_push_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"net/url"
+	"sync"
 	"testing"
 	"time"
 
@@ -144,5 +145,112 @@ func TestAddFile_StreamingIntegration_Zot(t *testing.T) {
 					len(gotBody), len(body), sha256Digest(gotBody) == wantDigest)
 			}
 		})
+	}
+}
+
+// TestAddFile_ConcurrentSameVersion_Zot exercises the OCI 1.1 referrers
+// concurrency property end-to-end against a real registry: N goroutines
+// upload distinct files into the same OwningTag in parallel and every
+// file must be recoverable via ReadFile afterwards. Under the
+// pre-redesign aggregated-manifest layout this would have lost layers to
+// the un-CAS'd tag-write race that issue #26 documented.
+func TestAddFile_ConcurrentSameVersion_Zot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping live-zot integration test in -short mode")
+	}
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
+	t.Cleanup(cancel)
+
+	zot, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        zotImage,
+			ExposedPorts: []string{"5000/tcp"},
+			WaitingFor: wait.ForHTTP("/v2/").
+				WithPort("5000/tcp").
+				WithStatusCodeMatcher(func(status int) bool { return status == 200 }).
+				WithStartupTimeout(60 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		t.Skipf("could not start zot container (Docker available?): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := zot.Terminate(context.Background()); err != nil {
+			t.Logf("zot terminate: %v", err)
+		}
+	})
+
+	host, err := zot.Host(ctx)
+	if err != nil {
+		t.Fatalf("zot.Host: %v", err)
+	}
+	port, err := zot.MappedPort(ctx, "5000/tcp")
+	if err != nil {
+		t.Fatalf("zot.MappedPort: %v", err)
+	}
+	base := &url.URL{Scheme: "http", Host: net.JoinHostPort(host, port.Port())}
+
+	r, err := NewRegistry(base)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	const goroutines = 12 // mirrors a typical mvn-deploy 12-file fan-out
+	bodies := make([][]byte, goroutines)
+	for i := range bodies {
+		bodies[i] = make([]byte, 32*1024)
+		if _, err := io.ReadFull(rand.Reader, bodies[i]); err != nil {
+			t.Fatalf("rand.Read: %v", err)
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	errs := make([]error, goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+			f := &RepoFile{
+				OwningRepo: "ocifactory/integration/concurrent",
+				OwningTag:  "v1",
+				Name:       fmt.Sprintf("file-%02d.bin", i),
+				Size:       int64(len(bodies[i])),
+			}
+			if _, err := r.AddFile(ctx, f, bytes.NewReader(bodies[i])); err != nil {
+				errs[i] = err
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d AddFile() error = %v", i, err)
+		}
+	}
+
+	for i := 0; i < goroutines; i++ {
+		f := &RepoFile{
+			OwningRepo: "ocifactory/integration/concurrent",
+			OwningTag:  "v1",
+			Name:       fmt.Sprintf("file-%02d.bin", i),
+		}
+		_, rc, err := r.ReadFile(ctx, f)
+		if err != nil {
+			t.Errorf("ReadFile(%s) error = %v", f.Name, err)
+			continue
+		}
+		gotBody, err := io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			t.Errorf("ReadAll(%s) error = %v", f.Name, err)
+			continue
+		}
+		if !bytes.Equal(bodies[i], gotBody) {
+			t.Errorf("ReadFile(%s): body mismatch (len=%d, want %d)", f.Name, len(gotBody), len(bodies[i]))
+		}
 	}
 }


### PR DESCRIPTION
Replaces the aggregated-version manifest + ref_-prefixed alias scheme with
a per-file manifest layout that uses subject/referrers:

  - Each file is its own image manifest with subject = version manifest;
    file manifests carry a single layer (the file blob) and surface the
    file name via annotations on both the manifest and the layer.
  - Each canonical version is a constant-size image manifest with no
    layers, tagged with OwningTag.
  - Each alias is its own image manifest with subject = the version
    manifest, tagged with the alias name. The ref_ prefix is gone; alias
    vs version discrimination is done via artifactType (suffixed
    .version / .file / .alias on the configured base type).

This eliminates the manifest read-modify-write cycle that #26 documented,
along with the cross-request race that silently dropped layers when two
goroutines uploaded into the same version. AppendRefs and AddFile now
HEAD the target tag and refuse on artifactType collision (alias trying
to overwrite a version, or vice versa) rather than silently clobbering.
Re-pointing an alias deletes the previous alias manifest best-effort so
orphans don't accumulate.

Constraints honoured:

  - handler.Registry interface is unchanged (AddFile, ReadFile, ListTags,
    ListFiles); handlers don't learn about subject/referrers.
  - Manifest size and layer-count limits don't apply: version manifests
    are constant size, file manifests carry exactly one layer.
  - The buffered/streaming AddFile dispatch (per #34/#38) is preserved.

The fake registry models the alias relationship via an Aliases map so
handler tests in other packages keep working unchanged.

New tests:

  - Concurrent AddFile to the same version (16 goroutines) — proves the
    race fix in #26 against the in-memory backend, plus a 12-goroutine
    integration test against zot.
  - Alias collides with version (AppendRefs side).
  - Version collides with alias (AddFile side).
  - Alias re-point reaps the previous alias manifest.

Closes #26 and #31.