### PR TITLE
Redirect blob downloads to OCI backend presigned URLs

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -62,6 +62,20 @@ control on `/metrics`, front it with your reverse proxy.
   `already_exists` buckets are normal-flow control labels — don't page
   on them.
 
+### Blob redirect
+
+| Metric | Type | Labels |
+|---|---|---|
+| `ocifactory_blob_redirect_total` | counter | `outcome` |
+
+- `outcome` ∈ `redirected` (the backend returned a presigned URL the
+  handler 307'd the client to), `inline` (the backend serves blobs
+  itself; handler fell back to streaming), `error` (the redirect probe
+  failed; handler also fell back to streaming).
+- A high `redirected:inline` ratio against a hosted backend (GAR, ECR,
+  ACR, GHCR, Docker Hub) confirms the egress short-circuit is doing its
+  job. The metric is not emitted when `--disable-blob-redirect` is set.
+
 ### Standard collectors
 
 The Prometheus recorder also registers `prometheus.NewGoCollector()`

--- a/pkg/commands/serve.go
+++ b/pkg/commands/serve.go
@@ -64,6 +64,7 @@ const (
 	flagRepoType                        = "repo-type"
 	flagBackendRegistry                 = "backend-registry"
 	flagDisableStreamingPush            = "disable-streaming-push"
+	flagDisableBlobRedirect             = "disable-blob-redirect"
 	flagSimpleIndexCacheTTL             = "simple-index-cache-ttl"
 	flagPythonMaxUploadBytes            = "python-max-upload-bytes"
 	flagEnableMetrics                   = "enable-metrics"
@@ -89,6 +90,7 @@ type serveConfig struct {
 	RepoType             string        `mapstructure:"repo-type"`
 	BackendRegistry      string        `mapstructure:"backend-registry"`
 	DisableStreamingPush bool          `mapstructure:"disable-streaming-push"`
+	DisableBlobRedirect  bool          `mapstructure:"disable-blob-redirect"`
 	SimpleIndexCacheTTL  time.Duration `mapstructure:"simple-index-cache-ttl"`
 	PythonMaxUploadBytes int64         `mapstructure:"python-max-upload-bytes"`
 	EnableMetrics        bool          `mapstructure:"enable-metrics"`
@@ -231,6 +233,15 @@ func registerServeFlags(flags *pflag.FlagSet) {
 			"Bodies above the in-memory threshold will spill to a temp file "+
 			"instead of streaming via chunked PATCH. Set this only for "+
 			"backend registries with broken or missing chunked-PATCH support.")
+	flags.Bool(flagDisableBlobRedirect, false,
+		"Disable redirecting blob downloads to backend-issued presigned "+
+			"URLs. By default, hosted backends (GAR, ECR, ACR, GHCR, Docker "+
+			"Hub) get a 307 to their CDN/object-store URL on blob GET, "+
+			"saving ocifactory egress on read-heavy workloads. Set this in "+
+			"environments where exposing backend URLs to clients is "+
+			"unacceptable (egress restrictions, DLP, audit requirements). "+
+			"Self-hosted inline-serving backends (zot, Harbor, distribution) "+
+			"are unaffected — they fall back to streaming automatically.")
 	flags.Duration(flagSimpleIndexCacheTTL, python.DefaultSimpleIndexCacheTTL,
 		"TTL for the per-replica per-package PyPI simple-index cache. "+
 			"Within the TTL, repeated GET /simple/<pkg>/ requests skip the "+
@@ -310,6 +321,7 @@ func runServe(ctx context.Context, cfg *serveConfig) error {
 	)
 	registryOpts := []oci.RegistryOption{
 		oci.WithStreamingPushDisabled(cfg.DisableStreamingPush),
+		oci.WithBlobRedirectDisabled(cfg.DisableBlobRedirect),
 		oci.WithMetrics(rec),
 		oci.WithBackendAuth(bp),
 	}

--- a/pkg/handler/common.go
+++ b/pkg/handler/common.go
@@ -16,6 +16,13 @@ type Registry interface {
 	ReadFile(ctx context.Context, f *oci.RepoFile) (*oci.FileDescriptor, io.ReadCloser, error)
 	ListTags(ctx context.Context, repo string) ([]string, error)
 	ListFiles(ctx context.Context, repo string) ([]*oci.RepoFile, error)
+
+	// BlobRedirectURL returns a presigned URL the client can follow to
+	// download the file's blob directly from the backend's CDN/object
+	// store, or ("", nil) when the backend serves blobs inline (or
+	// redirects are disabled). Hard failures return ("", err); callers
+	// should fall back to ReadFile in that case.
+	BlobRedirectURL(ctx context.Context, f *oci.RepoFile) (string, error)
 }
 
 type Middleware func(next http.Handler) http.Handler

--- a/pkg/handler/maven/hander.go
+++ b/pkg/handler/maven/hander.go
@@ -207,6 +207,20 @@ func (h *Handler) handlePut(w http.ResponseWriter, req *http.Request, f *oci.Rep
 func (h *Handler) handleGet(w http.ResponseWriter, req *http.Request, f *oci.RepoFile) {
 	logger := logging.FromContext(req.Context())
 
+	// HEAD wants headers only — never redirect. The redirect path is
+	// only worth taking when the response would otherwise transfer
+	// bytes; HEAD has no egress to save.
+	if req.Method != http.MethodHead {
+		if redirectURL, err := h.registry.BlobRedirectURL(req.Context(), f); err == nil && redirectURL != "" {
+			logger.DebugContext(req.Context(), "redirecting blob fetch to backend", "url", redirectURL)
+			http.Redirect(w, req, redirectURL, http.StatusTemporaryRedirect)
+			return
+		} else if err != nil {
+			// Best-effort — fall through to the streaming path.
+			logger.DebugContext(req.Context(), "blob redirect probe failed; falling back to streaming", "error", err)
+		}
+	}
+
 	desc, r, err := h.registry.ReadFile(req.Context(), f)
 	if err != nil {
 		logger.DebugContext(req.Context(), "failed to read file", "error", err)

--- a/pkg/handler/maven/handler_test.go
+++ b/pkg/handler/maven/handler_test.go
@@ -1,9 +1,12 @@
 package maven
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/yolocs/ocifactory/pkg/oci"
@@ -269,6 +272,118 @@ func TestHandleGet(t *testing.T) {
 				if got, want := w.Header().Get("Content-Type"), mediaType; got != want {
 					t.Errorf("Content-Type = %q, want %q", got, want)
 				}
+			}
+		})
+	}
+}
+
+// redirectingRegistry wraps an *oci.FakeRegistry and lets a test
+// program BlobRedirectURL's return values, exercising the handler's
+// redirect-vs-stream branching.
+type redirectingRegistry struct {
+	*oci.FakeRegistry
+	redirectURL string
+	redirectErr error
+	calls       atomic.Int64
+}
+
+func (r *redirectingRegistry) BlobRedirectURL(_ context.Context, _ *oci.RepoFile) (string, error) {
+	r.calls.Add(1)
+	return r.redirectURL, r.redirectErr
+}
+
+func TestHandleGet_BlobRedirect(t *testing.T) {
+	t.Parallel()
+
+	setupFile := &oci.RepoFile{
+		OwningRepo: "com/example/project",
+		OwningTag:  "1.0.0",
+		Name:       "project-1.0.0.jar",
+		MediaType:  "application/java-archive",
+	}
+	const setupData = "jar content"
+	const reqPath = "/com/example/project/1.0.0/project-1.0.0.jar"
+	const presigned = "https://cdn.example.com/blob?signature=xyz"
+
+	cases := []struct {
+		name           string
+		method         string
+		redirectURL    string
+		redirectErr    error
+		wantStatus     int
+		wantLocation   string
+		wantBody       string
+		wantProbeCalls int64
+	}{
+		{
+			name:           "GET redirects when backend returns presigned URL",
+			method:         http.MethodGet,
+			redirectURL:    presigned,
+			wantStatus:     http.StatusTemporaryRedirect,
+			wantLocation:   presigned,
+			wantProbeCalls: 1,
+		},
+		{
+			name:           "GET falls through to streaming when redirect URL is empty",
+			method:         http.MethodGet,
+			redirectURL:    "",
+			wantStatus:     http.StatusOK,
+			wantBody:       setupData,
+			wantProbeCalls: 1,
+		},
+		{
+			name:           "GET falls through to streaming on probe error",
+			method:         http.MethodGet,
+			redirectErr:    errors.New("transient backend failure"),
+			wantStatus:     http.StatusOK,
+			wantBody:       setupData,
+			wantProbeCalls: 1,
+		},
+		{
+			name:           "HEAD never probes for redirect",
+			method:         http.MethodHead,
+			redirectURL:    presigned,
+			wantStatus:     http.StatusOK,
+			wantProbeCalls: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fake := oci.NewFakeRegistry()
+			if _, err := fake.AddFile(t.Context(), setupFile, strings.NewReader(setupData)); err != nil {
+				t.Fatalf("setup AddFile: %v", err)
+			}
+			reg := &redirectingRegistry{
+				FakeRegistry: fake,
+				redirectURL:  tc.redirectURL,
+				redirectErr:  tc.redirectErr,
+			}
+
+			h, err := NewHandler(reg)
+			if err != nil {
+				t.Fatalf("NewHandler: %v", err)
+			}
+
+			req := httptest.NewRequest(tc.method, reqPath, nil)
+			w := httptest.NewRecorder()
+			h.Mux().ServeHTTP(w, req)
+
+			if got, want := w.Code, tc.wantStatus; got != want {
+				t.Errorf("status = %d, want %d", got, want)
+			}
+			if got, want := w.Header().Get("Location"), tc.wantLocation; got != want {
+				t.Errorf("Location = %q, want %q", got, want)
+			}
+			if tc.method == http.MethodGet && tc.wantBody != "" {
+				if got := w.Body.String(); got != tc.wantBody {
+					t.Errorf("body = %q, want %q", got, tc.wantBody)
+				}
+			}
+			if got, want := reg.calls.Load(), tc.wantProbeCalls; got != want {
+				t.Errorf("BlobRedirectURL calls = %d, want %d", got, want)
 			}
 		})
 	}

--- a/pkg/handler/observability_test.go
+++ b/pkg/handler/observability_test.go
@@ -41,6 +41,8 @@ func (r *recordingRecorder) HTTPRequest(format, op, status string, duration time
 }
 func (r *recordingRecorder) OCIBackendCall(string, string, time.Duration) {}
 
+func (r *recordingRecorder) BlobRedirect(string) {}
+
 func (r *recordingRecorder) snapshot() []httpCall {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/pkg/handler/python/handler.go
+++ b/pkg/handler/python/handler.go
@@ -558,6 +558,20 @@ func renderedFileURL(req *http.Request, pkg string, f cachedFile) string {
 func (h *Handler) handleGet(w http.ResponseWriter, req *http.Request, f *oci.RepoFile) {
 	logger := logging.FromContext(req.Context())
 
+	// HEAD wants headers only — never redirect. The redirect path is
+	// only worth taking when the response would otherwise transfer
+	// bytes; HEAD has no egress to save.
+	if req.Method != http.MethodHead {
+		if redirectURL, err := h.registry.BlobRedirectURL(req.Context(), f); err == nil && redirectURL != "" {
+			logger.DebugContext(req.Context(), "redirecting blob fetch to backend", "url", redirectURL)
+			http.Redirect(w, req, redirectURL, http.StatusTemporaryRedirect)
+			return
+		} else if err != nil {
+			// Best-effort — fall through to the streaming path.
+			logger.DebugContext(req.Context(), "blob redirect probe failed; falling back to streaming", "error", err)
+		}
+	}
+
 	desc, r, err := h.registry.ReadFile(req.Context(), f)
 	if err != nil {
 		logger.DebugContext(req.Context(), "failed to read file", "error", err)

--- a/pkg/handler/python/handler_test.go
+++ b/pkg/handler/python/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -356,6 +357,119 @@ func TestHandleGet(t *testing.T) {
 						t.Errorf("Content-Type = %q, want %q", got, want)
 					}
 				}
+			}
+		})
+	}
+}
+
+// redirectingRegistry wraps an *oci.FakeRegistry and lets a test
+// program BlobRedirectURL's return values, exercising the handler's
+// redirect-vs-stream branching without needing an HTTP-level fake of
+// the OCI backend.
+type redirectingRegistry struct {
+	*oci.FakeRegistry
+	redirectURL string
+	redirectErr error
+	calls       atomic.Int64
+}
+
+func (r *redirectingRegistry) BlobRedirectURL(_ context.Context, _ *oci.RepoFile) (string, error) {
+	r.calls.Add(1)
+	return r.redirectURL, r.redirectErr
+}
+
+func TestHandleGet_BlobRedirect(t *testing.T) {
+	t.Parallel()
+
+	setupFile := &oci.RepoFile{
+		OwningRepo: "packages/example-pkg",
+		OwningTag:  "1.0.0",
+		Name:       "example-pkg-1.0.0.whl",
+		MediaType:  "application/x-wheel+zip",
+	}
+	const setupData = "wheel content"
+	const reqPath = "/packages/example-pkg/1.0.0/example-pkg-1.0.0.whl"
+	const presigned = "https://cdn.example.com/blob?signature=xyz"
+
+	cases := []struct {
+		name           string
+		method         string
+		redirectURL    string
+		redirectErr    error
+		wantStatus     int
+		wantLocation   string
+		wantBody       string
+		wantProbeCalls int64
+	}{
+		{
+			name:           "GET redirects when backend returns presigned URL",
+			method:         http.MethodGet,
+			redirectURL:    presigned,
+			wantStatus:     http.StatusTemporaryRedirect,
+			wantLocation:   presigned,
+			wantProbeCalls: 1,
+		},
+		{
+			name:           "GET falls through to streaming when redirect URL is empty",
+			method:         http.MethodGet,
+			redirectURL:    "",
+			wantStatus:     http.StatusOK,
+			wantBody:       setupData,
+			wantProbeCalls: 1,
+		},
+		{
+			name:           "GET falls through to streaming on probe error",
+			method:         http.MethodGet,
+			redirectErr:    errors.New("transient backend failure"),
+			wantStatus:     http.StatusOK,
+			wantBody:       setupData,
+			wantProbeCalls: 1,
+		},
+		{
+			name:           "HEAD never probes for redirect",
+			method:         http.MethodHead,
+			redirectURL:    presigned,
+			wantStatus:     http.StatusOK,
+			wantProbeCalls: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fake := oci.NewFakeRegistry()
+			if _, err := fake.AddFile(t.Context(), setupFile, strings.NewReader(setupData)); err != nil {
+				t.Fatalf("setup AddFile: %v", err)
+			}
+			reg := &redirectingRegistry{
+				FakeRegistry: fake,
+				redirectURL:  tc.redirectURL,
+				redirectErr:  tc.redirectErr,
+			}
+
+			h, err := NewHandler(reg)
+			if err != nil {
+				t.Fatalf("NewHandler: %v", err)
+			}
+
+			req := httptest.NewRequest(tc.method, reqPath, nil)
+			w := httptest.NewRecorder()
+			h.Mux().ServeHTTP(w, req)
+
+			if got, want := w.Code, tc.wantStatus; got != want {
+				t.Errorf("status = %d, want %d", got, want)
+			}
+			if got, want := w.Header().Get("Location"), tc.wantLocation; got != want {
+				t.Errorf("Location = %q, want %q", got, want)
+			}
+			if tc.method == http.MethodGet && tc.wantBody != "" {
+				if got := w.Body.String(); got != tc.wantBody {
+					t.Errorf("body = %q, want %q", got, tc.wantBody)
+				}
+			}
+			if got, want := reg.calls.Load(), tc.wantProbeCalls; got != want {
+				t.Errorf("BlobRedirectURL calls = %d, want %d", got, want)
 			}
 		})
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -34,6 +34,13 @@ type Recorder interface {
 	// either "ok" or the HTTP status code returned by the backend, or
 	// "error" for non-HTTP failures.
 	OCIBackendCall(op, status string, duration time.Duration)
+
+	// BlobRedirect records the outcome of one BlobRedirectURL probe.
+	// outcome is "redirected" (caller will 307 to the backend's
+	// presigned URL), "inline" (backend serves bytes itself; caller
+	// falls back to ReadFile), or "error" (probe failed; caller
+	// also falls back to ReadFile).
+	BlobRedirect(outcome string)
 }
 
 // StatusOK is the conventional success label for OCIBackendCall.
@@ -58,6 +65,7 @@ type noopRecorder struct{}
 
 func (noopRecorder) HTTPRequest(string, string, string, time.Duration, int64, int64) {}
 func (noopRecorder) OCIBackendCall(string, string, time.Duration)                    {}
+func (noopRecorder) BlobRedirect(string)                                             {}
 
 // NoOp returns a Recorder that discards every observation. Used by tests
 // and by serve when --enable-metrics=false.
@@ -86,6 +94,8 @@ type Prometheus struct {
 
 	backendRequestsTotal   *prometheus.CounterVec
 	backendRequestDuration *prometheus.HistogramVec
+
+	blobRedirectTotal *prometheus.CounterVec
 }
 
 // NewPrometheus constructs a Prometheus-backed Recorder. Pass nil for reg
@@ -125,6 +135,10 @@ func NewPrometheus(reg *prometheus.Registry) *Prometheus {
 			Help:    "OCI backend call latency, labelled by operation.",
 			Buckets: prometheus.DefBuckets,
 		}, []string{"op"}),
+		blobRedirectTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "ocifactory_blob_redirect_total",
+			Help: "Total BlobRedirectURL probe outcomes, labelled by outcome (redirected, inline, error).",
+		}, []string{"outcome"}),
 	}
 	reg.MustRegister(
 		p.httpRequestsTotal,
@@ -133,6 +147,7 @@ func NewPrometheus(reg *prometheus.Registry) *Prometheus {
 		p.httpBytesOut,
 		p.backendRequestsTotal,
 		p.backendRequestDuration,
+		p.blobRedirectTotal,
 		collectors.NewGoCollector(),
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 	)
@@ -155,6 +170,11 @@ func (p *Prometheus) HTTPRequest(format, op, status string, duration time.Durati
 func (p *Prometheus) OCIBackendCall(op, status string, duration time.Duration) {
 	p.backendRequestsTotal.WithLabelValues(op, status).Inc()
 	p.backendRequestDuration.WithLabelValues(op).Observe(duration.Seconds())
+}
+
+// BlobRedirect implements Recorder.
+func (p *Prometheus) BlobRedirect(outcome string) {
+	p.blobRedirectTotal.WithLabelValues(outcome).Inc()
 }
 
 // Handler returns an http.Handler that serves the Prometheus exposition

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -18,6 +18,7 @@ func TestNoOp_DoesNothing(t *testing.T) {
 	r := NoOp()
 	r.HTTPRequest("python", "read", "200", time.Millisecond, 10, 20)
 	r.OCIBackendCall("push_blob", StatusOK, time.Millisecond)
+	r.BlobRedirect("redirected")
 	// The point of NoOp is that it has no observable side effects; if
 	// we reached this line without panicking the contract is met.
 }
@@ -88,12 +89,34 @@ func TestPrometheus_OCIBackendCall_RecordsCounters(t *testing.T) {
 	}
 }
 
+func TestPrometheus_BlobRedirect_RecordsCounters(t *testing.T) {
+	t.Parallel()
+
+	p := NewPrometheus(prometheus.NewRegistry())
+
+	p.BlobRedirect("redirected")
+	p.BlobRedirect("redirected")
+	p.BlobRedirect("inline")
+	p.BlobRedirect("error")
+
+	if got, want := testutil.ToFloat64(p.blobRedirectTotal.WithLabelValues("redirected")), 2.0; got != want {
+		t.Errorf("blob_redirect_total{redirected} = %v, want %v", got, want)
+	}
+	if got, want := testutil.ToFloat64(p.blobRedirectTotal.WithLabelValues("inline")), 1.0; got != want {
+		t.Errorf("blob_redirect_total{inline} = %v, want %v", got, want)
+	}
+	if got, want := testutil.ToFloat64(p.blobRedirectTotal.WithLabelValues("error")), 1.0; got != want {
+		t.Errorf("blob_redirect_total{error} = %v, want %v", got, want)
+	}
+}
+
 func TestPrometheus_Handler_ExposesRegisteredMetrics(t *testing.T) {
 	t.Parallel()
 
 	p := NewPrometheus(prometheus.NewRegistry())
 	p.HTTPRequest("maven", "write", "201", time.Millisecond, 1, 2)
 	p.OCIBackendCall("push_blob", StatusOK, time.Millisecond)
+	p.BlobRedirect("redirected")
 
 	rec := httptest.NewRecorder()
 	p.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
@@ -106,6 +129,7 @@ func TestPrometheus_Handler_ExposesRegisteredMetrics(t *testing.T) {
 		"ocifactory_http_response_bytes_out_total",
 		"ocifactory_oci_backend_requests_total",
 		"ocifactory_oci_backend_request_duration_seconds",
+		"ocifactory_blob_redirect_total",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("/metrics body missing %q\n%s", want, body)

--- a/pkg/oci/fake.go
+++ b/pkg/oci/fake.go
@@ -174,6 +174,15 @@ func (r *FakeRegistry) ListFiles(ctx context.Context, repo string) ([]*RepoFile,
 	return filesList, nil
 }
 
+// BlobRedirectURL always returns ("", nil), matching the inline-serving
+// branch of the real Registry's behaviour. Handlers that try the
+// redirect path against the fake fall through to ReadFile, which is
+// exactly what their tests want — blob streaming is exercised either
+// way.
+func (r *FakeRegistry) BlobRedirectURL(ctx context.Context, f *RepoFile) (string, error) {
+	return "", nil
+}
+
 func aliasKey(repo, alias string) string {
 	return repo + "/" + alias
 }

--- a/pkg/oci/instrumented_test.go
+++ b/pkg/oci/instrumented_test.go
@@ -18,9 +18,10 @@ import (
 // fakeRecorder captures every Recorder call so tests can assert on the
 // observed labels without standing up Prometheus.
 type fakeRecorder struct {
-	mu      sync.Mutex
-	backend []backendObs
-	http    []httpObs
+	mu       sync.Mutex
+	backend  []backendObs
+	http     []httpObs
+	redirect []string
 }
 
 type backendObs struct {
@@ -47,6 +48,18 @@ func (f *fakeRecorder) OCIBackendCall(op, status string, duration time.Duration)
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.backend = append(f.backend, backendObs{op, status, duration})
+}
+
+func (f *fakeRecorder) BlobRedirect(outcome string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.redirect = append(f.redirect, outcome)
+}
+
+func (f *fakeRecorder) redirectOutcomes() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.redirect...)
 }
 
 func (f *fakeRecorder) backendOpStatuses() []string {

--- a/pkg/oci/redirect.go
+++ b/pkg/oci/redirect.go
@@ -1,0 +1,143 @@
+package oci
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/errdef"
+	"oras.land/oras-go/v2/registry"
+	"oras.land/oras-go/v2/registry/remote/auth"
+)
+
+// Blob-redirect outcome labels recorded via metrics.Recorder.BlobRedirect.
+// "redirected" — the backend returned a presigned URL the caller can 307 to.
+// "inline"     — the backend serves the blob inline; caller falls back to ReadFile.
+// "error"      — the probe failed and the caller should fall back to ReadFile.
+const (
+	BlobRedirectOutcomeRedirected = "redirected"
+	BlobRedirectOutcomeInline     = "inline"
+	BlobRedirectOutcomeError      = "error"
+)
+
+// BlobRedirectURL returns a URL the client can follow to download the
+// blob directly from the backend's CDN/object store, bypassing
+// ocifactory's data path.
+//
+// Returns ("", nil) when the backend serves blobs inline (no redirect
+// available) or when --disable-blob-redirect is set; the caller should
+// fall back to ReadFile in that case. Returns ("", err) on hard
+// failures — the caller should also fall back to ReadFile, treating
+// the redirect probe as best-effort.
+//
+// Implementation: resolve the file blob descriptor the same way
+// ReadFile does, then issue a HEAD against the backend's
+// /v2/<repo>/blobs/<digest> using a non-redirect-following auth.Client.
+// A 3xx response surfaces the Location header; a 200 means the backend
+// is willing to serve the bytes itself.
+func (r *Registry) BlobRedirectURL(ctx context.Context, f *RepoFile) (string, error) {
+	if r.disableBlobRedirect {
+		return "", nil
+	}
+	url, err := r.blobRedirectURL(ctx, f)
+	r.rec.BlobRedirect(blobRedirectOutcome(url, err))
+	return url, err
+}
+
+func (r *Registry) blobRedirectURL(ctx context.Context, f *RepoFile) (string, error) {
+	if f.OwningTag == "" && f.RefTag == "" {
+		return "", fmt.Errorf("either OwningTag or RefTag must be set")
+	}
+
+	backend, err := r.newBackendFunc(ctx, f)
+	if err != nil {
+		return "", err
+	}
+
+	versionDesc, err := r.resolveVersionDescriptor(ctx, backend, f)
+	if err != nil {
+		return "", err
+	}
+
+	refs, err := registry.Referrers(ctx, backend, versionDesc, r.fileArtifactType)
+	if err != nil {
+		return "", fmt.Errorf("failed to list file referrers: %w", err)
+	}
+
+	for i := range refs {
+		if refs[i].Annotations[FileNameAnnotation] != f.Name {
+			continue
+		}
+		blobDesc, err := fetchBlobDescriptor(ctx, backend, refs[i])
+		if err != nil {
+			return "", err
+		}
+		return r.probeBlobRedirect(ctx, f, blobDesc)
+	}
+
+	return "", fmt.Errorf("file %q not found in version: %w", f.Name, errdef.ErrNotFound)
+}
+
+// probeBlobRedirect issues a HEAD against the backend's
+// /v2/<repo>/blobs/<digest> endpoint without following redirects, so a
+// 3xx Location is surfaced directly. Backends that serve blobs inline
+// answer 200 and we return ("", nil) so the caller falls through to
+// streaming via ReadFile.
+func (r *Registry) probeBlobRedirect(ctx context.Context, f *RepoFile, blobDesc ocispec.Descriptor) (string, error) {
+	repoRef := r.baseURL.Host + r.baseURL.Path + "/" + f.OwningRepo
+	ref, err := registry.ParseReference(repoRef)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse repository reference %q: %w", repoRef, err)
+	}
+
+	scheme := "https"
+	if r.baseURL.Scheme == "http" {
+		scheme = "http"
+	}
+	blobURL := fmt.Sprintf("%s://%s/v2/%s/blobs/%s", scheme, ref.Host(), ref.Repository, blobDesc.Digest)
+
+	// AppendRepositoryScope mirrors what oras-go sets on the context
+	// for any blob fetch — without it, the auth.Client would only
+	// learn it needs a pull token after the first 401 retry.
+	probeCtx := auth.AppendRepositoryScope(ctx, ref, auth.ActionPull)
+
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodHead, blobURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("build redirect probe request: %w", err)
+	}
+
+	resp, err := r.probeClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("blob redirect probe transport error: %w", err)
+	}
+	defer resp.Body.Close()
+	// HEAD has no body in practice, but drain anyway so the connection
+	// stays in net/http's keep-alive pool.
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	switch {
+	case resp.StatusCode >= 300 && resp.StatusCode < 400:
+		loc, err := resp.Location()
+		if err != nil {
+			return "", fmt.Errorf("backend returned %d but Location header was missing or invalid: %w", resp.StatusCode, err)
+		}
+		return loc.String(), nil
+	case resp.StatusCode == http.StatusOK:
+		return "", nil
+	default:
+		return "", fmt.Errorf("blob redirect probe returned %s", resp.Status)
+	}
+}
+
+func blobRedirectOutcome(url string, err error) string {
+	switch {
+	case err != nil:
+		return BlobRedirectOutcomeError
+	case url == "":
+		return BlobRedirectOutcomeInline
+	default:
+		return BlobRedirectOutcomeRedirected
+	}
+}

--- a/pkg/oci/redirect_test.go
+++ b/pkg/oci/redirect_test.go
@@ -1,0 +1,264 @@
+package oci
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"oras.land/oras-go/v2/content/memory"
+	"oras.land/oras-go/v2/errdef"
+)
+
+// fakeBackend is a minimal HTTP server that answers HEAD against
+// /v2/<repo>/blobs/<digest> with whatever the test configured. Returned
+// from newFakeBackend so tests can mutate behaviour mid-flight.
+type fakeBackend struct {
+	server *httptest.Server
+
+	// status is the status code the next HEAD request will get.
+	status int
+	// location is the Location header set on 3xx responses.
+	location string
+	// hits records HEAD-on-blob requests so tests can assert HEAD vs. GET.
+	hits int
+}
+
+func newFakeBackend(t *testing.T) *fakeBackend {
+	t.Helper()
+	fb := &fakeBackend{status: http.StatusOK}
+	fb.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// /v2/ probe — accept anything (oras-go pings this on auth setup).
+		if r.URL.Path == "/v2/" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		// Only HEAD on /v2/.../blobs/<digest> matters for the redirect probe.
+		if r.Method == http.MethodHead && strings.Contains(r.URL.Path, "/blobs/") {
+			fb.hits++
+			if fb.location != "" {
+				w.Header().Set("Location", fb.location)
+			}
+			w.WriteHeader(fb.status)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(fb.server.Close)
+	return fb
+}
+
+func (b *fakeBackend) baseURL(t *testing.T) *url.URL {
+	t.Helper()
+	u, err := url.Parse(b.server.URL)
+	if err != nil {
+		t.Fatalf("parse fake backend URL: %v", err)
+	}
+	return u
+}
+
+// newRedirectTestRegistry seeds a Registry whose newBackendFunc returns
+// a shared in-memory store (so AddFile / referrers resolution works
+// without touching the network) but whose baseURL points at fb so the
+// HTTP redirect probe lands on the fake backend.
+func newRedirectTestRegistry(t *testing.T, fb *fakeBackend, opts ...RegistryOption) (*Registry, *inMemoryRepo) {
+	t.Helper()
+	r, err := NewRegistry(fb.baseURL(t), opts...)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	memRepo := &inMemoryRepo{Store: memory.New(), allTags: map[string]string{}}
+	r.newBackendFunc = func(_ context.Context, _ *RepoFile) (destRepo, error) {
+		return memRepo, nil
+	}
+	return r, memRepo
+}
+
+func seedFile(t *testing.T, r *Registry) *RepoFile {
+	t.Helper()
+	ctx := t.Context()
+	f := &RepoFile{
+		OwningRepo: "pkg",
+		OwningTag:  "v1",
+		Name:       "thing.txt",
+	}
+	if _, err := r.AddFile(ctx, f, strings.NewReader("hello world")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	return f
+}
+
+func TestBlobRedirectURL_Redirected(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	fb := newFakeBackend(t)
+	fb.status = http.StatusTemporaryRedirect
+	fb.location = "https://cdn.example.com/blob?signature=xyz"
+
+	rec := &fakeRecorder{}
+	r, _ := newRedirectTestRegistry(t, fb, WithMetrics(rec))
+	f := seedFile(t, r)
+
+	got, err := r.BlobRedirectURL(ctx, f)
+	if err != nil {
+		t.Fatalf("BlobRedirectURL() error = %v", err)
+	}
+	if want := "https://cdn.example.com/blob?signature=xyz"; got != want {
+		t.Errorf("BlobRedirectURL() = %q, want %q", got, want)
+	}
+	if fb.hits != 1 {
+		t.Errorf("fake backend hits = %d, want 1", fb.hits)
+	}
+	if diff := cmp.Diff([]string{BlobRedirectOutcomeRedirected}, rec.redirectOutcomes()); diff != "" {
+		t.Errorf("redirect outcomes mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestBlobRedirectURL_InlineBackend(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	fb := newFakeBackend(t)
+	fb.status = http.StatusOK
+
+	rec := &fakeRecorder{}
+	r, _ := newRedirectTestRegistry(t, fb, WithMetrics(rec))
+	f := seedFile(t, r)
+
+	got, err := r.BlobRedirectURL(ctx, f)
+	if err != nil {
+		t.Fatalf("BlobRedirectURL() error = %v", err)
+	}
+	if got != "" {
+		t.Errorf("BlobRedirectURL() = %q, want empty (inline backend)", got)
+	}
+	if diff := cmp.Diff([]string{BlobRedirectOutcomeInline}, rec.redirectOutcomes()); diff != "" {
+		t.Errorf("redirect outcomes mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestBlobRedirectURL_Disabled(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	fb := newFakeBackend(t)
+	fb.status = http.StatusTemporaryRedirect
+	fb.location = "https://cdn.example.com/should-not-be-followed"
+
+	rec := &fakeRecorder{}
+	r, _ := newRedirectTestRegistry(t, fb, WithMetrics(rec), WithBlobRedirectDisabled(true))
+	f := seedFile(t, r)
+
+	got, err := r.BlobRedirectURL(ctx, f)
+	if err != nil {
+		t.Fatalf("BlobRedirectURL() error = %v", err)
+	}
+	if got != "" {
+		t.Errorf("BlobRedirectURL() = %q, want empty (disabled)", got)
+	}
+	if fb.hits != 0 {
+		t.Errorf("fake backend hits = %d, want 0 (probe should be skipped)", fb.hits)
+	}
+	if outcomes := rec.redirectOutcomes(); len(outcomes) != 0 {
+		t.Errorf("redirect outcomes = %v, want none (disabled path emits no metric)", outcomes)
+	}
+}
+
+func TestBlobRedirectURL_NotFound(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	fb := newFakeBackend(t)
+	rec := &fakeRecorder{}
+	r, _ := newRedirectTestRegistry(t, fb, WithMetrics(rec))
+	seedFile(t, r) // seed something else
+
+	missing := &RepoFile{
+		OwningRepo: "pkg",
+		OwningTag:  "v1",
+		Name:       "does-not-exist.txt",
+	}
+	got, err := r.BlobRedirectURL(ctx, missing)
+	if err == nil {
+		t.Fatalf("BlobRedirectURL() = %q, want error", got)
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("BlobRedirectURL() error = %v, want not-found", err)
+	}
+	if diff := cmp.Diff([]string{BlobRedirectOutcomeError}, rec.redirectOutcomes()); diff != "" {
+		t.Errorf("redirect outcomes mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestBlobRedirectURL_BackendError(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	fb := newFakeBackend(t)
+	// 418 is a non-retryable status — keeps the test fast. 5xx
+	// triggers oras-go's retry policy, which would multiply the test
+	// run time by the retry budget.
+	fb.status = http.StatusTeapot
+
+	rec := &fakeRecorder{}
+	r, _ := newRedirectTestRegistry(t, fb, WithMetrics(rec))
+	f := seedFile(t, r)
+
+	got, err := r.BlobRedirectURL(ctx, f)
+	if err == nil {
+		t.Fatalf("BlobRedirectURL() = %q, want error", got)
+	}
+	if got != "" {
+		t.Errorf("BlobRedirectURL() = %q on error, want empty", got)
+	}
+	if diff := cmp.Diff([]string{BlobRedirectOutcomeError}, rec.redirectOutcomes()); diff != "" {
+		t.Errorf("redirect outcomes mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestBlobRedirectURL_RedirectMissingLocation(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	fb := newFakeBackend(t)
+	fb.status = http.StatusTemporaryRedirect
+	fb.location = "" // 3xx with no Location → treat as error.
+
+	r, _ := newRedirectTestRegistry(t, fb)
+	f := seedFile(t, r)
+
+	if _, err := r.BlobRedirectURL(ctx, f); err == nil {
+		t.Fatalf("BlobRedirectURL() error = nil, want error for missing Location")
+	}
+}
+
+// TestBlobRedirectOutcome covers the small classifier directly so
+// future plumbing changes can't regress the metric labels without an
+// obvious test failure.
+func TestBlobRedirectOutcome(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		url  string
+		err  error
+		want string
+	}{
+		{name: "redirected", url: "https://cdn.example.com/x", want: BlobRedirectOutcomeRedirected},
+		{name: "inline", url: "", want: BlobRedirectOutcomeInline},
+		{name: "error wins over url", url: "https://cdn.example.com/x", err: errdef.ErrNotFound, want: BlobRedirectOutcomeError},
+		{name: "error", url: "", err: errdef.ErrNotFound, want: BlobRedirectOutcomeError},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := blobRedirectOutcome(tc.url, tc.err); got != tc.want {
+				t.Errorf("blobRedirectOutcome(%q, %v) = %q, want %q", tc.url, tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/oci/registry.go
+++ b/pkg/oci/registry.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -107,6 +108,14 @@ type Registry struct {
 	// uses O(streamChunkSize) memory and zero disk regardless of body size.
 	disableStreamingPush bool
 
+	// disableBlobRedirect, when true, makes BlobRedirectURL return
+	// ("", nil) without contacting the backend. Operators set this in
+	// environments where exposing backend (CDN / object-store)
+	// presigned URLs to clients is unacceptable — egress restrictions,
+	// DLP, audit requirements. Handlers fall through to the
+	// stream-through ReadFile path automatically.
+	disableBlobRedirect bool
+
 	// rec collects per-backend-call observations. Defaults to
 	// metrics.NoOp() so existing tests and library callers that don't
 	// opt into instrumentation see no behavioural change. Wire a real
@@ -126,6 +135,15 @@ type Registry struct {
 	// chunk and every manifest write, so a 200 MB upload pays for
 	// one token round-trip rather than ~50.
 	authClient *auth.Client
+
+	// probeClient is the auth.Client BlobRedirectURL uses to inspect
+	// the backend's /v2/<repo>/blobs/<digest> response. It shares the
+	// same auth.Cache and credential function as authClient so token
+	// fetches are amortised across both paths, but its inner
+	// http.Client refuses to follow redirects — we want to read the
+	// 3xx Location directly rather than transparently fetch the
+	// presigned URL.
+	probeClient *auth.Client
 
 	// Used in unit tests to stub with in-memory backend.
 	newBackendFunc func(ctx context.Context, f *RepoFile) (destRepo, error)
@@ -195,6 +213,20 @@ func WithStreamingPushDisabled(disabled bool) RegistryOption {
 	}
 }
 
+// WithBlobRedirectDisabled, when true, makes BlobRedirectURL return
+// ("", nil) without contacting the backend. Set this in environments
+// where exposing the backend's presigned object-store URLs to clients
+// is unacceptable (egress restrictions, DLP, audit requirements);
+// handlers fall through to the stream-through ReadFile path
+// automatically. The default (false) lets BlobRedirectURL probe the
+// backend and short-circuit blob downloads to the backend's CDN.
+func WithBlobRedirectDisabled(disabled bool) RegistryOption {
+	return func(r *Registry) error {
+		r.disableBlobRedirect = disabled
+		return nil
+	}
+}
+
 // RepoFile represents a file in an OCI repository.
 type RepoFile struct {
 	OwningRepo string // Repository the owns the file. Usually what's right after the registy host.
@@ -249,20 +281,36 @@ func NewRegistry(baseURL *url.URL, opt ...RegistryOption) (*Registry, error) {
 	if provider == nil {
 		provider = backend.Anonymous()
 	}
+	credFn := func(ctx context.Context, host string) (auth.Credential, error) {
+		c, err := provider.Credential(ctx, host)
+		if err != nil {
+			return auth.EmptyCredential, err
+		}
+		return auth.Credential{
+			Username:    c.Username,
+			Password:    c.Password,
+			AccessToken: c.AccessToken,
+		}, nil
+	}
+	cache := auth.NewCache()
 	r.authClient = &auth.Client{
-		Client: retry.DefaultClient,
-		Cache:  auth.NewCache(),
-		Credential: func(ctx context.Context, host string) (auth.Credential, error) {
-			c, err := provider.Credential(ctx, host)
-			if err != nil {
-				return auth.EmptyCredential, err
-			}
-			return auth.Credential{
-				Username:    c.Username,
-				Password:    c.Password,
-				AccessToken: c.AccessToken,
-			}, nil
-		},
+		Client:     retry.DefaultClient,
+		Cache:      cache,
+		Credential: credFn,
+	}
+
+	// probeClient shares the credential function and token cache with
+	// authClient — keeping bearer-token fetches amortised — but its
+	// inner http.Client refuses to follow redirects so the redirect
+	// probe sees the raw 3xx Location.
+	probeHTTP := retry.NewClient()
+	probeHTTP.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	r.probeClient = &auth.Client{
+		Client:     probeHTTP,
+		Cache:      cache,
+		Credential: credFn,
 	}
 
 	return r, nil


### PR DESCRIPTION
Adds an optional fast-path on python/maven blob GETs that 307s the
client to the backend's CDN/object-store URL when the backend (GAR,
ECR, ACR, GHCR, Docker Hub) supports it, eliminating ocifactory egress
on read-heavy workloads. Self-hosted inline-serving backends (zot,
Harbor, distribution) keep working transparently — the probe sees a
200 and the handler falls through to streaming.

- pkg/oci.Registry.BlobRedirectURL: HEAD probes /v2/<repo>/blobs/<digest>
  with a non-redirect-following auth.Client and surfaces the Location
  header on 3xx, returns ("", nil) on 200.
- Handlers call BlobRedirectURL on GET (not HEAD — no egress to save)
  and fall back to ReadFile on empty URL or hard error.
- --disable-blob-redirect (env OCIFACTORY_DISABLE_BLOB_REDIRECT) opts
  out for environments where exposing backend URLs is unacceptable.
- ocifactory_blob_redirect_total{outcome=redirected|inline|error}
  counter exposes the short-circuit hit rate.

Closes #61

https://claude.ai/code/session_01CPXmb8i2VUQWnq2jYD1E3n