### PR TITLE
Add echo handler and end-to-end OIDC CI test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,170 @@ jobs:
   # spin up zot without any extra setup steps here.
   go-test:
     uses: 'abcxyz/pkg/.github/workflows/go-test.yml@main' # ratchet:exclude
+
+  # oidc-e2e proves the auth chain end-to-end against a real OIDC
+  # issuer. GitHub Actions mints us an ID token for an audience we
+  # pick, ocifactory verifies it against the live GitHub JWKS, and
+  # the echo handler (no OCI backend, see pkg/handler/echo) returns
+  # the AuthContext so we can confirm the verified subject matched.
+  #
+  # This catches regressions the unit tests can't: discovery
+  # document layout drift at GitHub, JWKS fetch behaviour,
+  # signing-algorithm pinning, the entire serve.go wiring path.
+  oidc-e2e:
+    name: 'oidc-e2e'
+    runs-on: 'ubuntu-latest'
+    permissions:
+      id-token: 'write'
+      contents: 'read'
+    steps:
+      - uses: 'actions/checkout@v4' # ratchet:exclude
+
+      - uses: 'actions/setup-go@v5' # ratchet:exclude
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: 'Build ocifactory'
+        run: 'go build -o ./bin/ocifactory ./cmd/ocifactory'
+
+      - name: 'Write auth config'
+        run: |
+          mkdir -p ./run
+          cat > ./run/auth.yaml <<'EOF'
+          authenticators:
+            - kind: oidc
+              issuer: https://token.actions.githubusercontent.com
+              audience: ocifactory-ci
+          EOF
+
+      - name: 'Start ocifactory (echo handler)'
+        run: |
+          ./bin/ocifactory serve \
+            --repo-type=echo \
+            --auth-config=./run/auth.yaml \
+            --port=8080 \
+            > ./run/ocifactory.log 2>&1 &
+          echo $! > ./run/ocifactory.pid
+
+      - name: 'Wait for /healthz'
+        run: |
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:8080/healthz >/dev/null; then
+              echo "ocifactory is healthy"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "ocifactory did not become healthy in time"
+          cat ./run/ocifactory.log
+          exit 1
+
+      - name: 'Mint OIDC token (correct audience)'
+        id: 'mint_good'
+        run: |
+          TOKEN=$(curl -fsSL \
+            -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=ocifactory-ci" \
+            | jq -r .value)
+          if [ -z "${TOKEN}" ] || [ "${TOKEN}" = "null" ]; then
+            echo "failed to mint token"
+            exit 1
+          fi
+          echo "::add-mask::${TOKEN}"
+          echo "token=${TOKEN}" >> "${GITHUB_OUTPUT}"
+
+      - name: 'Mint OIDC token (wrong audience)'
+        id: 'mint_bad_aud'
+        run: |
+          TOKEN=$(curl -fsSL \
+            -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=not-ocifactory-ci" \
+            | jq -r .value)
+          if [ -z "${TOKEN}" ] || [ "${TOKEN}" = "null" ]; then
+            echo "failed to mint token"
+            exit 1
+          fi
+          echo "::add-mask::${TOKEN}"
+          echo "token=${TOKEN}" >> "${GITHUB_OUTPUT}"
+
+      - name: 'Assert: valid token → 200, body contains expected issuer/sub'
+        env:
+          TOKEN: '${{ steps.mint_good.outputs.token }}'
+        run: |
+          set -e
+          BODY=$(curl -fsS -H "Authorization: Bearer ${TOKEN}" \
+            http://127.0.0.1:8080/whoami)
+          echo "body: ${BODY}"
+          ISSUER=$(echo "${BODY}" | jq -r '.caller.issuer')
+          ID=$(echo "${BODY}" | jq -r '.caller.id')
+          if [ "${ISSUER}" != "https://token.actions.githubusercontent.com" ]; then
+            echo "wrong issuer in /whoami: got ${ISSUER}"
+            exit 1
+          fi
+          # ID for GHA tokens looks like: repo:owner/repo:ref:refs/heads/main
+          # We just assert the prefix to keep this robust to ref changes.
+          case "${ID}" in
+            repo:${GITHUB_REPOSITORY}:*) ;;
+            *) echo "wrong id in /whoami: got ${ID}, want prefix repo:${GITHUB_REPOSITORY}:"
+               exit 1 ;;
+          esac
+
+      - name: 'Assert: echo route returns the message'
+        env:
+          TOKEN: '${{ steps.mint_good.outputs.token }}'
+        run: |
+          set -e
+          BODY=$(curl -fsS -H "Authorization: Bearer ${TOKEN}" \
+            http://127.0.0.1:8080/echo/hello)
+          echo "body: ${BODY}"
+          MSG=$(echo "${BODY}" | jq -r '.message')
+          if [ "${MSG}" != "hello" ]; then
+            echo "wrong echo message: got ${MSG}"
+            exit 1
+          fi
+
+      - name: 'Assert: missing credential → 401'
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8080/whoami)
+          if [ "${STATUS}" != "401" ]; then
+            echo "expected 401, got ${STATUS}"
+            exit 1
+          fi
+
+      - name: 'Assert: garbage token → 401'
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer not-a-real-token" \
+            http://127.0.0.1:8080/whoami)
+          if [ "${STATUS}" != "401" ]; then
+            echo "expected 401, got ${STATUS}"
+            exit 1
+          fi
+
+      - name: 'Assert: wrong audience → 401'
+        env:
+          TOKEN: '${{ steps.mint_bad_aud.outputs.token }}'
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            http://127.0.0.1:8080/whoami)
+          if [ "${STATUS}" != "401" ]; then
+            echo "expected 401, got ${STATUS}"
+            exit 1
+          fi
+
+      - name: 'Stop ocifactory'
+        if: 'always()'
+        run: |
+          if [ -f ./run/ocifactory.pid ]; then
+            kill "$(cat ./run/ocifactory.pid)" || true
+          fi
+
+      - name: 'Dump server log'
+        if: 'always()'
+        run: |
+          if [ -f ./run/ocifactory.log ]; then
+            echo "=== ocifactory.log ==="
+            cat ./run/ocifactory.log
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,9 @@ Design pillars (in priority order):
 | `pkg/metrics` — pluggable Recorder (Prometheus default, no-op for tests) | Done |
 | `/healthz`, `/readyz`, `/metrics` endpoints (registered at server level) | Done |
 | `pkg/cred` — Backend OCI credential context | Carries Basic creds for backend HTTP client; populated by future backend cred provider |
-| `pkg/auth` — Pluggable frontend authentication (Authenticator, Subject, Chain, OIDC, kind registry) | Done, tested. OIDC-only — static passwords are out-of-tree by design. |
-| `cmd/ocifactory serve` | Works for `--repo-type=python|maven` |
+| `pkg/auth` — Pluggable frontend authentication (Authenticator, AuthContext, Chain, OIDC, kind registry) | Done, tested. OIDC-only — static passwords are out-of-tree by design. |
+| `pkg/handler/echo` — No-op auth target for the GitHub OIDC CI job | Done. Not a real artifact format; no OCI backend, no `handler.Registry`. Exists to give CI a concrete request to make against a real OIDC issuer. |
+| `cmd/ocifactory serve` | Works for `--repo-type=python|maven|echo` (echo runs without `--backend-registry`) |
 | Go module proxy support | Not started |
 | Debian/apt support | Not started |
 | Pull-through proxy / caching | Not started |
@@ -35,7 +36,7 @@ Design pillars (in priority order):
 | Authorization (per-repo, per-op policy) | Not started |
 | Backend credential provider (how ocifactory talks to GAR/ECR/zot) | Not started |
 | Dockerfile / deployment | Not started |
-| CI: lint, test, build, image publish | Only `go-test` from `abcxyz/pkg` |
+| CI: lint, test, build, image publish | `go-test` from `abcxyz/pkg`; `oidc-e2e` job mints a real GitHub OIDC token and exercises the auth chain against `--repo-type=echo`. |
 
 ## Architecture (read this before changing things)
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -223,6 +223,24 @@ audience the **caller** specified must match the audience
 (`https://ocifactory.your-domain`), put it in the auth config, and
 have callers use it when they request tokens.
 
+## CI: end-to-end OIDC test
+
+`.github/workflows/ci.yml` includes an `oidc-e2e` job that mints a
+real GitHub Actions OIDC token (audience `ocifactory-ci`), starts
+ocifactory with `--repo-type=echo` in front of an OIDC
+authenticator pointed at `https://token.actions.githubusercontent.com`,
+and asserts:
+
+| Case | Expected |
+|---|---|
+| Valid token, correct audience | 200; `/whoami` echoes the verified `iss` and `sub` |
+| Missing `Authorization` | 401 |
+| Garbage bearer token | 401 |
+| Valid token, wrong audience | 401 |
+
+The `echo` repo type is a no-op format that exists for this job — no
+OCI backend, no real artifacts. See `pkg/handler/echo`.
+
 ## Failure modes
 
 - **No credential** → `401 Unauthorized` with

--- a/pkg/commands/serve.go
+++ b/pkg/commands/serve.go
@@ -19,6 +19,7 @@ import (
 	// the registry lookup.
 	_ "github.com/yolocs/ocifactory/pkg/auth/oidc"
 	"github.com/yolocs/ocifactory/pkg/handler"
+	"github.com/yolocs/ocifactory/pkg/handler/echo"
 	"github.com/yolocs/ocifactory/pkg/handler/maven"
 	"github.com/yolocs/ocifactory/pkg/handler/python"
 	"github.com/yolocs/ocifactory/pkg/logging"
@@ -29,6 +30,16 @@ import (
 var supportedRepoTypes = []string{
 	maven.RepoType,
 	python.RepoType,
+	echo.RepoType,
+}
+
+// repoTypesNeedingBackend lists the repo types that talk to an OCI
+// backend. Anything not in this set runs without --backend-registry —
+// echo is the only such type today and exists purely as an auth
+// target for CI.
+var repoTypesNeedingBackend = map[string]bool{
+	maven.RepoType:  true,
+	python.RepoType: true,
 }
 
 type serveFlags struct {
@@ -63,8 +74,9 @@ func (f *serveFlags) Validate() error {
 	if !repoSupported {
 		merr = errors.Join(merr, fmt.Errorf("repo-type %q is not supported", f.repoType))
 	}
-	if f.registryURLStr == "" {
-		merr = errors.Join(merr, fmt.Errorf("backend-registry is required"))
+	needsBackend := repoTypesNeedingBackend[f.repoType]
+	if needsBackend && f.registryURLStr == "" {
+		merr = errors.Join(merr, fmt.Errorf("backend-registry is required for --repo-type=%s", f.repoType))
 		return merr
 	}
 	if f.authConfigPath != "" && f.authNone {
@@ -73,18 +85,20 @@ func (f *serveFlags) Validate() error {
 	if f.authConfigPath == "" && !f.authNone {
 		merr = errors.Join(merr, fmt.Errorf("either --auth-config or --disable-auth must be set"))
 	}
-	// Default to https when the user omits the scheme. Either way, parse
-	// unconditionally — the original code only assigned f.registryURL
-	// inside the prepend branch, leaving registryURL nil when the user
-	// passed an http:// or https:// URL directly.
-	if !strings.HasPrefix(f.registryURLStr, "http://") && !strings.HasPrefix(f.registryURLStr, "https://") {
-		f.registryURLStr = "https://" + f.registryURLStr
-	}
-	u, err := url.Parse(f.registryURLStr)
-	if err != nil {
-		merr = errors.Join(merr, fmt.Errorf("failed to parse backend-registry URL: %w", err))
-	} else {
-		f.registryURL = u
+	if f.registryURLStr != "" {
+		// Default to https when the user omits the scheme. Either way,
+		// parse unconditionally — the original code only assigned
+		// f.registryURL inside the prepend branch, leaving registryURL
+		// nil when the user passed an http:// or https:// URL directly.
+		if !strings.HasPrefix(f.registryURLStr, "http://") && !strings.HasPrefix(f.registryURLStr, "https://") {
+			f.registryURLStr = "https://" + f.registryURLStr
+		}
+		u, err := url.Parse(f.registryURLStr)
+		if err != nil {
+			merr = errors.Join(merr, fmt.Errorf("failed to parse backend-registry URL: %w", err))
+		} else {
+			f.registryURL = u
+		}
 	}
 	return merr
 }
@@ -199,6 +213,13 @@ func runServe(ctx context.Context, flags *serveFlags) error {
 			return fmt.Errorf("failed to create python handler: %w", err)
 		}
 		reg, format, h = r, python.RepoType, ph.Mux()
+	case echo.RepoType:
+		// echo is a no-op test format that does not talk to an OCI
+		// backend, so reg stays nil — ObservabilityHandler treats a
+		// nil pinger as "no backend configured" and /readyz collapses
+		// to liveness, which is what we want.
+		eh := echo.NewHandler(echo.WithAuthMiddleware(authMW))
+		format, h = echo.RepoType, eh.Mux()
 	default:
 		return fmt.Errorf("repo-type %q is not supported", flags.repoType)
 	}

--- a/pkg/commands/serve_test.go
+++ b/pkg/commands/serve_test.go
@@ -140,6 +140,34 @@ func TestServeFlagsValidate(t *testing.T) {
 				Host:   "example.com",
 			},
 		},
+		{
+			// echo is the no-op CI auth target — it never talks to
+			// an OCI backend, so --backend-registry is optional.
+			name: "echo without backend-registry is allowed",
+			flags: serveFlags{
+				port:     "8080",
+				repoType: "echo",
+				authNone: true,
+			},
+			wantErr: "",
+		},
+		{
+			// echo still accepts --backend-registry if the operator
+			// supplies one (it just won't be used). Make sure the URL
+			// parsing still happens so any malformed value is caught.
+			name: "echo with backend-registry parses URL",
+			flags: serveFlags{
+				port:           "8080",
+				repoType:       "echo",
+				registryURLStr: "https://example.com",
+				authNone:       true,
+			},
+			wantErr: "",
+			wantRegistryURL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/handler/echo/auth_test.go
+++ b/pkg/handler/echo/auth_test.go
@@ -1,0 +1,95 @@
+package echo
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/yolocs/ocifactory/pkg/auth"
+)
+
+// TestMux_AuthGating: a deny-all middleware reaches every route.
+// Mirrors pkg/handler/python/auth_test.go.
+func TestMux_AuthGating(t *testing.T) {
+	t.Parallel()
+
+	denyAll := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "denied", http.StatusUnauthorized)
+		})
+	}
+
+	h := NewHandler(WithAuthMiddleware(denyAll))
+	srv := h.Mux()
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{name: "echo", method: http.MethodGet, path: "/echo/hello"},
+		{name: "whoami", method: http.MethodGet, path: "/whoami"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := httptest.NewRequestWithContext(t.Context(), tc.method, tc.path, nil)
+			w := httptest.NewRecorder()
+			srv.ServeHTTP(w, r)
+			if got, want := w.Code, http.StatusUnauthorized; got != want {
+				t.Errorf("status = %d, want %d (auth middleware not chained?)", got, want)
+			}
+		})
+	}
+}
+
+// TestMux_NoAuthMiddleware: omitting WithAuthMiddleware leaves
+// routes ungated (this is what tests want; serve.go always passes
+// the option in production).
+func TestMux_NoAuthMiddleware(t *testing.T) {
+	t.Parallel()
+
+	h := NewHandler()
+	srv := h.Mux()
+
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/echo/hello", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+	if got := w.Code; got == http.StatusUnauthorized {
+		t.Errorf("status = 401 with no middleware configured; default should be ungated")
+	}
+}
+
+// TestMux_AuthChainsBeforeHandler proves the AuthContext put on the
+// request by the middleware is visible to the handler.
+func TestMux_AuthChainsBeforeHandler(t *testing.T) {
+	t.Parallel()
+
+	const wantIssuer = "test-issuer"
+	const wantID = "test-id"
+	installer := auth.Middleware(auth.AuthenticatorFunc(func(*http.Request) (*auth.AuthContext, error) {
+		return &auth.AuthContext{Issuer: wantIssuer, ID: wantID}, nil
+	}))
+
+	h := NewHandler(WithAuthMiddleware(installer))
+	srv := h.Mux()
+
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/whoami", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	if !contains(w.Body.String(), wantIssuer) || !contains(w.Body.String(), wantID) {
+		t.Errorf("body = %q; want issuer %q and id %q present", w.Body.String(), wantIssuer, wantID)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/handler/echo/handler.go
+++ b/pkg/handler/echo/handler.go
@@ -1,0 +1,122 @@
+// Package echo is a no-op artifact format that exists to give CI an
+// auth target. It does not store anything and does not depend on the
+// OCI backend; its routes return small JSON envelopes describing the
+// authenticated AuthContext on the request.
+//
+// The end-to-end CI job in .github/workflows/ci.yml mints a real
+// GitHub Actions OIDC token, starts ocifactory with --repo-type=echo
+// in front of an OIDC authenticator, and asserts the standard cases
+// (valid token → 200, missing/garbage/wrong-audience → 401). That
+// proves the wiring all the way from the binary through pkg/auth/oidc
+// against a real issuer's JWKS, which the unit tests can't.
+//
+// Echo is not a real artifact format and intentionally has no
+// ArtifactType — it never writes manifests.
+package echo
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/yolocs/ocifactory/pkg/auth"
+	"github.com/yolocs/ocifactory/pkg/handler"
+)
+
+// RepoType is the value passed to --repo-type to select this handler.
+const RepoType = "echo"
+
+// Handler serves the echo routes.
+type Handler struct {
+	authMW func(http.Handler) http.Handler
+}
+
+// Option configures optional Handler behaviour.
+type Option func(*handlerConfig)
+
+type handlerConfig struct {
+	authMW func(http.Handler) http.Handler
+}
+
+// WithAuthMiddleware installs an authentication middleware on every
+// echo route. Pass nil (or omit) to leave routes ungated; the serve
+// command always passes one.
+func WithAuthMiddleware(mw func(http.Handler) http.Handler) Option {
+	return func(c *handlerConfig) {
+		c.authMW = mw
+	}
+}
+
+// NewHandler creates a new echo Handler.
+func NewHandler(opts ...Option) *Handler {
+	var cfg handlerConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return &Handler{authMW: cfg.authMW}
+}
+
+// Mux returns the echo router. Both routes are auth-gated when
+// WithAuthMiddleware is set; the route names ("read" / "whoami")
+// flow into the metrics op label via RouteNameOpMiddleware.
+func (h *Handler) Mux() http.Handler {
+	router := mux.NewRouter()
+	router.Use(mux.MiddlewareFunc(handler.RouteNameOpMiddleware))
+	if h.authMW != nil {
+		router.Use(mux.MiddlewareFunc(h.authMW))
+	}
+
+	router.HandleFunc("/echo/{message}", h.handleEcho).Methods("GET").Name("read")
+	router.HandleFunc("/whoami", h.handleWhoami).Methods("GET").Name("whoami")
+
+	return router
+}
+
+// echoResponse is the body returned by GET /echo/{message}.
+type echoResponse struct {
+	Message string         `json:"message"`
+	Caller  *callerSummary `json:"caller,omitempty"`
+}
+
+// whoamiResponse is the body returned by GET /whoami.
+type whoamiResponse struct {
+	Caller *callerSummary `json:"caller,omitempty"`
+}
+
+// callerSummary is the JSON-safe projection of an *auth.AuthContext.
+// We don't echo the full Claims map by default — it's verified but
+// can be large and may contain claims the operator considers
+// sensitive (email, organization, repo). The CI test only needs
+// issuer + sub to prove the chain worked.
+type callerSummary struct {
+	Issuer string `json:"issuer"`
+	ID     string `json:"id"`
+}
+
+func (h *Handler) handleEcho(w http.ResponseWriter, r *http.Request) {
+	msg := mux.Vars(r)["message"]
+	writeJSON(w, http.StatusOK, echoResponse{
+		Message: msg,
+		Caller:  callerFromContext(r),
+	})
+}
+
+func (h *Handler) handleWhoami(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, whoamiResponse{
+		Caller: callerFromContext(r),
+	})
+}
+
+func callerFromContext(r *http.Request) *callerSummary {
+	ac, ok := auth.FromContext(r.Context())
+	if !ok || ac == nil {
+		return nil
+	}
+	return &callerSummary{Issuer: ac.Issuer, ID: ac.ID}
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/pkg/handler/echo/handler_test.go
+++ b/pkg/handler/echo/handler_test.go
@@ -1,0 +1,161 @@
+package echo
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/yolocs/ocifactory/pkg/auth"
+)
+
+// installContext is a test middleware that puts ac on the request
+// context, mimicking what auth.Middleware does after a successful
+// authentication.
+func installContext(ac *auth.AuthContext) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r = r.WithContext(auth.WithAuthContext(r.Context(), ac))
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func TestEcho(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		path       string
+		ac         *auth.AuthContext
+		wantMsg    string
+		wantCaller *callerSummary
+	}{
+		{
+			name:       "echo with caller",
+			path:       "/echo/hello",
+			ac:         &auth.AuthContext{Issuer: "https://example.test", ID: "user-1"},
+			wantMsg:    "hello",
+			wantCaller: &callerSummary{Issuer: "https://example.test", ID: "user-1"},
+		},
+		{
+			name:       "echo with anonymous",
+			path:       "/echo/world",
+			ac:         &auth.AuthContext{Issuer: "anonymous", ID: "anonymous"},
+			wantMsg:    "world",
+			wantCaller: &callerSummary{Issuer: "anonymous", ID: "anonymous"},
+		},
+		{
+			name:       "echo with no auth context",
+			path:       "/echo/silent",
+			ac:         nil,
+			wantMsg:    "silent",
+			wantCaller: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var opts []Option
+			if tc.ac != nil {
+				opts = append(opts, WithAuthMiddleware(installContext(tc.ac)))
+			}
+			h := NewHandler(opts...)
+
+			r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, tc.path, nil)
+			w := httptest.NewRecorder()
+			h.Mux().ServeHTTP(w, r)
+
+			if got, want := w.Code, http.StatusOK; got != want {
+				t.Fatalf("status = %d, want %d (body=%q)", got, want, w.Body.String())
+			}
+			var got echoResponse
+			if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+				t.Fatalf("decode body: %v (body=%q)", err, w.Body.String())
+			}
+			want := echoResponse{Message: tc.wantMsg, Caller: tc.wantCaller}
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("response mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestWhoami(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ac   *auth.AuthContext
+		want whoamiResponse
+	}{
+		{
+			name: "with caller",
+			ac:   &auth.AuthContext{Issuer: "https://token.actions.githubusercontent.com", ID: "repo:foo/bar:ref:refs/heads/main"},
+			want: whoamiResponse{Caller: &callerSummary{
+				Issuer: "https://token.actions.githubusercontent.com",
+				ID:     "repo:foo/bar:ref:refs/heads/main",
+			}},
+		},
+		{
+			name: "no auth context",
+			ac:   nil,
+			want: whoamiResponse{Caller: nil},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var opts []Option
+			if tc.ac != nil {
+				opts = append(opts, WithAuthMiddleware(installContext(tc.ac)))
+			}
+			h := NewHandler(opts...)
+
+			r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/whoami", nil)
+			w := httptest.NewRecorder()
+			h.Mux().ServeHTTP(w, r)
+
+			if got, want := w.Code, http.StatusOK; got != want {
+				t.Fatalf("status = %d, want %d", got, want)
+			}
+			var got whoamiResponse
+			if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("response mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestMethodNotAllowed(t *testing.T) {
+	t.Parallel()
+
+	h := NewHandler()
+	tests := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, "/echo/x"},
+		{http.MethodPut, "/echo/x"},
+		{http.MethodDelete, "/whoami"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.method+"_"+tc.path, func(t *testing.T) {
+			t.Parallel()
+			r := httptest.NewRequestWithContext(t.Context(), tc.method, tc.path, nil)
+			w := httptest.NewRecorder()
+			h.Mux().ServeHTTP(w, r)
+			if w.Code == http.StatusOK {
+				t.Errorf("status = 200 for %s %s; want non-200", tc.method, tc.path)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `pkg/handler/echo`, a no-op artifact format that exists purely as an auth target. No `handler.Registry`, no `ArtifactType`. Two routes (`GET /echo/{message}`, `GET /whoami`) return small JSON envelopes describing the verified `AuthContext`. Same `WithAuthMiddleware` option pattern as python and maven.
- Wires echo into `pkg/commands/serve.go`. `--backend-registry` is now optional when `--repo-type=echo`. `ObservabilityHandler` already collapses `/readyz` to liveness when the pinger is nil, so no further plumbing was needed.
- Adds an `oidc-e2e` job to `.github/workflows/ci.yml`. With `id-token: write`, the job mints a real GitHub Actions OIDC token for audience `ocifactory-ci`, starts ocifactory with `--repo-type=echo` in front of an OIDC authenticator pointed at `https://token.actions.githubusercontent.com`, and asserts the four cases below.
- Updates `AGENTS.md` status table and `docs/auth.md` to describe the new format and CI job.

## Why

The unit tests for `pkg/auth/oidc` cover the verifier against a fake issuer with synthetic JWKS. They cannot exercise the wiring against a real OIDC issuer's discovery document and JWKS endpoint, the real ocifactory binary serving the request, or signing-algorithm pinning at the edge. This job catches regressions those tests can't — it's the first end-to-end test of `pkg/auth/oidc` against a live IdP.

## CI assertions

| Case | Expected |
|---|---|
| Valid token, correct audience | 200; `/whoami` echoes the verified `iss` (`https://token.actions.githubusercontent.com`) and `sub` prefix `repo:${GITHUB_REPOSITORY}:` |
| Valid token, correct audience, `/echo/hello` | 200; body `.message == "hello"` |
| Missing `Authorization` | 401 |
| Garbage bearer token | 401 |
| Valid token, wrong audience | 401 |

## Test plan

- [x] `go test -race -short ./...` passes locally
- [x] `gofmt -s` and `go vet` clean
- [x] Local smoke test: `ocifactory serve --repo-type=echo --disable-auth --port=18083` then `curl /whoami` returns `{"caller":{"issuer":"anonymous","id":"anonymous"}}`
- [x] `oidc-e2e` job passes on this PR (this is what we're proving)

Closes #51

---
_Generated by [Claude Code](https://claude.ai/code/session_01SaZzaeFiF5tvjvfZeeQ6LV)_