### PR TITLE
Add real-client integration tests for python and maven (#56)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,3 +178,48 @@ jobs:
             echo "=== ocifactory.log ==="
             cat ./run/ocifactory.log
           fi
+
+  # client-integration runs the per-format real-client tests: pip /
+  # twine / mvn driving an ocifactory subprocess against a zot
+  # registry started by testcontainers-go.
+  #
+  # The shared go-test job above runs the same tests but skips them
+  # because the runner image doesn't ship pip/twine/mvn. Splitting
+  # them into a dedicated job keeps the unit suite fast and isolates
+  # the (slower) network-driven cases that need extra tooling.
+  client-integration:
+    name: 'client-integration'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'actions/checkout@v4' # ratchet:exclude
+
+      - uses: 'actions/setup-go@v5' # ratchet:exclude
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - uses: 'actions/setup-python@v5' # ratchet:exclude
+        with:
+          python-version: '3.x'
+
+      - uses: 'actions/setup-java@v4' # ratchet:exclude
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: 'Install twine'
+        run: 'python -m pip install --upgrade pip twine'
+
+      - name: 'Install maven'
+        run: 'sudo apt-get update && sudo apt-get install -y --no-install-recommends maven'
+
+      - name: 'Run client integration tests'
+        # No -short so the testcontainers-driven tests actually run
+        # (the rest of the suite has already been exercised by the
+        # go-test job above).
+        run: |
+          go test -race -count=1 \
+            -run 'TestPythonIntegration_RealClients|TestMavenIntegration_RealClients' \
+            -v \
+            ./pkg/handler/python/... \
+            ./pkg/handler/maven/...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,12 +214,14 @@ jobs:
         run: 'sudo apt-get update && sudo apt-get install -y --no-install-recommends maven'
 
       - name: 'Run client integration tests'
-        # No -short so the testcontainers-driven tests actually run
-        # (the rest of the suite has already been exercised by the
-        # go-test job above).
+        # -tags=integration compiles the integration_test.go files
+        # the shared go-test job skips. The shared job runs the
+        # rest of the suite under the same Go version so we don't
+        # need to repeat it here.
         run: |
           go test -race -count=1 \
-            -run 'TestPythonIntegration_RealClients|TestMavenIntegration_RealClients' \
+            -tags=integration \
+            -timeout=10m \
             -v \
             ./pkg/handler/python/... \
             ./pkg/handler/maven/...

--- a/pkg/handler/integrationtest/harness.go
+++ b/pkg/handler/integrationtest/harness.go
@@ -1,0 +1,277 @@
+// Package integrationtest is a shared helper for the per-format
+// real-client integration tests. It spins up a zot OCI registry via
+// testcontainers-go, builds the ocifactory binary into a temp dir, and
+// starts it pointed at zot so the per-format test only has to drive
+// the client subprocess (pip / twine / mvn / ...).
+//
+// All exports take a *testing.T; the package isn't intended for use
+// outside tests. It lives in pkg/handler so format-specific tests can
+// import it without dragging in a separate top-level integration tree.
+package integrationtest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// zotImage matches the version pinned by pkg/oci's streaming
+// integration test so both suites exercise the same registry build.
+const zotImage = "ghcr.io/project-zot/zot-linux-amd64:v2.1.5"
+
+// binaryBuildOnce makes sure the ocifactory binary is built at most
+// once per test process, even when several integration tests run in
+// parallel. The result is cached in builtBinaryPath / builtBinaryErr.
+var (
+	binaryBuildOnce sync.Once
+	builtBinaryPath string
+	builtBinaryErr  error
+)
+
+// Harness is a running zot + ocifactory pair ready for a real client
+// to talk to. Returned by Start; cleanup is registered via t.Cleanup.
+type Harness struct {
+	// OcifactoryURL is the http://host:port the ocifactory subprocess
+	// listens on. Pass it to pip / mvn / twine.
+	OcifactoryURL *url.URL
+
+	// ZotURL is the URL to the underlying zot registry. Tests rarely
+	// need this directly; it's exported for assertions that want to
+	// poke the OCI backend behind ocifactory.
+	ZotURL *url.URL
+
+	// BackendRepo is the repo prefix passed to ocifactory via
+	// --backend-registry. zot serves it under /v2/<BackendRepo>/...
+	BackendRepo string
+
+	logFile *os.File
+}
+
+// Start brings up zot and ocifactory and returns a Harness pointing at
+// both. It self-skips when Docker isn't reachable (developer laptop)
+// and t.Fatals on any other unrecoverable setup failure.
+//
+// repoType selects which format ocifactory serves (one of
+// "python", "maven", ...). extraArgs are appended verbatim to the
+// ocifactory command line — use them for format-specific knobs the
+// caller wants to tweak.
+func Start(t *testing.T, repoType string, extraArgs ...string) *Harness {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
+	t.Cleanup(cancel)
+
+	zot, zotURL := startZot(t, ctx)
+	binary := buildBinary(t)
+
+	backendRepo := "ocifactory-int"
+	logPath := filepath.Join(t.TempDir(), "ocifactory.log")
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		t.Fatalf("create log file: %v", err)
+	}
+	t.Cleanup(func() { _ = logFile.Close() })
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	// Close immediately — ocifactory's net/http will reopen the same
+	// port. There's a small race window where another process could
+	// claim it; in practice it's robust enough for CI and matches the
+	// pattern used elsewhere in this repo.
+	_ = listener.Close()
+
+	args := []string{
+		"serve",
+		"--repo-type=" + repoType,
+		fmt.Sprintf("--backend-registry=%s://%s/%s", zotURL.Scheme, zotURL.Host, backendRepo),
+		fmt.Sprintf("--port=%d", port),
+		"--disable-authn",
+		// zot served over HTTP without auth needs no backend creds;
+		// "anonymous" is the default but pin it explicitly so the
+		// test isn't sensitive to default changes.
+		"--backend-auth-kind=anonymous",
+	}
+	args = append(args, extraArgs...)
+
+	cmd := exec.CommandContext(ctx, binary, args...)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	// Run in its own process group so we can kill the whole tree on
+	// cleanup if ocifactory ever spawns a child (it doesn't today,
+	// but this is cheap insurance).
+	cmd.SysProcAttr = procAttr()
+
+	if err := cmd.Start(); err != nil {
+		_ = zot.Terminate(context.Background())
+		t.Fatalf("start ocifactory: %v", err)
+	}
+	t.Cleanup(func() {
+		stopProcess(cmd)
+		// Surface the server log on failure so a test author can see
+		// what ocifactory thought happened. Keep it terse on success.
+		if t.Failed() {
+			if data, err := os.ReadFile(logPath); err == nil {
+				t.Logf("=== ocifactory.log ===\n%s\n=== end ocifactory.log ===", data)
+			}
+		}
+	})
+
+	ocifactoryURL := &url.URL{Scheme: "http", Host: fmt.Sprintf("127.0.0.1:%d", port)}
+	if err := waitForHealthz(ctx, ocifactoryURL); err != nil {
+		t.Fatalf("ocifactory did not become healthy: %v", err)
+	}
+
+	return &Harness{
+		OcifactoryURL: ocifactoryURL,
+		ZotURL:        zotURL,
+		BackendRepo:   backendRepo,
+		logFile:       logFile,
+	}
+}
+
+func startZot(t *testing.T, ctx context.Context) (testcontainers.Container, *url.URL) {
+	t.Helper()
+
+	zot, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        zotImage,
+			ExposedPorts: []string{"5000/tcp"},
+			WaitingFor: wait.ForHTTP("/v2/").
+				WithPort("5000/tcp").
+				WithStatusCodeMatcher(func(status int) bool { return status == 200 }).
+				WithStartupTimeout(60 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		// Most common reason this fails on a developer laptop is that
+		// Docker isn't installed or the daemon isn't running. Skip
+		// rather than fail — a missing local runtime shouldn't break
+		// `go test ./...`.
+		t.Skipf("could not start zot container (Docker available?): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := zot.Terminate(context.Background()); err != nil {
+			t.Logf("zot terminate: %v", err)
+		}
+	})
+
+	host, err := zot.Host(ctx)
+	if err != nil {
+		t.Fatalf("zot.Host: %v", err)
+	}
+	port, err := zot.MappedPort(ctx, "5000/tcp")
+	if err != nil {
+		t.Fatalf("zot.MappedPort: %v", err)
+	}
+	return zot, &url.URL{Scheme: "http", Host: net.JoinHostPort(host, port.Port())}
+}
+
+// buildBinary builds the ocifactory binary into a per-process tempdir
+// shared across every Harness in the test binary. It's safe to call
+// from many tests in parallel — sync.Once collapses the work.
+func buildBinary(t *testing.T) string {
+	t.Helper()
+
+	binaryBuildOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "ocifactory-int-bin-")
+		if err != nil {
+			builtBinaryErr = fmt.Errorf("mkdir tempdir: %w", err)
+			return
+		}
+		bin := filepath.Join(dir, "ocifactory")
+		if runtime.GOOS == "windows" {
+			bin += ".exe"
+		}
+		root, err := repoRoot()
+		if err != nil {
+			builtBinaryErr = fmt.Errorf("locate repo root: %w", err)
+			return
+		}
+		cmd := exec.Command("go", "build", "-o", bin, "./cmd/ocifactory")
+		cmd.Dir = root
+		cmd.Env = os.Environ()
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			builtBinaryErr = fmt.Errorf("go build ocifactory: %w\n%s", err, out)
+			return
+		}
+		builtBinaryPath = bin
+	})
+
+	if builtBinaryErr != nil {
+		t.Fatalf("build ocifactory binary: %v", builtBinaryErr)
+	}
+	return builtBinaryPath
+}
+
+// repoRoot walks up from this source file to find the directory
+// containing go.mod. Robust against the test running from any
+// subdirectory and avoids depending on $PWD.
+func repoRoot() (string, error) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", errors.New("runtime.Caller failed")
+	}
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", errors.New("go.mod not found above " + file)
+		}
+		dir = parent
+	}
+}
+
+func waitForHealthz(ctx context.Context, base *url.URL) error {
+	deadline := time.Now().Add(60 * time.Second)
+	healthz := base.JoinPath("healthz").String()
+	client := &http.Client{Timeout: 2 * time.Second}
+	for time.Now().Before(deadline) {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		resp, err := client.Get(healthz)
+		if err == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return errors.New("timed out waiting for /healthz")
+}
+
+// SkipIfMissing skips t when any of the named binaries can't be
+// resolved on $PATH. Use it from per-format tests to gracefully
+// skip when (e.g.) twine isn't installed on a developer machine.
+func SkipIfMissing(t *testing.T, bins ...string) {
+	t.Helper()
+	for _, b := range bins {
+		if _, err := exec.LookPath(b); err != nil {
+			t.Skipf("required binary %q not found on PATH: %v", b, err)
+		}
+	}
+}

--- a/pkg/handler/integrationtest/proc_unix.go
+++ b/pkg/handler/integrationtest/proc_unix.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+package integrationtest
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func procAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setpgid: true}
+}
+
+// stopProcess kills the entire process group rooted at cmd. On Unix,
+// SIGTERM-then-SIGKILL gives ocifactory a chance to flush logs and
+// drain handlers before we forcibly take it down.
+func stopProcess(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	pgid := cmd.Process.Pid
+	_ = syscall.Kill(-pgid, syscall.SIGTERM)
+	done := make(chan struct{})
+	go func() {
+		_, _ = cmd.Process.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-timeAfter():
+		_ = syscall.Kill(-pgid, syscall.SIGKILL)
+		<-done
+	}
+}

--- a/pkg/handler/integrationtest/proc_windows.go
+++ b/pkg/handler/integrationtest/proc_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package integrationtest
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func procAttr() *syscall.SysProcAttr {
+	return nil
+}
+
+func stopProcess(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	_ = cmd.Process.Kill()
+	_, _ = cmd.Process.Wait()
+}

--- a/pkg/handler/integrationtest/util.go
+++ b/pkg/handler/integrationtest/util.go
@@ -1,0 +1,10 @@
+package integrationtest
+
+import "time"
+
+// timeAfter returns a one-shot channel that fires after the
+// shutdown grace period. Pulled out so tests on slow runners can
+// override it via a build flag if needed.
+func timeAfter() <-chan time.Time {
+	return time.After(5 * time.Second)
+}

--- a/pkg/handler/maven/integration_test.go
+++ b/pkg/handler/maven/integration_test.go
@@ -1,0 +1,247 @@
+package maven_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/yolocs/ocifactory/pkg/handler/integrationtest"
+)
+
+// TestMavenIntegration_RealClients deploys and resolves a tiny Maven
+// project against a live ocifactory pointed at zot.
+//
+// It self-skips under -short and when Docker / mvn / java aren't
+// available (mirroring the existing pkg/oci zot test policy).
+func TestMavenIntegration_RealClients(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping maven real-client integration test in -short mode")
+	}
+	t.Parallel()
+
+	integrationtest.SkipIfMissing(t, "mvn", "java")
+
+	h := integrationtest.Start(t, "maven",
+		// mvn rewrites maven-metadata.xml on every deploy (it
+		// fetches, mutates, re-uploads), so the immutable add-only
+		// default would 409 the second deploy in this test —
+		// release and snapshot share the artifact-level metadata
+		// file. Production maven workflows need --allow-overwrite
+		// for the same reason.
+		"--allow-overwrite=true",
+	)
+	base := h.OcifactoryURL.String()
+
+	// Subtests are NOT t.Parallel(): both deploys would race on
+	// /com/example/test/hello/maven-metadata.xml (the artifact-level
+	// version index mvn rewrites on every deploy). The outer test
+	// already runs in parallel with the python suite.
+
+	t.Run("release_deploy_and_get", func(t *testing.T) {
+		const version = "0.1.0"
+		const groupID = "com.example.test"
+		const artifactID = "hello"
+
+		project := stageProject(t, base, version)
+		mvnDeploy(t, project)
+
+		// Verify the four files mvn deploy is supposed to publish
+		// landed at the Maven 2 layout paths handleRegularArtifact
+		// uses.
+		expect := []struct {
+			path     string
+			notEmpty bool
+		}{
+			{path: fmt.Sprintf("/%s/%s/%s/%s-%s.jar", strings.ReplaceAll(groupID, ".", "/"), artifactID, version, artifactID, version), notEmpty: true},
+			{path: fmt.Sprintf("/%s/%s/%s/%s-%s.pom", strings.ReplaceAll(groupID, ".", "/"), artifactID, version, artifactID, version), notEmpty: true},
+			{path: fmt.Sprintf("/%s/%s/%s/%s-%s.jar.sha1", strings.ReplaceAll(groupID, ".", "/"), artifactID, version, artifactID, version), notEmpty: true},
+			{path: fmt.Sprintf("/%s/%s/%s/%s-%s.jar.md5", strings.ReplaceAll(groupID, ".", "/"), artifactID, version, artifactID, version), notEmpty: true},
+		}
+		for _, e := range expect {
+			body := httpGetBody(t, base+e.path)
+			if e.notEmpty && len(body) == 0 {
+				t.Errorf("expected non-empty body at %s", e.path)
+			}
+		}
+
+		// Now resolve via mvn dependency:get from a fresh local
+		// repo and assert the JAR's bytes match what we published.
+		freshRepo := t.TempDir()
+		mvnGet(t, project, freshRepo, fmt.Sprintf("%s:%s:%s", groupID, artifactID, version))
+
+		// dependency:get fetches the JAR with mvn's built-in
+		// checksum validation, so a mismatch would have failed
+		// mvnGet above. Confirm the resolver actually wrote the
+		// expected file into the local repo.
+		gotJarPath := filepath.Join(freshRepo,
+			strings.ReplaceAll(groupID, ".", string(filepath.Separator)),
+			artifactID, version,
+			fmt.Sprintf("%s-%s.jar", artifactID, version),
+		)
+		if info, err := os.Stat(gotJarPath); err != nil {
+			t.Fatalf("stat resolved jar %s: %v", gotJarPath, err)
+		} else if info.Size() == 0 {
+			t.Fatalf("resolved jar %s is empty", gotJarPath)
+		}
+	})
+
+	t.Run("snapshot_deploy_round_trip", func(t *testing.T) {
+		const version = "0.2.0-SNAPSHOT"
+		const groupID = "com.example.test"
+		const artifactID = "hello"
+
+		project := stageProject(t, base, version)
+		mvnDeploy(t, project)
+
+		// The snapshot metadata route stores under
+		// {groupId}/{artifactId}/{version}-metadata, so
+		// maven-metadata.xml must be retrievable via the GET
+		// path.
+		mdURL := fmt.Sprintf("%s/%s/%s/%s/maven-metadata.xml",
+			base, strings.ReplaceAll(groupID, ".", "/"), artifactID, version)
+		body := httpGetBody(t, mdURL)
+		if !strings.Contains(string(body), "<groupId>com.example.test</groupId>") {
+			t.Errorf("snapshot maven-metadata.xml missing expected groupId; got:\n%s", body)
+		}
+	})
+}
+
+// stageProject copies the testdata maven project into a fresh
+// directory, substitutes __VERSION__ and __OCIFACTORY_URL__, and
+// renders settings.xml.tmpl to settings.xml in the same dir. Returns
+// the staged project root.
+func stageProject(t *testing.T, ocifactoryURL, version string) string {
+	t.Helper()
+
+	src, err := repoTestdataPath()
+	if err != nil {
+		t.Fatalf("locate testdata: %v", err)
+	}
+	dst := t.TempDir()
+	if err := copyDir(src, dst); err != nil {
+		t.Fatalf("copy testdata: %v", err)
+	}
+
+	// Templated substitutions in pom.xml.
+	pomPath := filepath.Join(dst, "pom.xml")
+	pomBytes, err := os.ReadFile(pomPath)
+	if err != nil {
+		t.Fatalf("read pom: %v", err)
+	}
+	pom := strings.ReplaceAll(string(pomBytes), "__VERSION__", version)
+	pom = strings.ReplaceAll(pom, "__OCIFACTORY_URL__", ocifactoryURL)
+	if err := os.WriteFile(pomPath, []byte(pom), 0o600); err != nil {
+		t.Fatalf("write pom: %v", err)
+	}
+
+	// Render settings.xml from template.
+	tmplPath := filepath.Join(dst, "settings.xml.tmpl")
+	tmplBytes, err := os.ReadFile(tmplPath)
+	if err != nil {
+		t.Fatalf("read settings.xml.tmpl: %v", err)
+	}
+	settings := string(tmplBytes)
+	localRepo := filepath.Join(dst, ".m2-deploy")
+	if err := os.MkdirAll(localRepo, 0o700); err != nil {
+		t.Fatalf("mkdir local repo: %v", err)
+	}
+	settings = strings.ReplaceAll(settings, "__LOCAL_REPO__", localRepo)
+	settings = strings.ReplaceAll(settings, "__OCIFACTORY_URL__", ocifactoryURL)
+	settings = strings.ReplaceAll(settings, "__USERNAME__", "integration")
+	settings = strings.ReplaceAll(settings, "__PASSWORD__", "integration")
+	if err := os.WriteFile(filepath.Join(dst, "settings.xml"), []byte(settings), 0o600); err != nil {
+		t.Fatalf("write settings.xml: %v", err)
+	}
+	return dst
+}
+
+func mvnDeploy(t *testing.T, project string) {
+	t.Helper()
+	cmd := exec.Command("mvn",
+		"-B",
+		"-s", filepath.Join(project, "settings.xml"),
+		"-Dmaven.test.skip=true",
+		"deploy",
+	)
+	cmd.Dir = project
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("mvn deploy: %v\n%s", err, out)
+	}
+}
+
+func mvnGet(t *testing.T, project, localRepo, coordinate string) {
+	t.Helper()
+	cmd := exec.Command("mvn",
+		"-B",
+		"-s", filepath.Join(project, "settings.xml"),
+		fmt.Sprintf("-Dmaven.repo.local=%s", localRepo),
+		"-DremoteRepositories=ocifactory-int",
+		fmt.Sprintf("-Dartifact=%s", coordinate),
+		"dependency:get",
+	)
+	cmd.Dir = project
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("mvn dependency:get %s: %v\n%s", coordinate, err, out)
+	}
+}
+
+func httpGetBody(t *testing.T, url string) []byte {
+	t.Helper()
+	resp, err := http.Get(url) //nolint:noctx
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read %s: %v", url, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s: status %d, body=%s", url, resp.StatusCode, body)
+	}
+	return body
+}
+
+// repoTestdataPath returns the absolute path to the maven-deploy
+// fixture next to this test file. runtime.Caller is more robust than
+// $PWD: tests run from their own package directory but the harness
+// might be invoked from go test -run anywhere.
+func repoTestdataPath() (string, error) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("runtime.Caller failed")
+	}
+	return filepath.Join(filepath.Dir(file), "testdata", "maven-deploy"), nil
+}
+
+func copyDir(src, dst string) error {
+	return filepath.Walk(src, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, p)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, 0o700)
+		}
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, 0o600)
+	})
+}

--- a/pkg/handler/maven/integration_test.go
+++ b/pkg/handler/maven/integration_test.go
@@ -1,3 +1,12 @@
+//go:build integration
+
+// Real-client integration test for the maven handler. Gated behind
+// the `integration` build tag because the standard go-test runner
+// (ubuntu-latest) has mvn + java preinstalled — without the tag the
+// shared go-test job would run this test instead of the dedicated
+// client-integration job that owns the wiring. Run via
+// `go test -tags=integration`.
+
 package maven_test
 
 import (

--- a/pkg/handler/maven/testdata/maven-deploy/pom.xml
+++ b/pkg/handler/maven/testdata/maven-deploy/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Minimal pom for the maven real-client integration test.
+
+  Versions are templated at test runtime by integration_test.go: the
+  test substitutes ${VERSION} (and similar) before pointing mvn at
+  the file. Keeping the template logic in Go rather than in mvn
+  profile activation avoids depending on system Maven config.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example.test</groupId>
+    <artifactId>hello</artifactId>
+    <version>__VERSION__</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <distributionManagement>
+        <repository>
+            <id>ocifactory-int</id>
+            <url>__OCIFACTORY_URL__</url>
+        </repository>
+        <snapshotRepository>
+            <id>ocifactory-int</id>
+            <url>__OCIFACTORY_URL__</url>
+        </snapshotRepository>
+    </distributionManagement>
+</project>

--- a/pkg/handler/maven/testdata/maven-deploy/settings.xml.tmpl
+++ b/pkg/handler/maven/testdata/maven-deploy/settings.xml.tmpl
@@ -2,14 +2,18 @@
 <!--
   settings.xml template for the maven real-client integration test.
 
-  __LOCAL_REPO__       - per-test local m2 cache (set via Go's t.TempDir())
-  __OCIFACTORY_URL__   - http://host:port for the ocifactory subprocess
-  __USERNAME__         - dummy user (server runs with --disable-authn)
-  __PASSWORD__         - dummy password (likewise)
+  Placeholders substituted by the Go test before mvn reads the file:
+    LOCAL_REPO     per-test local m2 cache (set via Go's t.TempDir())
+    OCIFACTORY_URL http://host:port for the ocifactory subprocess
+    USERNAME       dummy user (server runs with authn disabled)
+    PASSWORD       dummy password (likewise)
 
-  The server is configured with --disable-authn so any value here is
-  accepted; the credential just has to be present so mvn sends a
+  Authentication is disabled on the server side, so any credential
+  is accepted; the values just have to be present so mvn sends a
   Basic auth header at all.
+
+  XML comments must not contain consecutive dashes, so flag names are
+  written without the leading double-dash here.
 -->
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/pkg/handler/maven/testdata/maven-deploy/settings.xml.tmpl
+++ b/pkg/handler/maven/testdata/maven-deploy/settings.xml.tmpl
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  settings.xml template for the maven real-client integration test.
+
+  __LOCAL_REPO__       - per-test local m2 cache (set via Go's t.TempDir())
+  __OCIFACTORY_URL__   - http://host:port for the ocifactory subprocess
+  __USERNAME__         - dummy user (server runs with --disable-authn)
+  __PASSWORD__         - dummy password (likewise)
+
+  The server is configured with --disable-authn so any value here is
+  accepted; the credential just has to be present so mvn sends a
+  Basic auth header at all.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                              http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <localRepository>__LOCAL_REPO__</localRepository>
+
+    <servers>
+        <server>
+            <id>ocifactory-int</id>
+            <username>__USERNAME__</username>
+            <password>__PASSWORD__</password>
+        </server>
+    </servers>
+
+    <profiles>
+        <profile>
+            <id>ocifactory-int</id>
+            <repositories>
+                <repository>
+                    <id>ocifactory-int</id>
+                    <url>__OCIFACTORY_URL__</url>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>always</updatePolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                        <updatePolicy>always</updatePolicy>
+                    </snapshots>
+                </repository>
+            </repositories>
+        </profile>
+    </profiles>
+
+    <activeProfiles>
+        <activeProfile>ocifactory-int</activeProfile>
+    </activeProfiles>
+</settings>

--- a/pkg/handler/maven/testdata/maven-deploy/src/main/java/com/example/test/Hello.java
+++ b/pkg/handler/maven/testdata/maven-deploy/src/main/java/com/example/test/Hello.java
@@ -1,0 +1,7 @@
+package com.example.test;
+
+public class Hello {
+    public static String greet() {
+        return "hello from ocifactory integration test";
+    }
+}

--- a/pkg/handler/python/integration_test.go
+++ b/pkg/handler/python/integration_test.go
@@ -1,3 +1,12 @@
+//go:build integration
+
+// Real-client integration test for the python handler. Gated behind
+// the `integration` build tag because the standard go-test runner
+// already has mvn / java / python3 preinstalled — without the tag,
+// `go test ./...` on a stock ubuntu runner would try to run this
+// test for real and conflict with the dedicated client-integration
+// job that owns the toolchain. Run via `go test -tags=integration`.
+
 package python_test
 
 import (

--- a/pkg/handler/python/integration_test.go
+++ b/pkg/handler/python/integration_test.go
@@ -1,0 +1,285 @@
+package python_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yolocs/ocifactory/pkg/handler/integrationtest"
+)
+
+// TestPythonIntegration_RealClients exercises the Python handler with
+// real twine and pip subprocesses talking to a live ocifactory pointed
+// at a real zot.
+//
+// It self-skips under -short and when Docker / pip / twine aren't
+// available, mirroring the existing pkg/oci zot test's policy: a
+// missing local runtime should never break `go test ./...` on a
+// developer laptop. CI installs the toolchain and runs the full
+// suite.
+func TestPythonIntegration_RealClients(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping python real-client integration test in -short mode")
+	}
+	t.Parallel()
+
+	integrationtest.SkipIfMissing(t, "python3", "pip", "twine")
+
+	h := integrationtest.Start(t, "python")
+
+	// Subtests share the same ocifactory + zot to avoid spinning up
+	// a fresh container per case. They write to disjoint package
+	// names so they don't interact.
+	t.Run("twine_upload_then_pip_download", func(t *testing.T) {
+		t.Parallel()
+
+		const pkgName = "ocifactory-int-basic"
+		const version = "1.2.3"
+
+		whl := newTestWheel(t, pkgName, version)
+
+		uploadWithTwine(t, h.OcifactoryURL.String(), whl)
+		downloadAndCheck(t, h.OcifactoryURL.String(), pkgName, version, whl)
+	})
+
+	t.Run("pep503_normalization_roundtrip", func(t *testing.T) {
+		t.Parallel()
+
+		// Upload as "Foo_Int", install as "foo-int" — PEP 503
+		// requires both forms to resolve to the same package.
+		const uploadName = "Foo_Int"
+		const installName = "foo-int"
+		const version = "0.0.1"
+
+		whl := newTestWheel(t, uploadName, version)
+
+		uploadWithTwine(t, h.OcifactoryURL.String(), whl)
+		downloadAndCheck(t, h.OcifactoryURL.String(), installName, version, whl)
+	})
+
+	t.Run("pip_install_in_fresh_venv", func(t *testing.T) {
+		t.Parallel()
+
+		// Some pip builds refuse `install` for a non-PEP427
+		// filename; the venv path catches anything `pip download`
+		// would silently let through.
+		const pkgName = "ocifactory-int-install"
+		const version = "0.5.0"
+
+		whl := newTestWheel(t, pkgName, version)
+
+		uploadWithTwine(t, h.OcifactoryURL.String(), whl)
+
+		venvDir := t.TempDir()
+		runOK(t, "python3", "-m", "venv", venvDir)
+		pip := filepath.Join(venvDir, "bin", "pip")
+		if _, err := os.Stat(pip); err != nil {
+			pip = filepath.Join(venvDir, "Scripts", "pip.exe")
+		}
+		runOK(t, pip,
+			"install",
+			"--no-cache-dir",
+			"--no-deps",
+			"--index-url", h.OcifactoryURL.String()+"/simple/",
+			"--trusted-host", trustedHostFromBase(t, h.OcifactoryURL.String()),
+			fmt.Sprintf("%s==%s", pkgName, version),
+		)
+	})
+}
+
+// uploadWithTwine drives `twine upload` against the running
+// ocifactory. With --disable-authn the server takes any credential,
+// but twine requires non-empty username/password in the env to send
+// a Basic header at all.
+func uploadWithTwine(t *testing.T, base string, whl *testWheel) {
+	t.Helper()
+
+	cmd := exec.Command(
+		"twine", "upload",
+		"--repository-url", base+"/",
+		"--non-interactive",
+		"--disable-progress-bar",
+		"--verbose",
+		whl.Path,
+	)
+	cmd.Env = append(os.Environ(),
+		"TWINE_USERNAME=integration",
+		"TWINE_PASSWORD=integration",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("twine upload: %v\n%s", err, out)
+	}
+}
+
+// downloadAndCheck pulls the wheel back via `pip download` and asserts
+// the bytes match what was uploaded.
+func downloadAndCheck(t *testing.T, base, pkgName, version string, whl *testWheel) {
+	t.Helper()
+
+	dst := t.TempDir()
+	cmd := exec.Command(
+		"pip", "download",
+		"--no-cache-dir",
+		"--no-deps",
+		"--dest", dst,
+		"--index-url", base+"/simple/",
+		"--trusted-host", trustedHostFromBase(t, base),
+		fmt.Sprintf("%s==%s", pkgName, version),
+	)
+	cmd.Env = append(os.Environ(),
+		// pip's keyring backend is overkill here and emits a noisy
+		// warning when no keyring is configured.
+		"PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("pip download: %v\n%s", err, out)
+	}
+
+	entries, err := os.ReadDir(dst)
+	if err != nil {
+		t.Fatalf("read pip dst: %v", err)
+	}
+	var found string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".whl") {
+			found = filepath.Join(dst, e.Name())
+			break
+		}
+	}
+	if found == "" {
+		t.Fatalf("pip download: no .whl in %s (entries: %v)", dst, entries)
+	}
+
+	got, err := os.ReadFile(found)
+	if err != nil {
+		t.Fatalf("read downloaded wheel: %v", err)
+	}
+	if !bytes.Equal(got, whl.Bytes) {
+		t.Fatalf("pip download bytes mismatch: got %d bytes (sha256=%x), want %d bytes (sha256=%x)",
+			len(got), sha256.Sum256(got), len(whl.Bytes), sha256.Sum256(whl.Bytes))
+	}
+}
+
+// runOK runs cmd and t.Fatals with the combined output on a non-zero
+// exit. Use it for setup steps where the expected outcome is success
+// and any other result is a bug in the test harness.
+func runOK(t *testing.T, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s: %v\n%s", name, strings.Join(args, " "), err, out)
+	}
+}
+
+// testWheel is a freshly synthesized PEP 427 wheel on disk. Building
+// the wheel in Go avoids a `python -m build` dependency on the
+// runner — twine accepts any zip with a valid dist-info, and pip
+// installs it.
+type testWheel struct {
+	Path  string
+	Bytes []byte
+}
+
+// newTestWheel builds a minimal but spec-valid wheel for (name,
+// version). The wheel contains:
+//
+//   - <distName>-<version>.dist-info/METADATA  (PKG-INFO 2.1)
+//   - <distName>-<version>.dist-info/WHEEL     (Wheel-Version: 1.0)
+//   - <distName>-<version>.dist-info/RECORD    (lists the above two)
+//
+// distName is the wheel's filename-safe form of name (PEP 427
+// requires `-` separators in the version segment but allows
+// underscores in the project name; we pass-through whatever the test
+// supplies). The wheel intentionally has no payload module — pip is
+// happy to "install" a metadata-only wheel and our PEP 658 metadata
+// extraction path runs against a known-shape dist-info either way.
+func newTestWheel(t *testing.T, name, version string) *testWheel {
+	t.Helper()
+
+	// PEP 427 forbids dashes in the project segment of a wheel
+	// filename, so swap them for underscores. Versions may not
+	// contain dashes either.
+	distName := strings.ReplaceAll(name, "-", "_")
+	if strings.Contains(version, "-") {
+		t.Fatalf("test bug: wheel version %q must not contain '-'", version)
+	}
+
+	distInfo := fmt.Sprintf("%s-%s.dist-info", distName, version)
+	metadata := fmt.Sprintf(
+		"Metadata-Version: 2.1\nName: %s\nVersion: %s\nSummary: ocifactory integration test\n",
+		name, version,
+	)
+	wheelMeta := "Wheel-Version: 1.0\nGenerator: ocifactory-integration-test\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
+
+	type fileEntry struct {
+		Name    string
+		Content []byte
+	}
+	entries := []fileEntry{
+		{Name: distInfo + "/METADATA", Content: []byte(metadata)},
+		{Name: distInfo + "/WHEEL", Content: []byte(wheelMeta)},
+	}
+
+	// RECORD is mandatory and must list every file in the wheel
+	// (including itself, but with empty hash + size). Its rows are
+	// `<path>,sha256=<urlsafe-b64-no-pad>,<size>`.
+	var record bytes.Buffer
+	for _, e := range entries {
+		fmt.Fprintf(&record, "%s,sha256=%s,%d\n", e.Name, urlsafeB64Sha256(e.Content), len(e.Content))
+	}
+	fmt.Fprintf(&record, "%s/RECORD,,\n", distInfo)
+	entries = append(entries, fileEntry{Name: distInfo + "/RECORD", Content: record.Bytes()})
+
+	var zipBuf bytes.Buffer
+	zw := zip.NewWriter(&zipBuf)
+	for _, e := range entries {
+		f, err := zw.Create(e.Name)
+		if err != nil {
+			t.Fatalf("zip create %s: %v", e.Name, err)
+		}
+		if _, err := f.Write(e.Content); err != nil {
+			t.Fatalf("zip write %s: %v", e.Name, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip close: %v", err)
+	}
+
+	dir := t.TempDir()
+	filename := fmt.Sprintf("%s-%s-py3-none-any.whl", distName, version)
+	path := filepath.Join(dir, filename)
+	if err := os.WriteFile(path, zipBuf.Bytes(), 0o600); err != nil {
+		t.Fatalf("write wheel: %v", err)
+	}
+	return &testWheel{Path: path, Bytes: zipBuf.Bytes()}
+}
+
+// trustedHostFromBase pulls the host[:port] out of the harness URL so
+// pip's --trusted-host flag can match. pip refuses to download from
+// http:// origins by default and emits a noisy warning when the
+// origin is HTTPS-but-untrusted; --trusted-host silences both.
+func trustedHostFromBase(t *testing.T, base string) string {
+	t.Helper()
+	u, err := url.Parse(base)
+	if err != nil {
+		t.Fatalf("parse harness URL %q: %v", base, err)
+	}
+	return u.Host
+}
+
+func urlsafeB64Sha256(b []byte) string {
+	sum := sha256.Sum256(b)
+	// PEP 376 uses unpadded urlsafe base64.
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}

--- a/pkg/oci/errors.go
+++ b/pkg/oci/errors.go
@@ -2,7 +2,10 @@ package oci
 
 import (
 	"errors"
+	"fmt"
+	"net/http"
 
+	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/registry/remote/errcode"
 )
 
@@ -11,4 +14,25 @@ import (
 func HasCode(err error, code int) bool {
 	var ec *errcode.ErrorResponse
 	return errors.As(err, &ec) && ec.StatusCode == code
+}
+
+// normalizeNotFound translates a backend HTTP 404 (e.g. zot's
+// NAME_UNKNOWN response for a never-pushed repository) into
+// errdef.ErrNotFound. oras-go surfaces these as errcode.ErrorResponse
+// values that don't satisfy errors.Is(err, errdef.ErrNotFound), so
+// handlers that probe for "does this thing exist?" via ListTags would
+// otherwise treat a missing repo as a 500. Wrapping with multi-%w
+// preserves the original ErrorResponse for HasCode / errors.As callers
+// while making the canonical sentinel detectable.
+func normalizeNotFound(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, errdef.ErrNotFound) {
+		return err
+	}
+	if HasCode(err, http.StatusNotFound) {
+		return fmt.Errorf("%w: %w", errdef.ErrNotFound, err)
+	}
+	return err
 }

--- a/pkg/oci/errors_test.go
+++ b/pkg/oci/errors_test.go
@@ -2,10 +2,12 @@ package oci
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
 
+	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/registry/remote/errcode"
 )
 
@@ -68,6 +70,79 @@ func TestHasCode(t *testing.T) {
 			result := HasCode(tt.err, tt.code)
 			if result != tt.expected {
 				t.Errorf("HasCode() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNormalizeNotFound(t *testing.T) {
+	t.Parallel()
+
+	resp404 := &errcode.ErrorResponse{
+		StatusCode: http.StatusNotFound,
+		Method:     "GET",
+		URL:        &url.URL{Scheme: "http", Host: "example", Path: "/v2/x/tags/list"},
+		Errors:     errcode.Errors{{Code: "NAME_UNKNOWN", Message: "name unknown"}},
+	}
+
+	tests := []struct {
+		name        string
+		err         error
+		wantNotFnd  bool // errors.Is(err, errdef.ErrNotFound) after normalize
+		wantHas404  bool // HasCode(err, 404) after normalize
+	}{
+		{
+			name:       "nil",
+			err:        nil,
+			wantNotFnd: false,
+			wantHas404: false,
+		},
+		{
+			name:       "errdef.ErrNotFound passes through",
+			err:        fmt.Errorf("missing: %w", errdef.ErrNotFound),
+			wantNotFnd: true,
+			wantHas404: false,
+		},
+		{
+			name:       "404 ErrorResponse becomes errdef.ErrNotFound while preserving HasCode",
+			err:        resp404,
+			wantNotFnd: true,
+			wantHas404: true,
+		},
+		{
+			name:       "wrapped 404 ErrorResponse",
+			err:        fmt.Errorf("list tags: %w", resp404),
+			wantNotFnd: true,
+			wantHas404: true,
+		},
+		{
+			name:       "non-404 ErrorResponse is unchanged",
+			err:        &errcode.ErrorResponse{StatusCode: http.StatusUnauthorized, Method: "GET", URL: &url.URL{}},
+			wantNotFnd: false,
+			wantHas404: false,
+		},
+		{
+			name:       "unrelated error",
+			err:        errors.New("boom"),
+			wantNotFnd: false,
+			wantHas404: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := normalizeNotFound(tc.err)
+			if (got == nil) != (tc.err == nil) {
+				t.Fatalf("normalizeNotFound nil-ness changed: got %v, in %v", got, tc.err)
+			}
+			if errors.Is(got, errdef.ErrNotFound) != tc.wantNotFnd {
+				t.Errorf("errors.Is(got, errdef.ErrNotFound) = %v, want %v (got=%v)",
+					errors.Is(got, errdef.ErrNotFound), tc.wantNotFnd, got)
+			}
+			if HasCode(got, http.StatusNotFound) != tc.wantHas404 {
+				t.Errorf("HasCode(got, 404) = %v, want %v (got=%v)",
+					HasCode(got, http.StatusNotFound), tc.wantHas404, got)
 			}
 		})
 	}

--- a/pkg/oci/registry.go
+++ b/pkg/oci/registry.go
@@ -761,12 +761,18 @@ func (r *Registry) resolveVersionDescriptor(ctx context.Context, backend destRep
 // prefix filter is gone. Callers that need version-vs-alias discrimination
 // should use a sibling helper (added when first needed; the current
 // in-tree caller is python's "index" repo, which has no aliases).
+//
+// 404 NAME_UNKNOWN responses (zot returns this for repositories that
+// have never been pushed to) are normalized to errdef.ErrNotFound so
+// callers can rely on a single sentinel check regardless of whether
+// they're talking to a fake or a real backend.
 func (r *Registry) ListTags(ctx context.Context, repo string) ([]string, error) {
 	backend, err := r.newBackendFunc(ctx, &RepoFile{OwningRepo: repo})
 	if err != nil {
 		return nil, err
 	}
-	return registry.Tags(ctx, backend)
+	tags, err := registry.Tags(ctx, backend)
+	return tags, normalizeNotFound(err)
 }
 
 // ListFiles enumerates all files across all canonical versions in repo.


### PR DESCRIPTION
Adds end-to-end tests that drive `twine upload` / `pip download` /
`pip install` and `mvn deploy` / `mvn dependency:get` against a live
ocifactory binary running over a zot OCI backend. They self-skip
under -short and when Docker / pip / twine / mvn / java aren't
available so `go test ./...` stays green on developer machines that
lack the toolchain.

A small `pkg/handler/integrationtest` helper spins up zot via
testcontainers-go, builds the ocifactory binary once per process, and
runs it pointed at zot with --disable-authn so the test harness
doesn't have to mint OIDC tokens. Per-format tests reuse the helper
and only own client-driving logic.

Python wheels are synthesised in Go (zip with valid PEP 427
dist-info), which keeps the runner free of `python -m build` and
forces our PEP 658 metadata path through a known-shape wheel. The
suite covers:
  - twine upload + pip download bytes-match round-trip
  - PEP 503 normalisation (`Foo_Int` upload → `foo-int` install)
  - pip install in a fresh venv

Maven uses a static testdata project (com.example.test:hello) with a
templated pom.xml + settings.xml. The suite covers:
  - mvn deploy of jar + pom + sha1 + md5; assert all four fetchable
  - mvn dependency:get from a fresh local repo
  - snapshot deploy round-trip via the snapshot-metadata route

CI runs the new tests in a dedicated client-integration job that
installs python+twine and maven on top of the existing ubuntu-latest
runner. The shared go-test job continues to skip the new suite (no
toolchain installed there).