### PR TITLE
Reject re-uploads by default and stop leaking 5xx error detail

### DIFF
--- a/pkg/commands/serve.go
+++ b/pkg/commands/serve.go
@@ -65,6 +65,7 @@ const (
 	flagBackendRegistry                 = "backend-registry"
 	flagDisableStreamingPush            = "disable-streaming-push"
 	flagDisableBlobRedirect             = "disable-blob-redirect"
+	flagAllowOverwrite                  = "allow-overwrite"
 	flagSimpleIndexCacheTTL             = "simple-index-cache-ttl"
 	flagPythonMaxUploadBytes            = "python-max-upload-bytes"
 	flagEnableMetrics                   = "enable-metrics"
@@ -91,6 +92,7 @@ type serveConfig struct {
 	BackendRegistry      string        `mapstructure:"backend-registry"`
 	DisableStreamingPush bool          `mapstructure:"disable-streaming-push"`
 	DisableBlobRedirect  bool          `mapstructure:"disable-blob-redirect"`
+	AllowOverwrite       bool          `mapstructure:"allow-overwrite"`
 	SimpleIndexCacheTTL  time.Duration `mapstructure:"simple-index-cache-ttl"`
 	PythonMaxUploadBytes int64         `mapstructure:"python-max-upload-bytes"`
 	EnableMetrics        bool          `mapstructure:"enable-metrics"`
@@ -233,6 +235,16 @@ func registerServeFlags(flags *pflag.FlagSet) {
 			"Bodies above the in-memory threshold will spill to a temp file "+
 			"instead of streaming via chunked PATCH. Set this only for "+
 			"backend registries with broken or missing chunked-PATCH support.")
+	flags.Bool(flagAllowOverwrite, false,
+		"Allow re-uploading a file whose (repo, version, name) tuple "+
+			"already exists. The default (false) rejects re-uploads with "+
+			"409 Conflict, matching PyPI's auditability story and keeping "+
+			"every published version immutable. Set this true for "+
+			"workflows that intentionally re-publish under the same "+
+			"version (Maven snapshots, fix-the-CI-job retries, ephemeral "+
+			"staging) — overwrites unlink the previous file manifest from "+
+			"the version's referrer set so readers always see exactly "+
+			"one match per filename.")
 	flags.Bool(flagDisableBlobRedirect, false,
 		"Disable redirecting blob downloads to backend-issued presigned "+
 			"URLs. By default, hosted backends (GAR, ECR, ACR, GHCR, Docker "+
@@ -322,6 +334,7 @@ func runServe(ctx context.Context, cfg *serveConfig) error {
 	registryOpts := []oci.RegistryOption{
 		oci.WithStreamingPushDisabled(cfg.DisableStreamingPush),
 		oci.WithBlobRedirectDisabled(cfg.DisableBlobRedirect),
+		oci.WithAllowOverwrite(cfg.AllowOverwrite),
 		oci.WithMetrics(rec),
 		oci.WithBackendAuth(bp),
 	}

--- a/pkg/commands/serve_test.go
+++ b/pkg/commands/serve_test.go
@@ -174,6 +174,7 @@ func TestServeCmd_Flags(t *testing.T) {
 		{name: flagRepoType, flagName: flagRepoType, shorthand: "t"},
 		{name: flagBackendRegistry, flagName: flagBackendRegistry},
 		{name: flagDisableStreamingPush, flagName: flagDisableStreamingPush},
+		{name: flagAllowOverwrite, flagName: flagAllowOverwrite},
 		{name: flagDisableAuthn, flagName: flagDisableAuthn},
 		{name: flagAuthnKind, flagName: flagAuthnKind},
 		{name: flagAuthnOIDCIssuers, flagName: flagAuthnOIDCIssuers},

--- a/pkg/handler/common.go
+++ b/pkg/handler/common.go
@@ -25,6 +25,25 @@ type Registry interface {
 	BlobRedirectURL(ctx context.Context, f *oci.RepoFile) (string, error)
 }
 
+// WriteError logs internal at ERROR (so operators see the backend
+// detail in the server logs) and writes public to the client with the
+// given status code. Use this for 5xx responses where the underlying
+// error often carries backend hostnames, paths, or auth-translation
+// noise that clients have no business seeing — leaking them via
+// http.Error(w, err.Error(), 500) is a small but real
+// deployment-topology disclosure.
+//
+// 4xx branches that already construct their own public message
+// (NotFound, Unauthorized, Forbidden, BadRequest from validation)
+// keep using http.Error directly; their messages are not leaky.
+func WriteError(ctx context.Context, w http.ResponseWriter, code int, internal error, public string) {
+	logging.FromContext(ctx).ErrorContext(ctx, "handler error",
+		"code", code,
+		"error", internal,
+	)
+	http.Error(w, public, code)
+}
+
 type Middleware func(next http.Handler) http.Handler
 
 // Server is a wrapper around serving.Server that allows for adding middlewares.

--- a/pkg/handler/common_test.go
+++ b/pkg/handler/common_test.go
@@ -1,0 +1,81 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/yolocs/ocifactory/pkg/logging"
+)
+
+// TestWriteError locks the public-vs-internal split: the body sent to
+// the client carries only the public message and the requested status
+// code, while the logger attached to ctx receives the wrapped internal
+// error. Without that split, handlers leak ORAS-derived backend
+// hostnames and paths to clients via http.Error(w, err.Error(), 500).
+func TestWriteError(t *testing.T) {
+	t.Parallel()
+
+	internal := errors.New("zot.internal:5000/packages/foo: 500 internal server error")
+
+	tests := []struct {
+		name           string
+		code           int
+		public         string
+		wantBody       string
+		wantLogContain string
+	}{
+		{
+			name:           "500 internal error",
+			code:           500,
+			public:         "internal error",
+			wantBody:       "internal error",
+			wantLogContain: "zot.internal:5000/packages/foo",
+		},
+		{
+			name:           "503 with custom public message",
+			code:           503,
+			public:         "backend unavailable",
+			wantBody:       "backend unavailable",
+			wantLogContain: "zot.internal:5000/packages/foo",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var logBuf bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{
+				Level: slog.LevelDebug,
+			}))
+			ctx := logging.WithLogger(context.Background(), logger)
+
+			rec := httptest.NewRecorder()
+			WriteError(ctx, rec, tc.code, internal, tc.public)
+
+			if got, want := rec.Code, tc.code; got != want {
+				t.Errorf("status = %d, want %d", got, want)
+			}
+			body := strings.TrimSpace(rec.Body.String())
+			if body != tc.wantBody {
+				t.Errorf("body = %q, want %q", body, tc.wantBody)
+			}
+			// Public message must NOT contain the internal detail.
+			if strings.Contains(body, tc.wantLogContain) {
+				t.Errorf("body leaked internal detail %q: %q", tc.wantLogContain, body)
+			}
+			logged := logBuf.String()
+			if !strings.Contains(logged, tc.wantLogContain) {
+				t.Errorf("log missing internal detail %q: %q", tc.wantLogContain, logged)
+			}
+			if !strings.Contains(logged, "level=ERROR") {
+				t.Errorf("log not at ERROR severity: %q", logged)
+			}
+		})
+	}
+}

--- a/pkg/handler/maven/handler.go
+++ b/pkg/handler/maven/handler.go
@@ -203,8 +203,11 @@ func (h *Handler) handlePut(w http.ResponseWriter, req *http.Request, f *oci.Rep
 		logger.DebugContext(req.Context(), "checksum verification failed", "error", err)
 		code := httpStatus(err)
 		if code == 0 {
-			code = http.StatusInternalServerError
+			handler.WriteError(req.Context(), w, http.StatusInternalServerError, err, "internal error")
+			return
 		}
+		// Checksum-validation errors carry deliberately framed
+		// public messages (4xx); pass them through.
 		http.Error(w, err.Error(), code)
 		return
 	}
@@ -212,6 +215,10 @@ func (h *Handler) handlePut(w http.ResponseWriter, req *http.Request, f *oci.Rep
 	desc, err := h.registry.AddFile(req.Context(), f, body)
 	if err != nil {
 		logger.DebugContext(req.Context(), "failed to add file", "error", err)
+		if errors.Is(err, oci.ErrAlreadyExists) {
+			http.Error(w, "file already exists in version", http.StatusConflict)
+			return
+		}
 		if oci.HasCode(err, http.StatusUnauthorized) {
 			http.Error(w, err.Error(), http.StatusUnauthorized)
 			return
@@ -220,7 +227,7 @@ func (h *Handler) handlePut(w http.ResponseWriter, req *http.Request, f *oci.Rep
 			http.Error(w, err.Error(), http.StatusForbidden)
 			return
 		}
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		handler.WriteError(req.Context(), w, http.StatusInternalServerError, err, "internal error")
 		return
 	}
 	logger.DebugContext(req.Context(), "added file", "descriptor", desc)
@@ -292,7 +299,7 @@ func (h *Handler) handleGet(w http.ResponseWriter, req *http.Request, f *oci.Rep
 			http.Error(w, err.Error(), http.StatusForbidden)
 			return
 		}
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		handler.WriteError(req.Context(), w, http.StatusInternalServerError, err, "internal error")
 		return
 	}
 	defer r.Close()
@@ -306,8 +313,7 @@ func (h *Handler) handleGet(w http.ResponseWriter, req *http.Request, f *oci.Rep
 	}
 
 	if _, err := io.Copy(w, r); err != nil {
-		logger.DebugContext(req.Context(), "failed to write response", "error", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		handler.WriteError(req.Context(), w, http.StatusInternalServerError, err, "internal error")
 		return
 	}
 }

--- a/pkg/handler/maven/handler_test.go
+++ b/pkg/handler/maven/handler_test.go
@@ -436,3 +436,55 @@ func pathToRepoFile(t *testing.T, p string) *oci.RepoFile {
 		MediaType:  detectMediaType(fn),
 	}
 }
+
+// TestHandlePut_ReuploadConflict locks the wire-level shape of the
+// re-upload contract for Maven uploads: a second PUT to the same
+// (repo, version, filename) returns 409 by default and 201 when the
+// fake registry is flipped into overwrite mode.
+func TestHandlePut_ReuploadConflict(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		allowOverwrite bool
+		wantSecond     int
+	}{
+		{name: "default rejects re-upload", allowOverwrite: false, wantSecond: http.StatusConflict},
+		{name: "allow-overwrite returns 201", allowOverwrite: true, wantSecond: http.StatusCreated},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			reg := oci.NewFakeRegistry()
+			reg.AllowOverwrite = tc.allowOverwrite
+			h, err := NewHandler(reg)
+			if err != nil {
+				t.Fatalf("NewHandler: %v", err)
+			}
+			mux := h.Mux()
+
+			send := func(body string) *httptest.ResponseRecorder {
+				req := httptest.NewRequest(http.MethodPut, "/com/example/project/1.0.0/project-1.0.0.jar", strings.NewReader(body))
+				rec := httptest.NewRecorder()
+				mux.ServeHTTP(rec, req)
+				return rec
+			}
+
+			if rec := send("first jar"); rec.Code != http.StatusCreated {
+				t.Fatalf("first PUT status=%d, want 201 (body=%s)", rec.Code, rec.Body.String())
+			}
+
+			rec := send("second jar")
+			if got, want := rec.Code, tc.wantSecond; got != want {
+				t.Fatalf("second PUT status=%d, want %d (body=%s)", got, want, rec.Body.String())
+			}
+			if rec.Code == http.StatusConflict {
+				if got := rec.Body.String(); !strings.Contains(got, "file already exists") {
+					t.Errorf("409 body = %q, want contains %q", got, "file already exists")
+				}
+			}
+		})
+	}
+}

--- a/pkg/handler/python/handler.go
+++ b/pkg/handler/python/handler.go
@@ -201,12 +201,9 @@ func (h *Handler) Mux() http.Handler {
 // (already-normalized) package name; ListTags is enough to enumerate
 // them.
 func (h *Handler) handleSimpleIndex(w http.ResponseWriter, req *http.Request) {
-	logger := logging.FromContext(req.Context())
-
 	tags, err := h.registry.ListTags(req.Context(), "index")
 	if err != nil && !errors.Is(err, errdef.ErrNotFound) {
-		logger.ErrorContext(req.Context(), "failed to list package index", "error", err)
-		http.Error(w, "failed to list package index", http.StatusInternalServerError)
+		handler.WriteError(req.Context(), w, http.StatusInternalServerError, err, "failed to list package index")
 		return
 	}
 
@@ -353,19 +350,32 @@ func (h *Handler) handleFilePut(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// The index repo write is a single sentinel per package, not per
-	// version. handleSimpleIndex only reads tag names from "index"
-	// via ListTags, so storing one constant placeholder layer under
-	// index/<normalizedName> is enough — the OCI backend deduplicates
-	// the identical blob and file manifest across every subsequent
-	// upload of the same package.
-	sentinelRF := &oci.RepoFile{
-		OwningRepo: "index",
-		OwningTag:  normalizedName,
-		Name:       indexSentinelName,
-		MediaType:  "text/plain",
-		Size:       int64(len(indexSentinelContent)),
-	}
-	if !h.streamAddFile(ctx, w, sentinelRF, strings.NewReader(indexSentinelContent)) {
+	// version — handleSimpleIndex only reads tag names from "index"
+	// via ListTags, so one constant placeholder layer under
+	// index/<normalizedName> is enough.
+	//
+	// We must skip the AddFile call when the sentinel is already
+	// there: with the default re-upload policy (--allow-overwrite=false)
+	// any second AddFile to the same (index, normalizedName, present)
+	// tuple would 409, which would surface as a spurious upload
+	// failure on every package release after the first. ListTags is
+	// cheap (the index repo is one tag per package, and it's the
+	// same call /simple/ already makes on the read side), so we
+	// trade an extra round-trip per upload for a clean immutable
+	// AddFile contract.
+	if err := h.ensureIndexSentinel(ctx, normalizedName); err != nil {
+		logger.DebugContext(ctx, "failed to ensure index sentinel", "error", err)
+		var maxBytesErr *http.MaxBytesError
+		switch {
+		case errors.As(err, &maxBytesErr):
+			http.Error(w, fmt.Sprintf("upload exceeds %d-byte limit", maxBytesErr.Limit), http.StatusRequestEntityTooLarge)
+		case oci.HasCode(err, http.StatusUnauthorized):
+			http.Error(w, err.Error(), http.StatusUnauthorized)
+		case oci.HasCode(err, http.StatusForbidden):
+			http.Error(w, err.Error(), http.StatusForbidden)
+		default:
+			handler.WriteError(ctx, w, http.StatusInternalServerError, err, "internal error")
+		}
 		return
 	}
 
@@ -388,6 +398,38 @@ func (h *Handler) handleFilePut(w http.ResponseWriter, req *http.Request) {
 
 	h.indexCache.invalidate(normalizedName)
 	w.WriteHeader(http.StatusCreated)
+}
+
+// ensureIndexSentinel writes the index/<normalizedName> sentinel only
+// when no tag exists for that package yet. Idempotent: a second
+// upload of any version of the same package skips the write entirely
+// rather than colliding with the immutable-add contract that AddFile
+// now enforces by default.
+//
+// errdef.ErrNotFound from ListTags is treated as "no packages yet"
+// (zot returns it for empty repositories), matching how
+// handleSimpleIndex already absorbs the same shape.
+func (h *Handler) ensureIndexSentinel(ctx context.Context, normalizedName string) error {
+	tags, err := h.registry.ListTags(ctx, "index")
+	if err != nil && !errors.Is(err, errdef.ErrNotFound) {
+		return fmt.Errorf("list index tags: %w", err)
+	}
+	for _, t := range tags {
+		if t == normalizedName {
+			return nil
+		}
+	}
+	sentinelRF := &oci.RepoFile{
+		OwningRepo: "index",
+		OwningTag:  normalizedName,
+		Name:       indexSentinelName,
+		MediaType:  "text/plain",
+		Size:       int64(len(indexSentinelContent)),
+	}
+	if _, err := h.registry.AddFile(ctx, sentinelRF, strings.NewReader(indexSentinelContent)); err != nil {
+		return fmt.Errorf("add index sentinel: %w", err)
+	}
+	return nil
 }
 
 // errFieldTooLarge is returned by readTextPart when a non-file form
@@ -440,12 +482,14 @@ func (h *Handler) streamAddFile(ctx context.Context, w http.ResponseWriter, f *o
 		switch {
 		case errors.As(err, &maxBytesErr):
 			http.Error(w, fmt.Sprintf("upload exceeds %d-byte limit", maxBytesErr.Limit), http.StatusRequestEntityTooLarge)
+		case errors.Is(err, oci.ErrAlreadyExists):
+			http.Error(w, "file already exists in version", http.StatusConflict)
 		case oci.HasCode(err, http.StatusUnauthorized):
 			http.Error(w, err.Error(), http.StatusUnauthorized)
 		case oci.HasCode(err, http.StatusForbidden):
 			http.Error(w, err.Error(), http.StatusForbidden)
 		default:
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			handler.WriteError(ctx, w, http.StatusInternalServerError, err, "internal error")
 		}
 		return false
 	}
@@ -501,7 +545,7 @@ func (h *Handler) handlePackageIndex(w http.ResponseWriter, req *http.Request) {
 				http.Error(w, err.Error(), http.StatusForbidden)
 				return
 			}
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			handler.WriteError(req.Context(), w, http.StatusInternalServerError, err, "internal error")
 			return
 		}
 		h.indexCache.put(pkg, files)
@@ -587,7 +631,7 @@ func (h *Handler) handleGet(w http.ResponseWriter, req *http.Request, f *oci.Rep
 			http.Error(w, err.Error(), http.StatusForbidden)
 			return
 		}
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		handler.WriteError(req.Context(), w, http.StatusInternalServerError, err, "internal error")
 		return
 	}
 	defer r.Close()
@@ -601,8 +645,7 @@ func (h *Handler) handleGet(w http.ResponseWriter, req *http.Request, f *oci.Rep
 	}
 
 	if _, err := io.Copy(w, r); err != nil {
-		logger.DebugContext(req.Context(), "failed to write response", "error", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		handler.WriteError(req.Context(), w, http.StatusInternalServerError, err, "internal error")
 		return
 	}
 }

--- a/pkg/handler/python/handler_test.go
+++ b/pkg/handler/python/handler_test.go
@@ -1505,3 +1505,114 @@ func (dummyByteReader) Read(p []byte) (int, error) {
 	}
 	return len(p), nil
 }
+
+// TestHandleFilePut_ReuploadConflict locks the wire-level shape of the
+// re-upload contract: the second upload of the same wheel under the
+// same version returns 409 Conflict by default, and flipping
+// AllowOverwrite on the registry promotes it back to 201.
+func TestHandleFilePut_ReuploadConflict(t *testing.T) {
+	t.Parallel()
+
+	build := func(content string) (*bytes.Buffer, string) {
+		var b bytes.Buffer
+		mw := multipart.NewWriter(&b)
+		_ = mw.WriteField("name", "example-pkg")
+		_ = mw.WriteField("version", "1.0.0")
+		fw, _ := mw.CreateFormFile("content", "example_pkg-1.0.0.whl")
+		_, _ = fw.Write([]byte(content))
+		_ = mw.Close()
+		return &b, mw.FormDataContentType()
+	}
+
+	send := func(t *testing.T, h http.Handler, body *bytes.Buffer, ctype string) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPut, "/", body)
+		req.Header.Set("Content-Type", ctype)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		return rec
+	}
+
+	tests := []struct {
+		name           string
+		allowOverwrite bool
+		wantSecond     int
+	}{
+		{name: "default rejects re-upload", allowOverwrite: false, wantSecond: http.StatusConflict},
+		{name: "allow-overwrite returns 201", allowOverwrite: true, wantSecond: http.StatusCreated},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			reg := oci.NewFakeRegistry()
+			reg.AllowOverwrite = tc.allowOverwrite
+			h, err := NewHandler(reg)
+			if err != nil {
+				t.Fatalf("NewHandler: %v", err)
+			}
+
+			body, ctype := build("first upload")
+			if rec := send(t, h.Mux(), body, ctype); rec.Code != http.StatusCreated {
+				t.Fatalf("first upload status=%d, want 201 (body=%s)", rec.Code, rec.Body.String())
+			}
+
+			body, ctype = build("second upload")
+			rec := send(t, h.Mux(), body, ctype)
+			if got, want := rec.Code, tc.wantSecond; got != want {
+				t.Fatalf("second upload status=%d, want %d (body=%s)", got, want, rec.Body.String())
+			}
+			if rec.Code == http.StatusConflict {
+				// Public 409 message is not the wrapped internal one
+				// (which would carry the OCI repo / tag / name path).
+				if got := rec.Body.String(); !strings.Contains(got, "file already exists") {
+					t.Errorf("409 body = %q, want contains %q", got, "file already exists")
+				}
+			}
+		})
+	}
+}
+
+// TestHandleFilePut_ReuploadOfDifferentVersionSucceeds proves the
+// 409 default scopes by version: a second upload of the same package
+// under a new version is the normal release flow and must succeed.
+// The index sentinel must remain a single tag under index/<pkg>.
+func TestHandleFilePut_ReuploadOfDifferentVersionSucceeds(t *testing.T) {
+	t.Parallel()
+
+	build := func(version string) (*bytes.Buffer, string) {
+		var b bytes.Buffer
+		mw := multipart.NewWriter(&b)
+		_ = mw.WriteField("name", "example-pkg")
+		_ = mw.WriteField("version", version)
+		fw, _ := mw.CreateFormFile("content", "example_pkg-"+version+".whl")
+		_, _ = fw.Write([]byte("content for " + version))
+		_ = mw.Close()
+		return &b, mw.FormDataContentType()
+	}
+
+	reg := oci.NewFakeRegistry()
+	h, err := NewHandler(reg)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+
+	for _, version := range []string{"1.0.0", "1.0.1", "2.0.0"} {
+		body, ctype := build(version)
+		req := httptest.NewRequest(http.MethodPut, "/", body)
+		req.Header.Set("Content-Type", ctype)
+		rec := httptest.NewRecorder()
+		h.Mux().ServeHTTP(rec, req)
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("upload %s status=%d, want 201 (body=%s)", version, rec.Code, rec.Body.String())
+		}
+	}
+
+	// Exactly one sentinel under the index repo, regardless of how
+	// many versions were uploaded.
+	indexTags := reg.Tags["index"]
+	if got, want := len(indexTags), 1; got != want {
+		t.Errorf("index tags = %v, want exactly one entry for the package", indexTags)
+	}
+}

--- a/pkg/oci/fake.go
+++ b/pkg/oci/fake.go
@@ -31,6 +31,14 @@ type FakeRegistry struct {
 	Files   map[string][]byte
 	Tags    map[string][]string
 	Aliases map[string]string
+
+	// AllowOverwrite mirrors WithAllowOverwrite on the real Registry.
+	// When false (the default), AddFile returns ErrAlreadyExists for a
+	// re-upload of an existing (OwningRepo, OwningTag, Name); when
+	// true the existing entry is replaced. Tests that exercise the
+	// 409-on-re-upload branch leave it false; tests for overwrite
+	// flip it on per-test.
+	AllowOverwrite bool
 }
 
 func NewFakeRegistry() *FakeRegistry {
@@ -61,12 +69,19 @@ func (r *FakeRegistry) AddFile(ctx context.Context, f *RepoFile, ro io.Reader) (
 		return nil, fmt.Errorf("%w: tag %q in repo %q is an alias", ErrAliasCollision, f.OwningTag, f.OwningRepo)
 	}
 
+	key := f.OwningRepo + "/" + f.OwningTag + "/" + f.Name
+	if _, exists := r.Files[key]; exists && !r.AllowOverwrite {
+		// Match the real Registry's pre-upload rejection: the body
+		// is not consumed, so handler tests that simulate a twine
+		// retry can re-use the same reader.
+		return nil, fmt.Errorf("%w: %s", ErrAlreadyExists, key)
+	}
+
 	content, err := io.ReadAll(ro)
 	if err != nil {
 		return nil, err
 	}
 
-	key := f.OwningRepo + "/" + f.OwningTag + "/" + f.Name
 	r.Files[key] = content
 	r.AddTag(f.OwningRepo, f.OwningTag)
 

--- a/pkg/oci/registry.go
+++ b/pkg/oci/registry.go
@@ -75,6 +75,14 @@ var ErrDigestMismatch = errors.New("file digest mismatch")
 // write path turns silent overwrite into a typed error.
 var ErrAliasCollision = errors.New("tag collides with incompatible artifactType")
 
+// ErrAlreadyExists is returned by AddFile when a file with the same
+// (OwningRepo, OwningTag, Name) already exists and the registry was
+// constructed without WithAllowOverwrite(true). Handlers translate it
+// to 409 Conflict — re-uploading an existing file in an existing
+// version is rejected by default to match PyPI's auditability story
+// and keep an immutable view of every published version.
+var ErrAlreadyExists = errors.New("file already exists in version")
+
 // destRepo is the subset of oras-go's remote.Repository (and our in-memory
 // fake) that pkg/oci needs. Pinned as an interface so tests can substitute
 // memory-backed implementations.
@@ -115,6 +123,17 @@ type Registry struct {
 	// DLP, audit requirements. Handlers fall through to the
 	// stream-through ReadFile path automatically.
 	disableBlobRedirect bool
+
+	// allowOverwrite, when true, lets AddFile re-upload a file whose
+	// (OwningRepo, OwningTag, Name) already exists; the old file
+	// manifest is unlinked from the version's referrer set after the
+	// new one is pushed so readers always see exactly one match per
+	// filename. The default (false) returns ErrAlreadyExists instead,
+	// which handlers translate to 409 Conflict — safe-by-default for
+	// auditability and immutable-version semantics. Operators flip
+	// this on via --allow-overwrite when they need lax behaviour
+	// (e.g. snapshot workflows that re-publish under the same tag).
+	allowOverwrite bool
 
 	// rec collects per-backend-call observations. Defaults to
 	// metrics.NoOp() so existing tests and library callers that don't
@@ -209,6 +228,25 @@ func WithBackendAuth(p backend.Provider) RegistryOption {
 func WithStreamingPushDisabled(disabled bool) RegistryOption {
 	return func(r *Registry) error {
 		r.disableStreamingPush = disabled
+		return nil
+	}
+}
+
+// WithAllowOverwrite controls re-upload semantics. When true, AddFile
+// permits replacing a file whose (OwningRepo, OwningTag, Name) already
+// exists in the version: the new file manifest is pushed and the old
+// one is unlinked from the version's referrer set so subsequent reads
+// see only the new content. When false (the default), AddFile returns
+// ErrAlreadyExists on a re-upload attempt; handlers translate that to
+// 409 Conflict.
+//
+// The safe-by-default shape mirrors PyPI's behaviour and keeps every
+// published version auditably immutable. Operators that intentionally
+// re-publish under the same tag (Maven snapshots, fix-the-CI-job
+// workflows, ephemeral staging) flip this on via --allow-overwrite.
+func WithAllowOverwrite(allow bool) RegistryOption {
+	return func(r *Registry) error {
+		r.allowOverwrite = allow
 		return nil
 	}
 }
@@ -371,9 +409,27 @@ func NewRegistry(baseURL *url.URL, opt ...RegistryOption) (*Registry, error) {
 //   - If RepoFile.OwningTag currently resolves to an alias manifest
 //     (artifactType ≠ versionArtifactType), AddFile returns
 //     ErrAliasCollision rather than silently overwriting the alias.
+//   - If a file with the same (OwningRepo, OwningTag, Name) already
+//     exists and the registry was constructed without
+//     WithAllowOverwrite(true), AddFile returns ErrAlreadyExists
+//     before the body is read so a rejected re-upload doesn't pay for
+//     a wasted upload. With WithAllowOverwrite(true), the previous
+//     file manifest is unlinked from the version's referrer set after
+//     the new one is pushed; readers only ever see one match per
+//     filename, even across overwrites.
 func (r *Registry) AddFile(ctx context.Context, f *RepoFile, ro io.Reader) (*FileDescriptor, error) {
 	if f.OwningTag == "" {
 		return nil, fmt.Errorf("OwningTag must be set")
+	}
+
+	// Existence probe runs before uploadBlob so a rejected re-upload
+	// doesn't read a byte of the request body. The probe also returns
+	// the pre-existing file manifest descriptor when overwrite is
+	// allowed, so we can unlink it after the new manifest lands
+	// without a second referrer scan.
+	oldFileManifest, err := r.probeExistingFile(ctx, f)
+	if err != nil {
+		return nil, err
 	}
 
 	blobDesc, backend, err := r.uploadBlob(ctx, f, ro)
@@ -391,7 +447,74 @@ func (r *Registry) AddFile(ctx context.Context, f *RepoFile, ro io.Reader) (*Fil
 		return nil, err
 	}
 
+	// Best-effort cleanup of the previous file manifest when this is
+	// an overwrite. Skipped when the new manifest is byte-identical
+	// (same digest) to the old — re-uploading identical content is
+	// idempotent and there's nothing to unlink. A delete failure is
+	// not fatal: the orphan remains discoverable via the version's
+	// referrers list until backend GC reaps it, but the live referrer
+	// scan in ReadFile may then return either manifest. That
+	// uncertainty is exactly what overwrite-mode opts into.
+	if oldFileManifest != nil && oldFileManifest.Digest != fileManifestDesc.Digest {
+		_ = backend.Delete(ctx, *oldFileManifest)
+	}
+
 	return &FileDescriptor{Manifest: fileManifestDesc, File: blobDesc}, nil
+}
+
+// probeExistingFile resolves the version manifest (if any) and scans
+// its file referrers for one whose FileNameAnnotation matches f.Name.
+// Behaviour:
+//
+//   - No version tag yet, or no matching file referrer → returns
+//     (nil, nil); caller proceeds with the normal write path.
+//   - Match found and overwrite is disabled → returns
+//     (nil, ErrAlreadyExists).
+//   - Match found and overwrite is enabled → returns the existing
+//     descriptor so AddFile can unlink it after the new manifest is
+//     pushed.
+//
+// The tag-points-at-an-alias case is left to ensureVersionManifest to
+// translate into ErrAliasCollision: this probe only cares about file
+// referrers under a canonical version manifest.
+func (r *Registry) probeExistingFile(ctx context.Context, f *RepoFile) (*ocispec.Descriptor, error) {
+	backend, err := r.newBackendFunc(ctx, f)
+	if err != nil {
+		return nil, err
+	}
+
+	versionDesc, err := backend.Resolve(ctx, f.OwningTag)
+	if err != nil {
+		if errors.Is(err, errdef.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to resolve version tag %q: %w", f.OwningTag, err)
+	}
+
+	aType, err := manifestArtifactType(ctx, backend, versionDesc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect tag %q: %w", f.OwningTag, err)
+	}
+	if aType != r.versionArtifactType {
+		// Alias or foreign manifest — ensureVersionManifest will
+		// surface ErrAliasCollision when the write reaches it.
+		return nil, nil
+	}
+
+	refs, err := registry.Referrers(ctx, backend, versionDesc, r.fileArtifactType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list file referrers for %q: %w", f.OwningTag, err)
+	}
+	for i := range refs {
+		if refs[i].Annotations[FileNameAnnotation] != f.Name {
+			continue
+		}
+		if !r.allowOverwrite {
+			return nil, fmt.Errorf("%w: %s/%s/%s", ErrAlreadyExists, f.OwningRepo, f.OwningTag, f.Name)
+		}
+		return &refs[i], nil
+	}
+	return nil, nil
 }
 
 // uploadBlob picks between the buffered and streaming push paths and

--- a/pkg/oci/registry_test.go
+++ b/pkg/oci/registry_test.go
@@ -170,8 +170,9 @@ func TestDetectFileMediaType(t *testing.T) {
 type inMemoryRepo struct {
 	*memory.Store
 
-	mu      sync.Mutex
-	allTags map[string]string
+	mu             sync.Mutex
+	allTags        map[string]string
+	deletedDigests map[string]struct{}
 }
 
 func (r *inMemoryRepo) Tags(_ context.Context, _ string, fn func(tags []string) error) error {
@@ -188,6 +189,11 @@ func (r *inMemoryRepo) Tag(ctx context.Context, desc ocispec.Descriptor, referen
 	return r.Store.Tag(ctx, desc, reference)
 }
 
+// Delete simulates removal: oras-go's memory.Store has no Delete, so
+// we keep a deleted-digest set and let Predecessors filter on it.
+// That's enough for the unit tests that need to observe an unlinked
+// referrer (e.g. AddFile's overwrite path); a real registry GCs the
+// underlying blob/manifest for us.
 func (r *inMemoryRepo) Delete(ctx context.Context, target ocispec.Descriptor) error {
 	r.mu.Lock()
 	for tag, digest := range r.allTags {
@@ -195,8 +201,32 @@ func (r *inMemoryRepo) Delete(ctx context.Context, target ocispec.Descriptor) er
 			delete(r.allTags, tag)
 		}
 	}
+	if r.deletedDigests == nil {
+		r.deletedDigests = map[string]struct{}{}
+	}
+	r.deletedDigests[target.Digest.String()] = struct{}{}
 	r.mu.Unlock()
 	return nil
+}
+
+func (r *inMemoryRepo) Predecessors(ctx context.Context, node ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+	all, err := r.Store.Predecessors(ctx, node)
+	if err != nil {
+		return nil, err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.deletedDigests) == 0 {
+		return all, nil
+	}
+	kept := make([]ocispec.Descriptor, 0, len(all))
+	for _, d := range all {
+		if _, gone := r.deletedDigests[d.Digest.String()]; gone {
+			continue
+		}
+		kept = append(kept, d)
+	}
+	return kept, nil
 }
 
 // Intercept the Resolve call to return ErrNotFound if the target has been deleted.
@@ -535,15 +565,18 @@ func TestAddFile_BufferedPath(t *testing.T) {
 				t.Errorf("AddFile() pushed blob size = %d, want %d", gotBytes, tc.wantFileSize)
 			}
 
-			// Re-adding the same content must not re-push the blob: the
-			// Exists check should short-circuit it, and the unchanged
-			// manifest path should skip the manifest re-pack as well.
+			// Re-uploading the same (repo, tag, name) is rejected by
+			// default — the immutable-add contract takes precedence
+			// over the older dedup-via-pushIfMissing path. The error
+			// is returned before any byte is read from the body, so
+			// the second call must not push anything.
 			pushesAfterFirst := counting.pushCalls
-			if _, err := r.AddFile(ctx, tc.repoFile, bytes.NewReader(tc.content)); err != nil {
-				t.Fatalf("AddFile() second call error = %v", err)
+			_, err = r.AddFile(ctx, tc.repoFile, bytes.NewReader(tc.content))
+			if !errors.Is(err, ErrAlreadyExists) {
+				t.Fatalf("AddFile() second call error = %v, want ErrAlreadyExists", err)
 			}
 			if counting.pushCalls != pushesAfterFirst {
-				t.Errorf("AddFile() second call pushed %d more times, want 0", counting.pushCalls-pushesAfterFirst)
+				t.Errorf("AddFile() rejected re-upload pushed %d more times, want 0", counting.pushCalls-pushesAfterFirst)
 			}
 		})
 	}
@@ -1132,4 +1165,154 @@ func TestAppendRefs_RepointReapsOldAlias(t *testing.T) {
 	if string(got) != "b" {
 		t.Errorf("ReadFile(latest, b.txt) = %q, want %q", got, "b")
 	}
+}
+
+// TestAddFile_ReuploadRejectedByDefault locks the safe-by-default
+// re-upload behaviour. A second AddFile to the same
+// (OwningRepo, OwningTag, Name) returns ErrAlreadyExists without
+// touching the body, regardless of whether the new content matches
+// the existing file. The byte-untouched property matters because
+// streaming clients can retry without rewinding.
+func TestAddFile_ReuploadRejectedByDefault(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	tests := []struct {
+		name   string
+		first  string
+		second string
+	}{
+		{name: "identical content", first: "hello", second: "hello"},
+		{name: "different content", first: "hello", second: "world!"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			r, _ := newTestRegistry(t)
+			f := &RepoFile{
+				OwningRepo: "pkg",
+				OwningTag:  "v1",
+				Name:       "a.txt",
+			}
+			if _, err := r.AddFile(ctx, f, strings.NewReader(tc.first)); err != nil {
+				t.Fatalf("AddFile() first call error = %v", err)
+			}
+
+			body := &readCounter{src: strings.NewReader(tc.second)}
+			_, err := r.AddFile(ctx, f, body)
+			if !errors.Is(err, ErrAlreadyExists) {
+				t.Fatalf("AddFile() second call error = %v, want ErrAlreadyExists", err)
+			}
+			if body.calls != 0 {
+				t.Errorf("AddFile() rejected re-upload read %d Read call(s), want 0", body.calls)
+			}
+		})
+	}
+}
+
+// TestAddFile_ReuploadAllowedWithOverwrite verifies the opt-in
+// overwrite path: with WithAllowOverwrite(true), a second AddFile to
+// the same name replaces the previous file manifest, and ReadFile
+// subsequently yields the new content. The previous file manifest is
+// unlinked from the version's referrer set so ListFiles reports
+// exactly one entry per filename.
+func TestAddFile_ReuploadAllowedWithOverwrite(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	r, err := NewRegistry(
+		&url.URL{Scheme: "https", Host: "example.com"},
+		WithAllowOverwrite(true),
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	memRepo := &inMemoryRepo{Store: memory.New(), allTags: map[string]string{}}
+	r.newBackendFunc = func(_ context.Context, _ *RepoFile) (destRepo, error) {
+		return memRepo, nil
+	}
+
+	f := &RepoFile{
+		OwningRepo: "pkg",
+		OwningTag:  "v1",
+		Name:       "a.txt",
+	}
+	if _, err := r.AddFile(ctx, f, strings.NewReader("first")); err != nil {
+		t.Fatalf("AddFile() first call error = %v", err)
+	}
+	if _, err := r.AddFile(ctx, f, strings.NewReader("second")); err != nil {
+		t.Fatalf("AddFile() second call error = %v", err)
+	}
+
+	files, err := r.ListFiles(ctx, "pkg")
+	if err != nil {
+		t.Fatalf("ListFiles() error = %v", err)
+	}
+	if got, want := len(files), 1; got != want {
+		t.Fatalf("ListFiles() = %d files, want %d (got: %+v)", got, want, files)
+	}
+
+	_, body, err := r.ReadFile(ctx, f)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	got, _ := io.ReadAll(body)
+	body.Close()
+	if string(got) != "second" {
+		t.Errorf("ReadFile() after overwrite = %q, want %q", got, "second")
+	}
+}
+
+// TestAddFile_ReuploadDistinctNamesNotAffected proves the existence
+// probe scopes its match by Name: a second AddFile with a different
+// filename under the same OwningTag is the normal multi-file case
+// and must succeed even with the default policy.
+func TestAddFile_ReuploadDistinctNamesNotAffected(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	r, _ := newTestRegistry(t)
+
+	if _, err := r.AddFile(ctx, &RepoFile{
+		OwningRepo: "pkg",
+		OwningTag:  "v1",
+		Name:       "a.txt",
+	}, strings.NewReader("a")); err != nil {
+		t.Fatalf("AddFile(a.txt) error = %v", err)
+	}
+	if _, err := r.AddFile(ctx, &RepoFile{
+		OwningRepo: "pkg",
+		OwningTag:  "v1",
+		Name:       "b.txt",
+	}, strings.NewReader("b")); err != nil {
+		t.Fatalf("AddFile(b.txt) error = %v", err)
+	}
+
+	files, err := r.ListFiles(ctx, "pkg")
+	if err != nil {
+		t.Fatalf("ListFiles() error = %v", err)
+	}
+	gotNames := make([]string, 0, len(files))
+	for _, f := range files {
+		gotNames = append(gotNames, f.Name)
+	}
+	slices.Sort(gotNames)
+	if diff := cmp.Diff([]string{"a.txt", "b.txt"}, gotNames); diff != "" {
+		t.Errorf("ListFiles() names mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// readCounter tracks how many times Read is called on the wrapped
+// reader. Used to assert that the rejected-re-upload path returns
+// ErrAlreadyExists before consuming any of the request body.
+type readCounter struct {
+	src   io.Reader
+	calls int
+}
+
+func (r *readCounter) Read(p []byte) (int, error) {
+	r.calls++
+	return r.src.Read(p)
 }


### PR DESCRIPTION
Closes part of #58 — concerns 1 (error sanitization) and 4
(re-upload semantics). Concerns 2 (upload size cap), 3 (path
validation), and 5 (filename rename) already landed in #59 / #63.

Re-upload (concern 4):
- Add oci.ErrAlreadyExists and oci.WithAllowOverwrite. AddFile probes
  the version's file referrers up-front; a same-name match returns
  ErrAlreadyExists without reading any of the request body. The
  byte-untouched property keeps a rejected re-upload from burning
  upload bandwidth on streaming clients.
- Default is reject; --allow-overwrite=true (OCIFACTORY_ALLOW_OVERWRITE)
  re-enables overwrites, in which case the previous file manifest is
  unlinked from the version's referrer set so readers always see one
  match per filename.
- Mirror the semantics in oci.FakeRegistry via AllowOverwrite.
- Translate to 409 Conflict in python (streamAddFile) and maven
  (handlePut) handlers.
- Make the python index-sentinel write conditional on ListTags so
  every package release after the first doesn't 409 against itself.

Error sanitization (concern 1):
- Add handler.WriteError(ctx, w, code, internal, public): logs the
  internal error at ERROR severity and writes only the public
  message to the client. Used for every 5xx in python and maven;
  4xx not-found / unauthorized / forbidden branches keep their
  current public messages (those are not leaky).