### PR TITLE
Add per-format operator docs for python and maven

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,8 @@ Design pillars (in priority order):
 | Area | State |
 |---|---|
 | `pkg/oci` — OCI-backed registry primitives (Add/Read/List/Delete/AppendRefs) | Done, tested with in-memory fake |
-| `pkg/handler/python` — PEP 503 simple index, twine upload, pip download | Done, tested |
-| `pkg/handler/maven` — Maven 2 layout (releases, snapshots, metadata, archetype catalog) | Done, tested |
+| `pkg/handler/python` — PEP 503 simple index, twine upload, pip download | Done, tested. Operator docs: [`docs/repos/python.md`](docs/repos/python.md). |
+| `pkg/handler/maven` — Maven 2 layout (releases, snapshots, metadata, archetype catalog) | Done, tested. Operator docs: [`docs/repos/maven.md`](docs/repos/maven.md). |
 | `pkg/handler/npm` — Routes wired up, all handlers return 501 | **Stub — next up** |
 | `pkg/handler` — `Server`, `PassThroughAuth`, `Logger`, `MetricsMiddleware` | Done |
 | `pkg/metrics` — pluggable Recorder (Prometheus default, no-op for tests) | Done |
@@ -173,7 +173,7 @@ These are non-negotiable. Apply them to every test in the repo:
 4. Plumb it into `pkg/commands/serve.go`'s `supportedRepoTypes` and the `switch` in `Run`. Pass `WithAuthMiddleware(authMW)` (built earlier in `runServe`) to the handler constructor.
 5. Add handler tests using the `oci.fake` backend (cover happy path + 404 + auth errors at minimum). Add a `pkg/handler/<format>/auth_test.go` that mirrors `pkg/handler/python/auth_test.go`: a deny-all middleware reaches every route, omitting the option leaves routes ungated, and the middleware chains before the route handler runs.
 6. Add an integration test or a documented manual test against a real client (`pip`, `mvn`, `npm install`, `go mod download`, `apt-get`).
-7. Document the format under `docs/repos/<format>.md`: URL layout, supported client commands, known limitations.
+7. Document the format under `docs/repos/<format>.md`: URL layout, supported client commands, known limitations. Copy [`docs/repos/_template.md`](docs/repos/_template.md) — it has the headings and depth `python.md` / `maven.md` use, plus inline notes on what to call out front-and-center (e.g. operator footguns that break the second invocation of the most common client command).
 8. Update the status table in this file.
 
 ## Roadmap (one step at a time)

--- a/README.md
+++ b/README.md
@@ -24,14 +24,18 @@ service.
 
 ## Supported formats
 
-| Format | Client | Status |
-|---|---|---|
-| Maven | `mvn`, `gradle` | ✅ Functional |
-| PyPI  | `pip`, `twine`  | ✅ Functional |
-| npm   | `npm`, `yarn`, `pnpm` | 🚧 In progress (routes wired, handlers pending) |
-| Go module proxy | `go mod`        | ⏳ Planned |
-| Debian / apt    | `apt-get`       | ⏳ Planned |
-| Pull-through caching of upstreams | — | ⏳ Phase 4 |
+| Format | Client | Status | Docs |
+|---|---|---|---|
+| Maven | `mvn`, `gradle` | ✅ Functional | [`docs/repos/maven.md`](docs/repos/maven.md) |
+| PyPI  | `pip`, `twine`  | ✅ Functional | [`docs/repos/python.md`](docs/repos/python.md) |
+| npm   | `npm`, `yarn`, `pnpm` | 🚧 In progress (routes wired, handlers pending) | — |
+| Go module proxy | `go mod`        | ⏳ Planned | — |
+| Debian / apt    | `apt-get`       | ⏳ Planned | — |
+| Pull-through caching of upstreams | — | ⏳ Phase 4 | — |
+
+Per-format operator guides live under [`docs/repos/`](docs/repos/) — URL
+layouts, supported client commands, OCI storage shape, knobs, and known
+limitations.
 
 ## Quickstart
 
@@ -52,7 +56,7 @@ Every runtime knob is a CLI flag with a matching env var — no config files.
 Common ones: `PORT`, `OCIFACTORY_REPO_TYPE`, `OCIFACTORY_BACKEND_REGISTRY`,
 `OCIFACTORY_AUTHN_*`, `OCIFACTORY_BACKEND_AUTH_*`, `OCIFACTORY_LOG_LEVEL`,
 `OCIFACTORY_LOG_FORMAT`. See [`docs/auth.md`](docs/auth.md) for the auth
-options.
+options and [`docs/repos/`](docs/repos/) for per-format guides.
 
 ## Architecture
 

--- a/docs/repos/README.md
+++ b/docs/repos/README.md
@@ -1,0 +1,32 @@
+# Repository formats
+
+Per-format operator documentation. Each page covers URL layout,
+supported client commands, OCI storage shape, authn model, operator
+knobs, and known limitations — enough that someone who has never seen
+the codebase can configure their client against a running ocifactory
+using only the page.
+
+| Format | Status | Doc |
+|---|---|---|
+| Python (PyPI) | ✅ Functional | [`python.md`](python.md) |
+| Maven         | ✅ Functional | [`maven.md`](maven.md) |
+| npm           | 🚧 In progress (routes wired, handlers stub) | — |
+| Go module proxy | ⏳ Planned | — |
+| Debian / apt    | ⏳ Planned | — |
+
+Cross-cutting concerns live elsewhere:
+
+- [`../auth.md`](../auth.md) — frontend (caller-to-ocifactory) and
+  backend (ocifactory-to-OCI) authentication.
+- [`../observability.md`](../observability.md) — `/healthz`,
+  `/readyz`, `/metrics`, Prometheus metrics surface.
+- [`../ROADMAP.md`](../ROADMAP.md) — phased plan: Phase 1 core
+  formats, Phase 2 deployability, Phase 3 authz, Phase 4 pull-through
+  caching, Phase 5 add-ons.
+
+## Adding a new format
+
+Copy [`_template.md`](_template.md) and fill it in. Step 7 of the
+"Adding a new repo type" checklist in
+[`AGENTS.md`](../../AGENTS.md#adding-a-new-repo-type--checklist)
+points at this template.

--- a/docs/repos/_template.md
+++ b/docs/repos/_template.md
@@ -1,0 +1,136 @@
+# <Format>
+
+> **Template note:** copy this file to `docs/repos/<format>.md` when
+> adding a new repo type, then strip every `> Template note:` block
+> before publishing. The acceptance criterion is that an operator who
+> has never seen the codebase can configure their client against a
+> running ocifactory using only this doc — match the depth of
+> `docs/repos/python.md` and `docs/repos/maven.md`.
+
+One-paragraph pitch: which client protocol does this format speak,
+which clients are known to work, and what's the OCI storage shape in
+one sentence.
+
+## Quickstart
+
+Server invocation (full `ocifactory serve` line including `--repo-type`,
+`--backend-registry`, `--allow-overwrite` if required, and the auth
+flags):
+
+```bash
+ocifactory serve \
+  --repo-type=<format> \
+  --backend-registry=zot.local:5000/ocifactory \
+  --authn-kind=oidc \
+  --authn-oidc-issuers=https://accounts.google.com \
+  --authn-oidc-audience=https://ocifactory.your-domain \
+  --port=8080
+```
+
+Client configuration (`pip.conf`, `~/.m2/settings.xml`, `~/.npmrc`,
+`go env GOPROXY`, etc. — show the exact snippet operators paste):
+
+```text
+# ... client config ...
+```
+
+> **Template note:** if there's a single operator gotcha that breaks
+> the second invocation of the most common command (Maven's
+> `--allow-overwrite=true` is the precedent), call it out
+> **before** the URL layout — front-and-center under a 🚨 heading,
+> not buried in "Operator knobs".
+
+## URL layout
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET …` | `/…` | … |
+| `PUT …` | `/…` | … |
+
+Concrete examples for the most common deploys / fetches:
+
+```
+GET /…
+PUT /…
+```
+
+Any path validation rules (`pkg/handler/<format>/paths.go` if you
+borrow the Maven pattern). Reject anything that could escape the OCI
+repo namespace at the handler boundary.
+
+## Supported client commands
+
+| Command | Status | Reference |
+|---|---|---|
+| `<client> publish` | ✅ Supported | `pkg/handler/<format>/integration_test.go` — `<subtest_name>` |
+| `<client> install` | ✅ Supported | `pkg/handler/<format>/integration_test.go` — `<subtest_name>` |
+| `<client> search` | ❌ Not supported | reason / tracking issue |
+
+> **Template note:** the integration test file proves the supported
+> claim. If a row says ✅ Supported, link to a real subtest.
+
+## OCI storage layout
+
+| Client URL | OCI repo | OCI tag | Layer name |
+|---|---|---|---|
+| … | `<format>/<package>` | `<version>` | `<filename>` |
+| … | `index` | `<package>` | `<sentinel>` |
+
+`artifactType` = `application/vnd.ocifactory.<format>`.
+
+> **Template note:** if you maintain an `index` repo for the "list all
+> packages" use case, document the sentinel layer's name and body
+> exactly. The Python handler's pattern is the reference — see
+> `docs/repos/python.md`.
+
+## Protocol compliance
+
+| Feature | Status | Notes |
+|---|---|---|
+| <core protocol feature> | ✅ Supported | … |
+| <optional feature> | ❌ Not supported | tracking issue |
+
+## Authentication
+
+State whether every route is gated, or whether some routes are
+public-by-default (npm registry root, future Go module proxy
+listings). If there are public routes, list them explicitly.
+
+```
+- All routes gated by pkg/auth.Middleware: yes / no
+- Public-by-default routes (if any): /...
+- Outlier endpoints with their own auth contract (if any): /...
+```
+
+See [`docs/auth.md`](../auth.md) for authenticator configuration.
+
+## Operator knobs
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--<format>-…` | `…` | … |
+| `--allow-overwrite` | `false` | leave default unless this format requires it (Maven does, Python doesn't) |
+
+Common server-wide flags (`--port`, `--backend-registry`,
+`--enable-metrics`, the `--authn-*` and `--backend-auth-*` families)
+are documented in [`docs/auth.md`](../auth.md) and
+[`docs/observability.md`](../observability.md). Don't re-document
+them here.
+
+## Migration: pre-existing data in the OCI backend
+
+> **Template note:** required for any format that does name
+> normalisation, content-addressing, or anything else that changes
+> how the same logical artifact maps to OCI storage between releases.
+> If your format passes the client's coordinates through verbatim,
+> say so explicitly so operators with pre-existing data know nothing
+> needs to change.
+
+## Limitations
+
+- Concrete missing features that operators will hit on day one.
+- Tracking issues for each.
+- Phase 4 pull-through caching note if relevant.
+
+> **Template note:** be specific. "No yank API" is useful;
+> "incomplete" is not.

--- a/docs/repos/maven.md
+++ b/docs/repos/maven.md
@@ -1,0 +1,267 @@
+# Maven
+
+ocifactory speaks the [Maven 2 repository layout](https://maven.apache.org/repository/layout.html)
+that `mvn`, `gradle`, `sbt`, and friends already know. Each
+`(groupId, artifactId, version)` becomes one OCI manifest, and the files
+inside that version (jar, pom, sources, javadoc, checksum companions)
+become its layers.
+
+## 🚨 Operator requirement: `--allow-overwrite=true`
+
+**You must run `--allow-overwrite=true` for any production Maven
+deployment.** The default `--allow-overwrite=false` rejects every
+re-upload with `409 Conflict`, which sounds reasonable but breaks
+`mvn deploy` on the second invocation of *any* artifact:
+
+`mvn` rewrites the artifact-level `maven-metadata.xml` (the file at
+`<groupId>/<artifactId>/maven-metadata.xml` that lists known versions)
+on every deploy as part of the standard release/snapshot workflow.
+With overwrite disabled the second push of that file 409s and the
+deploy fails. The same is true for the version-level metadata of
+snapshots.
+
+Concretely, run:
+
+```bash
+ocifactory serve \
+  --repo-type=maven \
+  --backend-registry=zot.local:5000/ocifactory \
+  --allow-overwrite=true \
+  --authn-kind=oidc \
+  --authn-oidc-issuers=https://accounts.google.com \
+  --authn-oidc-audience=https://ocifactory.your-domain \
+  --port=8080
+```
+
+This loosens immutability for **every** Maven file type, not just
+metadata — operators who require immutable releases (production
+binaries that should never be silently re-published) should add a CI
+gate that refuses re-deploys of fixed-version artifacts. A future
+code-side fix that special-cases `maven-metadata.xml` for overwrite
+without affecting other files is tracked separately; until that lands,
+`--allow-overwrite=true` is the only way to run a working Maven
+ocifactory.
+
+## Quickstart
+
+After starting the server with `--allow-overwrite=true` (above),
+configure `~/.m2/settings.xml`:
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>ocifactory</id>
+      <username>_oidc</username>
+      <!-- mvn supports password from env via Maven 4 / settings-security; -->
+      <!-- for older mvn, drop the OIDC ID token in here directly. -->
+      <password>${env.OCIFACTORY_TOKEN}</password>
+    </server>
+  </servers>
+  <profiles>
+    <profile>
+      <id>ocifactory</id>
+      <repositories>
+        <repository>
+          <id>ocifactory</id>
+          <url>https://ocifactory.your-domain/</url>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>ocifactory</activeProfile>
+  </activeProfiles>
+</settings>
+```
+
+And in `pom.xml`:
+
+```xml
+<distributionManagement>
+  <repository>
+    <id>ocifactory</id>
+    <url>https://ocifactory.your-domain/</url>
+  </repository>
+  <snapshotRepository>
+    <id>ocifactory</id>
+    <url>https://ocifactory.your-domain/</url>
+  </snapshotRepository>
+</distributionManagement>
+```
+
+`_oidc` is one of three sentinel usernames the auth middleware
+recognises; see [`docs/auth.md`](../auth.md#how-clients-send-credentials).
+The `password` is an OIDC ID token — there is no static-password path.
+
+## URL layout
+
+All routes accept `PUT` and `POST` for upload, and `GET` and `HEAD`
+for resolve.
+
+| Path | Purpose |
+|---|---|
+| `/{groupId}/{artifactId}/{version}/{filename}` | Regular artifact (jar, pom, sources, javadoc). |
+| `/{groupId}/{artifactId}/{version}/{filename}.{sha1,md5,sha256,sha512}` | Checksum companion. **Must arrive after the artifact it covers.** |
+| `/{groupId}/{artifactId}/{version}-SNAPSHOT/maven-metadata.xml` | Version-level snapshot metadata. |
+| `/{groupId}/{artifactId}/maven-metadata.xml` | Artifact-level metadata (mvn rewrites this on every deploy — see overwrite warning above). |
+| `/archetype-catalog.xml` | Global archetype catalog. |
+
+`{groupId}` is the dotted Java group with `.` rewritten to `/`
+(e.g. `com.example.foo` → `/com/example/foo/`), matching standard
+Maven 2 layout. Both release and snapshot artifacts use the same
+URL shape; the routing differs only on the `-SNAPSHOT` suffix in the
+version segment.
+
+### Concrete examples
+
+```
+PUT /com/example/foo/1.0.0/foo-1.0.0.jar
+PUT /com/example/foo/1.0.0/foo-1.0.0.jar.sha1
+PUT /com/example/foo/1.0.0/foo-1.0.0.pom
+PUT /com/example/foo/1.0.0/foo-1.0.0.pom.sha1
+PUT /com/example/foo/maven-metadata.xml
+PUT /com/example/foo/maven-metadata.xml.sha1
+
+# Snapshot
+PUT /com/example/foo/1.1.0-SNAPSHOT/foo-1.1.0-20260101.123456-1.jar
+PUT /com/example/foo/1.1.0-SNAPSHOT/maven-metadata.xml
+```
+
+## Path validation grammar
+
+Each segment of the URL must match `[A-Za-z0-9._-]+`. Specifically:
+
+- No `..` or `.` segments (rejected with `400 Bad Request`).
+- No empty segments (no leading, trailing, or doubled slashes).
+- No characters outside the conservative class above. Maven's standard
+  groupId / artifactId / version grammar
+  (`[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*`) fits inside this class with
+  room to spare; if your build uses unusual characters in coordinates,
+  ocifactory will reject the deploy at the handler boundary before it
+  reaches the OCI backend.
+
+Reference: `pkg/handler/maven/paths.go`.
+
+## Supported client commands
+
+| Command | Status | Reference |
+|---|---|---|
+| `mvn deploy` (release) | ✅ Supported | `pkg/handler/maven/integration_test.go` — `release_deploy_and_get` |
+| `mvn deploy` (snapshot) | ✅ Supported | `pkg/handler/maven/integration_test.go` — `snapshot_deploy_round_trip` |
+| `mvn dependency:get` | ✅ Supported | `pkg/handler/maven/integration_test.go` — `release_deploy_and_get` |
+| `gradle publish` | ⚠️ Untested but expected to work | Same Maven 2 protocol as mvn; report bugs. |
+| `mvn deploy:deploy-file` (raw upload) | ⚠️ Works only if the caller writes `maven-metadata.xml` themselves | ocifactory does not synthesize metadata — see [Limitations](#limitations). |
+
+The integration tests are gated behind `-tags=integration`; CI runs
+them in the dedicated client-integration job. Locally:
+
+```bash
+go test -tags=integration ./pkg/handler/maven/...
+```
+
+## OCI storage layout
+
+ocifactory writes one OCI manifest per `(repo, tag)` tuple, with the
+uploaded files as layers. The mapping from Maven URL to OCI tuple:
+
+| Maven URL | OCI repo | OCI tag | Layer name |
+|---|---|---|---|
+| `/{groupId}/{artifactId}/{version}/{filename}` | `{groupId}/{artifactId}` | `{version}` | `{filename}` |
+| `/{groupId}/{artifactId}/{version}-SNAPSHOT/maven-metadata.xml` | `{groupId}/{artifactId}` | `{version}-SNAPSHOT-metadata` | `maven-metadata.xml` |
+| `/{groupId}/{artifactId}/maven-metadata.xml` | `{groupId}/{artifactId}` | `metadata` | `maven-metadata.xml` |
+| `/archetype-catalog.xml` | `archetype` | `latest` | `archetype-catalog.xml` |
+
+`{groupId}` keeps its slash form (`com/example/foo`), matching the URL.
+
+The OCI manifest `artifactType` is `application/vnd.ocifactory.maven`
+so a backend with multiple ocifactory tenants (or formats) can tell
+them apart.
+
+## Checksum verification
+
+Every checksum companion (`.sha1`, `.md5`, `.sha256`, `.sha512`) is
+verified at upload time against the previously-uploaded artifact in
+the same `(OwningRepo, OwningTag)`. Failures:
+
+| Failure | Status | Reason |
+|---|---|---|
+| Companion artifact not yet uploaded | `400 Bad Request` | Checksums must arrive **after** the file they cover. mvn does this naturally; raw `curl` uploaders need to ensure ordering. |
+| Body is not a hex digest | `400 Bad Request` | "Malformed checksum body". |
+| Computed digest disagrees with the body | `400 Bad Request` | "Checksum mismatch". |
+| Body exceeds 1 KiB | `400 Bad Request` | DoS guard — sha512 hex is 128 bytes; legitimate bodies are far below the cap. |
+
+The parser tolerates three common body formats:
+
+```
+9b8a3a8a4a8c…                          # bare hex
+9b8a3a8a4a8c…  foo-1.0.0.jar           # GNU coreutils style (two-space-separated)
+9b8a3a8a4a8c… *foo-1.0.0.jar           # BSD-style (asterisk-prefixed filename)
+```
+
+Anything past the first whitespace run is ignored; the digest is
+compared case-insensitively.
+
+For `.sha256` the OCI backend already records the digest at push time,
+so verification reuses it without re-streaming the blob. `.sha1`,
+`.md5`, and `.sha512` re-hash the companion at the edge — fine in
+practice because checksum files arrive immediately after the artifact
+(warm in the backend's cache).
+
+Reference: `pkg/handler/maven/checksum.go`.
+
+## Authentication
+
+Every Maven route is gated by `pkg/auth.Middleware` — there are no
+public-by-default endpoints in the Maven format. The middleware chain
+runs **before** any route handler, so an unauthenticated request gets
+a `401 Unauthorized` before touching the OCI backend.
+
+Configure the authenticator via `--authn-*` (or `--disable-authn` for
+local dev). See [`docs/auth.md`](../auth.md) for the full table.
+
+Authorization (per-coordinate, per-operation policy) is **not**
+implemented yet — every authenticated caller can read and write every
+artifact. Tracked by [#49](https://github.com/yolocs/ocifactory/issues/49).
+
+## Operator knobs
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--allow-overwrite` | `false` | **REQUIRED to set to `true` for any working Maven deployment** — see the warning at the top. |
+| `--disable-streaming-push` | `false` | Force buffered+monolithic uploads through the OCI backend instead of chunked PATCH. Set only if your backend has broken chunked-PATCH support. |
+| `--disable-blob-redirect` | `false` | Disable `307` redirects to backend-issued presigned URLs on blob downloads. Set when exposing backend URLs to clients is unacceptable (egress restrictions, DLP, audit). |
+
+Maven uploads carry a `Content-Length` header and stream straight to
+the OCI backend; there is no Maven-specific upload-size knob. The
+effective upload limit is whatever your OCI backend enforces on a
+single layer push.
+
+Common server-wide flags (`--port`, `--backend-registry`,
+`--enable-metrics`, the `--authn-*` and `--backend-auth-*` families)
+are documented in [`docs/auth.md`](../auth.md) and
+[`docs/observability.md`](../observability.md).
+
+## Limitations
+
+- **Passive store: ocifactory does not synthesize `maven-metadata.xml`.**
+  The client (`mvn`, `gradle`) writes it. Tools that don't write it —
+  raw `curl` deploys, custom uploaders, hand-rolled scripts — must
+  construct the metadata themselves. The handler stores whatever bytes
+  the client uploads, byte-for-byte.
+- **Single global archetype catalog.** `/archetype-catalog.xml` is one
+  OCI tag in one OCI repo (`archetype/latest`). Multi-tenant catalogs
+  (per-team, per-environment) are not supported.
+- **No timestamp-based snapshot resolution synthesis.** Timestamped
+  filenames like `foo-1.0-20260101.123456-1.jar` are stored as plain
+  artifacts; the `<snapshot>` indirection in `maven-metadata.xml` is
+  whatever the client uploaded. Tools that depend on the registry
+  generating the indirection will not get it.
+- **No staging / promotion workflow.** Every deploy is final. There is
+  no "stage to a sandbox repo, then promote to releases" feature.
+- **No pull-through caching of Maven Central.** Tracked under Phase 4
+  of [`docs/ROADMAP.md`](../ROADMAP.md).
+- **`--allow-overwrite=true` loosens immutability for every file type.**
+  Operators who want immutable release jars should add a CI gate that
+  refuses re-deploys of fixed-version artifacts; ocifactory itself
+  does not distinguish "metadata" from "jar" once overwrite is on.

--- a/docs/repos/python.md
+++ b/docs/repos/python.md
@@ -1,0 +1,182 @@
+# Python (PyPI)
+
+ocifactory speaks the [PEP 503](https://peps.python.org/pep-0503/) /
+[PEP 691](https://peps.python.org/pep-0691/) "simple repository" protocol
+clients like `pip` and `twine` already know. Storage is your OCI registry —
+one OCI manifest per `(package, version)` and a parallel `index` repo whose
+tags enumerate the packages you've published.
+
+## Quickstart
+
+Run the server:
+
+```bash
+ocifactory serve \
+  --repo-type=python \
+  --backend-registry=zot.local:5000/ocifactory \
+  --authn-kind=oidc \
+  --authn-oidc-issuers=https://accounts.google.com \
+  --authn-oidc-audience=https://ocifactory.your-domain \
+  --port=8080
+```
+
+Configure `pip`:
+
+```ini
+# ~/.pip/pip.conf  (or pip.ini on Windows)
+[global]
+index-url = https://_oidc:${OCIFACTORY_TOKEN}@ocifactory.your-domain/simple/
+```
+
+Configure `twine`:
+
+```bash
+twine upload \
+  --repository-url https://ocifactory.your-domain/ \
+  --username _oidc \
+  --password "$OCIFACTORY_TOKEN" \
+  dist/*
+```
+
+`_oidc` is one of three sentinel usernames the auth middleware recognises;
+see [`docs/auth.md`](../auth.md#how-clients-send-credentials) for the full
+list. The matching `password` is an OIDC ID token, not a static password —
+ocifactory has no static-password path on purpose.
+
+## URL layout
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST /` (or `PUT /`) | (multipart) | `twine upload` — accepts the legacy PyPI multipart form. |
+| `GET /simple/` | — | Root simple index: every package the registry knows about. |
+| `GET /simple/{pkg}/` | — | Per-package simple index: every file for `pkg`. |
+| `GET\|HEAD /packages/{pkg}/{version}/{filename}` | — | Download a wheel/sdist blob. |
+
+Trailing slashes are tolerated on `/simple` and `/simple/{pkg}` — both
+forms are routed to the same handler.
+
+`{pkg}` is normalised on every read and write per
+[PEP 503 §normalized-names](https://peps.python.org/pep-0503/#normalized-names):
+lowercased, runs of `[-_.]` collapsed to a single `-`. Both
+`twine upload Foo_Bar` and `pip install foo-bar` resolve to the same
+package.
+
+## Supported client commands
+
+| Command | Status | Reference |
+|---|---|---|
+| `twine upload` | ✅ Supported | `pkg/handler/python/integration_test.go` — `twine_upload_then_pip_download` |
+| `pip download --index-url=…` | ✅ Supported | `pkg/handler/python/integration_test.go` — `twine_upload_then_pip_download` |
+| `pip install --index-url=…` (in venv) | ✅ Supported | `pkg/handler/python/integration_test.go` — `pip_install_in_fresh_venv` |
+| Normalisation round-trip (`Foo_Bar` ↔ `foo-bar`) | ✅ Supported | `pkg/handler/python/integration_test.go` — `pep503_normalization_roundtrip` |
+| `pip search` | ❌ Not supported | XML-RPC; out of scope. |
+| Yank API | ❌ Not supported | Tracked separately. |
+
+The integration tests are gated behind `-tags=integration`; CI runs them in
+the dedicated client-integration job. Locally:
+
+```bash
+go test -tags=integration ./pkg/handler/python/...
+```
+
+## OCI storage layout
+
+Two OCI repositories under `--backend-registry`:
+
+| OCI repo | Tag | Layers |
+|---|---|---|
+| `packages/<pkg>` | `<version>` | The wheel / sdist files uploaded for that version (one layer per file). |
+| `index` | `<pkg>` | A single sentinel layer (`name=present`, body=`"1"`). The body is unused; `ListTags("index")` is the package list. |
+
+`<pkg>` is always the PEP 503 normalised name. The OCI manifest
+`artifactType` is `application/vnd.ocifactory.python` so a backend with
+multiple ocifactory tenants (or formats) can tell them apart at a glance.
+
+The `index` repo write is one sentinel **per package**, not per version.
+The first upload of a given package writes the sentinel; later uploads
+short-circuit on `ListTags`. This keeps the immutable-add contract — see
+[Operator knobs](#operator-knobs) — compatible with publishing many
+versions of the same package.
+
+## PEP compliance
+
+| PEP | Status | Notes |
+|---|---|---|
+| [PEP 503](https://peps.python.org/pep-0503/) — simple repository (HTML) | ✅ Supported | Names normalised; HTML simple index served by default. |
+| [PEP 691](https://peps.python.org/pep-0691/) — JSON simple index | ✅ Supported | Served when the request `Accept`s `application/vnd.pypi.simple.v1+json` with q-value at least as high as any HTML alternative. Default (no `Accept` header, or unparseable) is HTML so legacy clients keep working. |
+| [PEP 658](https://peps.python.org/pep-0658/) — `data-dist-info-metadata` | ❌ Not supported | Tracked by [#60](https://github.com/yolocs/ocifactory/issues/60). |
+| `data-requires-python` | ❌ Not supported | Tracked by [#60](https://github.com/yolocs/ocifactory/issues/60). |
+| [PEP 700](https://peps.python.org/pep-0700/) — `size`, `upload-time`, `versions`, `tracks` | ❌ Not supported | Out of scope; would require additional metadata in the manifest annotations. The PEP 691 response advertises `api-version: "1.0"` to signal we don't emit these fields. |
+| `/json/<pkg>/` legacy JSON | ❌ Not supported | Different schema from PEP 691; not implemented. |
+| Yank API | ❌ Not supported | Out of scope today. |
+| XML-RPC mirror endpoints (`changelog`, `list_packages`) | ❌ Not supported | Deprecated upstream; out of scope. |
+
+The HTML index emits `<a href="…#sha256=…">` per file so `pip` can
+verify the download against the OCI backend's digest without an extra
+round-trip. The JSON index emits the same digest under
+`files[].hashes.sha256`.
+
+## Authentication
+
+Every PyPI route is gated by `pkg/auth.Middleware` — there are no
+public-by-default endpoints in the Python format. The middleware
+chain runs **before** any route handler, so an unauthenticated request
+gets a `401 Unauthorized` before touching the OCI backend.
+
+Configure the authenticator via `--authn-*` (or `--disable-authn` for
+local dev). See [`docs/auth.md`](../auth.md) for the full table.
+
+Authorization (per-package, per-operation policy) is **not** implemented
+yet — every authenticated caller can read and write every package.
+Tracked by [#49](https://github.com/yolocs/ocifactory/issues/49).
+
+## Operator knobs
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--python-max-upload-bytes` | `1073741824` (1 GiB) | Caps the total request body the upload endpoint accepts. Defends against an authenticated client streaming arbitrary bytes. Set to `0` to disable; tighten for cost-sensitive deployments. |
+| `--simple-index-cache-ttl` | `60s` | Per-replica per-package memoisation of `/simple/<pkg>/`. Successful uploads invalidate the affected entry locally; in multi-replica deployments other replicas may take up to one TTL to see a new release. Set to `0` to disable. |
+| `--allow-overwrite` | `false` | **Leave this `false` for Python.** twine semantics are immutable-add: the same `(package, version, filename)` should never be re-published. The default rejects re-uploads with `409 Conflict`, matching PyPI's auditability story. |
+
+Common server-wide flags (`--port`, `--backend-registry`, `--enable-metrics`,
+the `--authn-*` and `--backend-auth-*` families) are documented in
+[`docs/auth.md`](../auth.md) and [`docs/observability.md`](../observability.md).
+
+## Migration: pre-existing un-normalized data in the OCI backend
+
+The handler normalises package names at every entry point: writes
+canonicalise `Foo_Bar` → `foo-bar` before pushing, and reads
+canonicalise the requested name before looking up. **Reads of the
+un-normalized name are not aliased back to the canonical name.**
+
+Concretely: if you populated `packages/Foo_Bar:1.0` in your OCI backend
+before upgrading to a normalising ocifactory, `pip install Foo_Bar`
+will look for `packages/foo-bar:1.0` and 404. Two ways forward:
+
+1. **Re-upload** the affected versions (`twine upload`). The handler
+   normalises on write, so the new manifest lands at
+   `packages/foo-bar:1.0`. The old `packages/Foo_Bar` repo is harmless
+   but unreachable; clean it up via your OCI backend's tooling.
+2. **Rename in place** at the OCI layer. Out of ocifactory's scope —
+   doable with `oras cp` against your backend, but verify the resulting
+   manifest's `artifactType` annotation still reads
+   `application/vnd.ocifactory.python`.
+
+For new deployments this never matters: every write canonicalises.
+
+## Limitations
+
+- **No PEP 658 `data-dist-info-metadata`.** `pip` falls back to
+  downloading the full wheel for dependency resolution; on slow links or
+  large wheels this is noticeably slower than against PyPI proper.
+  Tracked by [#60](https://github.com/yolocs/ocifactory/issues/60).
+- **No `data-requires-python`.** Resolvers can't pre-filter wheels by
+  Python version from the index. Same tracking issue as above.
+- **No `/json/<pkg>/` endpoint.** A handful of older tools used the
+  pre-PEP-691 JSON shape; modern clients negotiate via `Accept` and
+  get the PEP 691 response.
+- **No yank API.** A bad release has to be pulled by deleting the
+  `packages/<pkg>:<version>` tag in your OCI backend.
+- **No pull-through caching of upstream PyPI.** Tracked under Phase 4
+  of [`docs/ROADMAP.md`](../ROADMAP.md).
+- **No XML-RPC mirror endpoints.** Deprecated upstream; not implemented.

--- a/pkg/handler/python/normalize.go
+++ b/pkg/handler/python/normalize.go
@@ -18,7 +18,8 @@ var pep503Separators = regexp.MustCompile(`[-_.]+`)
 // name, so a `pip install foo-bar` after `twine upload Foo_Bar` resolves
 // to the same package — the behaviour a spec-conforming PyPI client
 // expects. Migration policy for un-normalized data already in an OCI
-// backend is documented in docs/repos/python.md.
+// backend is documented in docs/repos/python.md, section "Migration:
+// pre-existing un-normalized data in the OCI backend".
 func normalize(name string) string {
 	return pep503Separators.ReplaceAllString(strings.ToLower(name), "-")
 }


### PR DESCRIPTION
Creates docs/repos/{python,maven}.md plus a docs/repos/_template.md
for future formats and a docs/repos/README.md index. Each per-format
doc covers URL layout, supported client commands, OCI storage shape,
authn model, operator knobs, and known limitations — enough that an
operator who has never seen the codebase can configure pip / mvn
against a running ocifactory.

The maven doc front-loads the --allow-overwrite=true requirement:
mvn rewrites maven-metadata.xml on every deploy, so the default
--allow-overwrite=false 409s the second invocation of any working
mvn deploy. The integration test passes the same flag for the same
reason.

Cross-links from AGENTS.md (status table rows + step 7 of the new-
format checklist) and README.md (supported-formats table). Resolves
the previously-dead doc reference in pkg/handler/python/normalize.go
to a real anchor in docs/repos/python.md, documenting the migration
policy for un-normalized data already in an OCI backend.

Closes #57