### PR TITLE
Add pluggable authorization with static config policy (#49)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,13 +27,14 @@ Design pillars (in priority order):
 | `/healthz`, `/readyz`, `/metrics` endpoints (registered at server level) | Done |
 | `pkg/auth` — Pluggable frontend authentication (Authenticator, AuthContext, Chain, OIDC) | Done, tested. OIDC-only — static passwords are out-of-tree by design. Configured via `OCIFACTORY_AUTHN_*` flags / env vars. |
 | `pkg/auth/backend` — Pluggable backend credential `Provider` interface and in-tree adapters (`anonymous`, `gcpadc`, `staticenv`, `dockerconfig`) | Done, tested. Wired into `oci.Registry` via `WithBackendAuth`. Configured via `OCIFACTORY_BACKEND_AUTH_*` flags / env vars. |
+| `pkg/auth` Authorizer — Pluggable `Authorizer` interface (`Action`, `Op`, `Check`, `AllowAll`, `DenyAll`) with read/write granularity per (repo, format, op) | Done, tested. |
+| `pkg/auth/staticauthz` — Config-file backed Authorizer (subject + action matchers, `*`/`**` globs, default deny). | Done, tested. Configured via `--authz-config` / `OCIFACTORY_AUTHZ_CONFIG`. |
 | `pkg/handler/echo` — No-op auth target for the GitHub OIDC CI job | Done. Not a real artifact format; no OCI backend, no `handler.Registry`. Exists to give CI a concrete request to make against a real OIDC issuer. |
 | `cmd/ocifactory serve` | Works for `--repo-type=python|maven|echo` (echo runs without `--backend-registry`) |
 | Go module proxy support | Not started |
 | Debian/apt support | Not started |
 | Pull-through proxy / caching | Not started |
 | Vulnerability scanning | Not started |
-| Authorization (per-repo, per-op policy) | Not started |
 | Dockerfile / deployment | Not started |
 | CI: lint, test, build, image publish | `go-test` from `abcxyz/pkg`; `oidc-e2e` job mints a real GitHub OIDC token and exercises the auth chain against `--repo-type=echo`. |
 
@@ -170,11 +171,12 @@ These are non-negotiable. Apply them to every test in the repo:
 1. Create `pkg/handler/<format>/` with `handler.go`, the `Mux()`, and translation logic.
 2. Define `RepoType` and `ArtifactType` constants.
 3. **Accept `WithAuthMiddleware(func(http.Handler) http.Handler)` as an Option** and chain the middleware on whichever routes need authentication. The convention today (python, maven) is `router.Use(mux.MiddlewareFunc(h.authMW))` on the root router so every route is gated. Public-by-default formats (npm registry root, Go module proxy listings) chain on a sub-router and leave reads ungated; outlier endpoints with their own auth contract (npm login bootstrap, Docker token server) sit on a sub-router that doesn't chain it at all. **Do not add an open default**: in `pkg/commands/serve.go`, always pass `WithAuthMiddleware(authMW)` when constructing the handler. The handler-side option is permissive (omitting it leaves routes ungated, which is what tests want), so the gate against silent-no-auth lives in serve.go — verify it's wired before merging.
-4. Plumb it into `pkg/commands/serve.go`'s `supportedRepoTypes` and the `switch` in `Run`. Pass `WithAuthMiddleware(authMW)` (built earlier in `runServe`) to the handler constructor.
-5. Add handler tests using the `oci.fake` backend (cover happy path + 404 + auth errors at minimum). Add a `pkg/handler/<format>/auth_test.go` that mirrors `pkg/handler/python/auth_test.go`: a deny-all middleware reaches every route, omitting the option leaves routes ungated, and the middleware chains before the route handler runs.
-6. Add an integration test or a documented manual test against a real client (`pip`, `mvn`, `npm install`, `go mod download`, `apt-get`).
-7. Document the format under `docs/repos/<format>.md`: URL layout, supported client commands, known limitations. Copy [`docs/repos/_template.md`](docs/repos/_template.md) — it has the headings and depth `python.md` / `maven.md` use, plus inline notes on what to call out front-and-center (e.g. operator footguns that break the second invocation of the most common client command).
-8. Update the status table in this file.
+4. **Accept `WithAuthorizer(auth.Authorizer)` as an Option** and call `auth.Check(ctx, h.authz, auth.Action{Repo, Format, Op})` at the start of every routed handler function. Map `auth.ErrUnauthorized` to 403 and any other authz error to 500. `Repo` MUST match the value the corresponding `oci.RepoFile.OwningRepo` uses, so policies are written against the same names operators see in the OCI registry. Public-by-default routes can skip the check; the call site is the single place auditors look to confirm the gate is wired.
+5. Plumb it into `pkg/commands/serve.go`'s `supportedRepoTypes` and the `switch` in `Run`. Pass both `WithAuthMiddleware(authMW)` and `WithAuthorizer(authz)` (built earlier in `runServe`) to the handler constructor.
+6. Add handler tests using the `oci.fake` backend (cover happy path + 404 + auth errors at minimum). Add a `pkg/handler/<format>/auth_test.go` that mirrors `pkg/handler/python/auth_test.go` (deny-all middleware reaches every route, omitting the option leaves routes ungated, the middleware chains before the route handler runs) and a `pkg/handler/<format>/authz_test.go` that mirrors `pkg/handler/python/authz_test.go` (the authorizer fires per route with the expected (Repo, Format, Op) Action; `ErrUnauthorized` → 403; non-sentinel errors → 500).
+7. Add an integration test or a documented manual test against a real client (`pip`, `mvn`, `npm install`, `go mod download`, `apt-get`).
+8. Document the format under `docs/repos/<format>.md`: URL layout, supported client commands, known limitations. Copy [`docs/repos/_template.md`](docs/repos/_template.md) — it has the headings and depth `python.md` / `maven.md` use, plus inline notes on what to call out front-and-center (e.g. operator footguns that break the second invocation of the most common client command).
+9. Update the status table in this file.
 
 ## Roadmap (one step at a time)
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,4 +1,4 @@
-# Authentication
+# Authentication and authorization
 
 ocifactory has two independent identities:
 
@@ -9,9 +9,17 @@ ocifactory has two independent identities:
   adapters for ADC, env vars, and docker config; configured via
   `OCIFACTORY_BACKEND_AUTH_*`.
 
-There is no config file. Every knob is a CLI flag or environment
-variable so deployments on Cloud Run / k8s / docker compose stay a
-single deployable unit with no extra mounts.
+Authentication asks "who is calling?". A separate **authorization**
+layer (`Authorizer`, configured via `--authz-config` /
+`OCIFACTORY_AUTHZ_CONFIG`) asks "what is this caller allowed to
+do?". See the [Authorization](#authorization) section below.
+
+Authentication and backend-credential knobs are CLI flags / env
+vars so single-process deploys (Cloud Run, fly.io, ...) stay a
+mountless unit. The authorization policy is the one exception:
+operators write a YAML file describing rules and pass its path via
+`--authz-config`. Mounting a file is the natural fit for tabular
+data of unbounded size.
 
 ## Where auth runs
 
@@ -301,14 +309,153 @@ OCI backend, no real artifacts. See `pkg/handler/echo`.
   to 503, and the next request after recovery succeeds (lazy
   re-discovery on the failure path).
 
+## Authorization
+
+`pkg/auth.Authorizer` is the swap point for authorization policy.
+The interface is small:
+
+```go
+type Authorizer interface {
+    Authorize(ctx context.Context, ac *AuthContext, act Action) error
+}
+
+type Action struct {
+    Repo   string  // OCI repository path, matches RepoFile.OwningRepo
+    Format string  // "python", "maven", "echo", ...
+    Op     Op      // OpRead | OpWrite
+}
+```
+
+Per-format handlers translate the inbound HTTP request into an
+`Action` and call `auth.Check(ctx, h.authz, act)` at the start of
+every routed handler function. `auth.ErrUnauthorized` becomes
+`403 Forbidden`; any other authorizer error becomes `500
+Internal Server Error` so transient policy-system failures don't
+look like a legitimate denial.
+
+ocifactory ships:
+
+- `pkg/auth.AllowAll` — no authz, every action allowed. Used in
+  tests and behind another authz layer.
+- `pkg/auth.DenyAll` — explicit deny. Used in tests.
+- `pkg/auth/staticauthz` — config-file backed implementation.
+
+Out-of-tree implementations (OPA / Casbin / Rego, GitHub team
+membership, cloud IAM bindings, custom HTTP authz, ...) implement
+`Authorizer` directly and pass an instance through the same
+`WithAuthorizer` option from a custom main.
+
+### Static config policy (`--authz-config`)
+
+When `--authz-config=/path/to/policy.yaml` is set, ocifactory loads
+the file at startup, compiles every regex / glob, and consults it
+for every routed request. When the flag is empty, no authorization
+runs and every authenticated caller can read and write everything
+— acceptable for local dev, not for production. The startup log
+warns when no policy is configured.
+
+Schema:
+
+```yaml
+default: deny             # deny | allow (default: deny)
+rules:
+  # GitHub Actions OIDC: build-bot publishes packages/* (Python).
+  - subject:
+      issuer: https://token.actions.githubusercontent.com
+      sub_match: "^repo:my-org/build-bot:.*"
+    allow:
+      - { repo: "packages/*", format: python, op: write }
+      - { repo: "packages/*", format: python, op: read  }
+
+  # Any GH Actions job in my-org can read across formats.
+  - subject:
+      issuer: https://token.actions.githubusercontent.com
+      sub_match: "^repo:my-org/.*"
+    allow:
+      - { repo: "**", format: "*", op: read }
+
+  # Dedicated Google service account: full access.
+  - subject:
+      issuer: https://accounts.google.com
+      email: build-sa@project.iam.gserviceaccount.com
+    allow:
+      - { repo: "**", format: "*", op: "*" }
+
+  # Any Google account from the example.com domain can read.
+  - subject:
+      issuer: https://accounts.google.com
+      claims_match:
+        hd: "^example\\.com$"
+    allow:
+      - { repo: "**", op: read }
+```
+
+**Subject matchers.** Every field is optional and ANDed; an empty
+matcher matches every authenticated subject (use sparingly).
+
+| Field | Matches against | Match style |
+|---|---|---|
+| `issuer` | `AuthContext.Issuer` | exact |
+| `sub_match` | `AuthContext.ID` | regex |
+| `email` | `AuthContext.Email` | exact |
+| `claims_match` | `AuthContext.Claims[<name>]` | map of claim → regex |
+
+**Action matchers.** `repo`, `format`, and `op` accept globs:
+
+- `*` matches any single path segment (does not cross `/`).
+- `**` matches across slashes (use this for "any repo").
+- Other characters match literally — regex metacharacters in the
+  pattern are escaped, so `foo.bar` requires a literal dot.
+- An empty value means "any" (equivalent to `**`).
+
+`op` is one of `read`, `write`, or `*`.
+
+**Evaluation.** Rules are tried in order. The first rule whose
+subject matches AND whose `allow` list contains a matching action
+wins. If subject matches but no action matches, evaluation
+continues to the next rule. If no rule allows, the configured
+`default` (deny by default) decides. There is no negation / deny
+list in v1; operators who need richer expressiveness implement
+`Authorizer` themselves.
+
+**Read/write granularity.** `OpRead` covers GET/HEAD reads and
+listing endpoints (PyPI simple index, future npm registry root).
+`OpWrite` covers PUT/POST uploads. There is no separate `delete`
+or `list` op today — ocifactory does not expose a delete endpoint
+to clients, and folding listing into read avoids surprising
+operators with policy that lets a caller fetch a file they cannot
+discover.
+
+**Action repo names.** Match the OCI repo that the format handler
+uses. For Python, that is `packages/<normalized-name>` for
+artifact requests and the literal `index` for the simple-index
+list endpoint; for Maven it is the `groupId/artifactId` path. The
+echo format uses the literal `echo`. Writing a policy is a matter
+of looking at the same names that show up in the backend OCI
+registry.
+
+### 401 vs 403
+
+| Outcome | Status |
+|---|---|
+| No / invalid credential | 401 Unauthorized |
+| Issuer unreachable | 503 Service Unavailable |
+| Verified subject, lacks permission | **403 Forbidden** |
+| Authorizer itself failed | 500 Internal Server Error |
+
+The split matters for clients: 401 means "rotate / mint a token
+and retry", 403 means "your identity is fine, ask the operator
+for access".
+
 ## What's out of scope (for now)
 
-- **Authorization** — what a verified caller is allowed to do.
-  Tracked separately; today every authenticated caller can
-  read/write everything.
 - **GitHub PATs / App tokens** — opaque, not OIDC. A future
   authenticator could validate them via `api.github.com/user`,
   but it has different perf characteristics; meanwhile the
   out-of-tree pattern above is the supported path.
 - **Token revocation lists / introspection endpoints** — punt.
 - **Web UI / login flows** — API-only product.
+- **Hot-reload of the authz policy** — restart the process to
+  pick up policy changes. Operators running on Cloud Run / k8s
+  already have a clean restart story; live reload adds complexity
+  the v1 surface does not need.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -434,6 +434,28 @@ echo format uses the literal `echo`. Writing a policy is a matter
 of looking at the same names that show up in the backend OCI
 registry.
 
+### Hot-reload
+
+The static authorizer watches the policy file and reloads on
+change. No restart is needed when an operator edits the rules.
+
+| Deploy shape | What changes | What happens |
+|---|---|---|
+| Plain file mount, edit in place | The file's contents | fsnotify on the parent dir picks up `WRITE`, debounces 100ms, re-reads the path. |
+| kubernetes ConfigMap volume | `..data` symlink swap | Same watcher catches the burst of `CREATE` / `RENAME` / `REMOVE` events the kubelet emits during rotation. The path operators reference (`/etc/ocifactory/authz.yaml`) is itself a symlink to `..data/authz.yaml`, so re-reading the original path after the swap resolves to the new file. No additional configuration needed. |
+| Atomic rename (e.g. helm upgrade) | The symlink target | Same path — the watcher sees the parent directory event and reloads. |
+
+A reload that fails to parse, validate, or compile is logged at
+`WARN` and **discarded** — the previously loaded rules stay in
+effect, so a typo on disk cannot brick authorization.
+Successful reloads log at `INFO` with the rule count for an
+audit trail.
+
+The reload is atomic at the rule-set level: every concurrent
+`Authorize` call sees either the old rule set or the new one,
+never a mix. There is no per-request locking; the swap goes
+through `atomic.Pointer`.
+
 ### 401 vs 403
 
 | Outcome | Status |
@@ -455,7 +477,3 @@ for access".
   out-of-tree pattern above is the supported path.
 - **Token revocation lists / introspection endpoints** — punt.
 - **Web UI / login flows** — API-only product.
-- **Hot-reload of the authz policy** — restart the process to
-  pick up policy changes. Operators running on Cloud Run / k8s
-  already have a clean restart story; live reload adds complexity
-  the v1 surface does not need.

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.0
 
 require (
 	github.com/coreos/go-oidc/v3 v3.18.0
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/google/go-cmp v0.7.0
 	github.com/gorilla/mux v1.8.1
@@ -39,7 +40,6 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/testcontainers/testcontainers-go v0.42.0
 	golang.org/x/oauth2 v0.36.0
+	gopkg.in/yaml.v3 v3.0.1
 	oras.land/oras-go/v2 v2.6.0
 )
 
@@ -88,5 +89,4 @@ require (
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/auth/authz.go
+++ b/pkg/auth/authz.go
@@ -1,0 +1,139 @@
+package auth
+
+import (
+	"context"
+	"errors"
+)
+
+// Op enumerates the high-level operation kinds an authorizer
+// distinguishes between. Today only read and write are defined —
+// every routed handler in every format maps onto one of these. New
+// operation kinds (delete, list, ...) get added as separate string
+// constants when a format actually exposes a route that needs the
+// distinction; until then keeping the surface narrow keeps policy
+// configurations short and unambiguous.
+type Op string
+
+const (
+	// OpRead covers GET / HEAD reads of artifact bytes and any
+	// listing endpoint a client uses to enumerate available
+	// artifacts. The split between "fetch one file" and "list every
+	// file" is intentionally absent at this level — operators who
+	// want a caller to read at all almost always want them to be
+	// able to discover what is readable.
+	OpRead Op = "read"
+
+	// OpWrite covers PUT / POST uploads that mutate the registry.
+	// Delete is folded into write today; ocifactory's surface does
+	// not expose a delete endpoint to clients, so there is no
+	// policy distinction to make.
+	OpWrite Op = "write"
+)
+
+// Action is what an Authorizer is asked to allow or deny. Format
+// handlers translate the inbound HTTP request into an Action right
+// before authorizing — Repo matches the OCI repo path used by
+// pkg/oci.RepoFile.OwningRepo so policies are written against the
+// same names operators see in their backend OCI registry.
+type Action struct {
+	// Repo is the OCI repository path the action targets, e.g.
+	// "packages/requests" for python, "com/example/foo" for maven,
+	// or "index" for the python simple-index list endpoint.
+	Repo string
+
+	// Format is the artifact format the route belongs to, e.g.
+	// "python" or "maven". Lets policy distinguish callers that
+	// should be able to write Python wheels but not Maven jars
+	// without the operator listing every per-language repo.
+	Format string
+
+	// Op is the operation kind. See OpRead / OpWrite.
+	Op Op
+}
+
+// Authorizer decides whether ac may perform act. Implementations
+// return nil to allow, ErrUnauthorized to deny, or any other error
+// (wrapped however they like) to signal the authorizer itself
+// failed.
+//
+// ctx is passed in so implementations can cancel or time out remote
+// lookups (GitHub team membership, IAM bindings, ...) without
+// having to plumb a context themselves. The static config-file
+// implementation ignores it.
+//
+// ac is the *AuthContext the authentication middleware installed
+// on the request context. It is never nil at the call site —
+// authentication runs first and 401s the request when it cannot
+// resolve a caller, so authorization only ever sees verified
+// identities.
+type Authorizer interface {
+	Authorize(ctx context.Context, ac *AuthContext, act Action) error
+}
+
+// AuthorizerFunc adapts a plain function to the Authorizer
+// interface. Useful in tests and for one-off authorizers.
+type AuthorizerFunc func(ctx context.Context, ac *AuthContext, act Action) error
+
+// Authorize calls f(ctx, ac, act).
+func (f AuthorizerFunc) Authorize(ctx context.Context, ac *AuthContext, act Action) error {
+	return f(ctx, ac, act)
+}
+
+// Sentinel errors. Authorizer implementations MUST return one of
+// these (or wrap with %w) so per-format handlers can map the
+// failure to the right HTTP status without inspecting concrete
+// types.
+var (
+	// ErrUnauthorized is returned when the caller is known but is
+	// not permitted to perform the requested action. Maps to 403.
+	ErrUnauthorized = errors.New("not authorized")
+
+	// ErrAuthzInternal is returned when the authorizer itself
+	// failed (config-file unreadable, remote lookup down, ...).
+	// Maps to 500 — distinct from ErrUnauthorized so transient
+	// authorization-system failures don't look like a legitimate
+	// policy denial.
+	ErrAuthzInternal = errors.New("authorization error")
+)
+
+// AllowAll is a permit-everything Authorizer. Useful for local
+// development, for tests that want to focus on something other
+// than authorization, and for deployments running behind a
+// separate authz layer (mesh policy, k8s NetworkPolicy + a single
+// trusted client, ...). Production deployments behind no other
+// gate should use a real authorizer.
+var AllowAll Authorizer = AuthorizerFunc(func(context.Context, *AuthContext, Action) error {
+	return nil
+})
+
+// DenyAll is the explicit deny authorizer. Tests use it to assert
+// that a route actually calls the authorizer; production should
+// never wire it.
+var DenyAll Authorizer = AuthorizerFunc(func(context.Context, *AuthContext, Action) error {
+	return ErrUnauthorized
+})
+
+// Check is the helper format handlers call at the start of every
+// routed handler function once the Action has been parsed from the
+// path / body. It loads the AuthContext from ctx and delegates to
+// the authorizer.
+//
+// When authz is nil the function returns nil — handlers wired
+// without an Authorizer (legacy, tests) stay open. The serve
+// command always supplies one in production.
+//
+// When the AuthContext is missing the function returns
+// ErrUnauthorized — the authentication middleware should have
+// rejected the request before reaching here, so a missing context
+// at this point is treated as deny rather than allow. Callers map
+// this to 403 like any other authorization denial.
+func Check(ctx context.Context, authz Authorizer, act Action) error {
+	if authz == nil {
+		return nil
+	}
+	ac, ok := FromContext(ctx)
+	if !ok || ac == nil {
+		return ErrUnauthorized
+	}
+	return authz.Authorize(ctx, ac, act)
+}

--- a/pkg/auth/authz_test.go
+++ b/pkg/auth/authz_test.go
@@ -1,0 +1,93 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestCheck(t *testing.T) {
+	t.Parallel()
+
+	allow := AuthorizerFunc(func(context.Context, *AuthContext, Action) error { return nil })
+	deny := AuthorizerFunc(func(context.Context, *AuthContext, Action) error { return ErrUnauthorized })
+	boom := errors.New("boom")
+	broken := AuthorizerFunc(func(context.Context, *AuthContext, Action) error { return boom })
+
+	tests := []struct {
+		name    string
+		authz   Authorizer
+		ac      *AuthContext
+		setACOn bool
+		want    error
+	}{
+		{
+			name:    "nil authz allows",
+			authz:   nil,
+			ac:      &AuthContext{Issuer: "i", ID: "u"},
+			setACOn: true,
+			want:    nil,
+		},
+		{
+			name:    "missing AuthContext denies",
+			authz:   allow,
+			setACOn: false,
+			want:    ErrUnauthorized,
+		},
+		{
+			name:    "nil AuthContext on context denies",
+			authz:   allow,
+			ac:      nil,
+			setACOn: true,
+			want:    ErrUnauthorized,
+		},
+		{
+			name:    "allow",
+			authz:   allow,
+			ac:      &AuthContext{Issuer: "i", ID: "u"},
+			setACOn: true,
+			want:    nil,
+		},
+		{
+			name:    "deny propagates ErrUnauthorized",
+			authz:   deny,
+			ac:      &AuthContext{Issuer: "i", ID: "u"},
+			setACOn: true,
+			want:    ErrUnauthorized,
+		},
+		{
+			name:    "internal error propagates",
+			authz:   broken,
+			ac:      &AuthContext{Issuer: "i", ID: "u"},
+			setACOn: true,
+			want:    boom,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+			if tc.setACOn {
+				ctx = WithAuthContext(ctx, tc.ac)
+			}
+			got := Check(ctx, tc.authz, Action{Repo: "r", Format: "f", Op: OpRead})
+			if !errors.Is(got, tc.want) && got != tc.want {
+				t.Errorf("Check() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAllowAllAndDenyAll(t *testing.T) {
+	t.Parallel()
+
+	ac := &AuthContext{Issuer: "i", ID: "u"}
+	act := Action{Repo: "r", Format: "f", Op: OpRead}
+
+	if err := AllowAll.Authorize(t.Context(), ac, act); err != nil {
+		t.Errorf("AllowAll.Authorize = %v, want nil", err)
+	}
+	if err := DenyAll.Authorize(t.Context(), ac, act); !errors.Is(err, ErrUnauthorized) {
+		t.Errorf("DenyAll.Authorize = %v, want ErrUnauthorized", err)
+	}
+}

--- a/pkg/auth/staticauthz/staticauthz.go
+++ b/pkg/auth/staticauthz/staticauthz.go
@@ -30,7 +30,7 @@
 //   - "*"  matches any single path segment (no "/")
 //   - "**" matches across path segments (including "/")
 //   - exact strings match exactly
-//   - empty matcher field = match anything (equivalent to "*")
+//   - empty matcher field = match anything (equivalent to "**")
 //
 // Subject matchers (all optional, all must match if set):
 //   - issuer: exact string match against AuthContext.Issuer
@@ -38,19 +38,43 @@
 //   - email: exact match against AuthContext.Email
 //   - claims_match: map of claim name -> regex matched against
 //     the claim value (must be a string in the verified Claims map)
+//
+// Hot-reload. An Authorizer constructed via Load remembers its
+// source path. Calling Watch(ctx) starts a goroutine that
+// reloads the file when it changes, so operators can edit a
+// mounted ConfigMap (or push a new release of a versioned
+// policy file) without restarting the server. The reload is
+// atomic at the rule-set level — concurrent Authorize calls
+// either see the old rules or the new rules, never a mix —
+// and a malformed reload is logged and discarded so a typo
+// can't take the server's policy down. See Watch for the
+// kubernetes ConfigMap symlink-swap pattern.
 package staticauthz
 
 import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
+	"sync/atomic"
+	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/yolocs/ocifactory/pkg/auth"
+	"github.com/yolocs/ocifactory/pkg/logging"
 	"gopkg.in/yaml.v3"
 )
+
+// reloadDebounce is how long Watch waits after the last fsnotify
+// event before re-reading the config. kubernetes ConfigMap
+// updates burst many events (new timestamped dir created, symlink
+// renamed, old dir removed); the debounce coalesces them into one
+// reload.
+const reloadDebounce = 100 * time.Millisecond
 
 // Default determines the fall-through decision when no rule
 // matches. defaultDeny is the strongly-recommended setting.
@@ -100,8 +124,22 @@ type ActionMatcher struct {
 }
 
 // Authorizer is the auth.Authorizer implementation. Construct via
-// New (from raw Config) or Load (from a YAML file on disk).
+// New (from raw Config) or Load (from a YAML file on disk). The
+// compiled rule set is held in an atomic.Pointer so Watch can
+// swap it out under live traffic without locking the Authorize
+// fast path.
 type Authorizer struct {
+	rules atomic.Pointer[ruleset]
+
+	// path is the config file path captured by Load. Empty for
+	// authorizers built via New — Watch refuses to start in that
+	// case because there is no source file to re-read.
+	path string
+}
+
+// ruleset is the immutable compiled view of a Config. Reload
+// builds a new ruleset and atomically swaps it into Authorizer.
+type ruleset struct {
 	def   Default
 	rules []compiledRule
 }
@@ -133,12 +171,41 @@ type compiledAction struct {
 }
 
 // Load reads the YAML config at path, parses it, validates it,
-// compiles every regex / glob, and returns an Authorizer ready to
-// answer Authorize calls.
+// compiles every regex / glob, and returns an Authorizer ready
+// to answer Authorize calls. The path is remembered so a
+// subsequent Watch(ctx) can pick up changes.
 func Load(path string) (*Authorizer, error) {
 	if path == "" {
 		return nil, errors.New("staticauthz: empty config path")
 	}
+	rs, err := loadRuleset(path)
+	if err != nil {
+		return nil, err
+	}
+	a := &Authorizer{path: path}
+	a.rules.Store(rs)
+	return a, nil
+}
+
+// New builds an Authorizer from an in-memory Config. Useful for
+// tests and for callers building rules programmatically. An
+// Authorizer built via New has no source path, so Watch returns
+// an error if called on it.
+func New(cfg Config) (*Authorizer, error) {
+	rs, err := compileRuleset(cfg)
+	if err != nil {
+		return nil, err
+	}
+	a := &Authorizer{}
+	a.rules.Store(rs)
+	return a, nil
+}
+
+// Path returns the source path captured by Load. Empty for
+// authorizers built via New.
+func (a *Authorizer) Path() string { return a.path }
+
+func loadRuleset(path string) (*ruleset, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("staticauthz: read %q: %w", path, err)
@@ -147,16 +214,14 @@ func Load(path string) (*Authorizer, error) {
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("staticauthz: parse %q: %w", path, err)
 	}
-	a, err := New(cfg)
+	rs, err := compileRuleset(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("staticauthz: invalid config %q: %w", path, err)
 	}
-	return a, nil
+	return rs, nil
 }
 
-// New builds an Authorizer from an in-memory Config. Useful for
-// tests and for callers building rules programmatically.
-func New(cfg Config) (*Authorizer, error) {
+func compileRuleset(cfg Config) (*ruleset, error) {
 	def := cfg.Default
 	switch def {
 	case "":
@@ -174,7 +239,7 @@ func New(cfg Config) (*Authorizer, error) {
 		}
 		rules = append(rules, cr)
 	}
-	return &Authorizer{def: def, rules: rules}, nil
+	return &ruleset{def: def, rules: rules}, nil
 }
 
 func compileRule(r Rule) (compiledRule, error) {
@@ -250,7 +315,8 @@ func (a *Authorizer) Authorize(_ context.Context, ac *auth.AuthContext, act auth
 		// invoking the authorizer directly shouldn't crash.
 		return auth.ErrUnauthorized
 	}
-	for _, r := range a.rules {
+	rs := a.rules.Load()
+	for _, r := range rs.rules {
 		if !r.subject.matches(ac) {
 			continue
 		}
@@ -260,10 +326,118 @@ func (a *Authorizer) Authorize(_ context.Context, ac *auth.AuthContext, act auth
 			}
 		}
 	}
-	if a.def == DefaultAllow {
+	if rs.def == DefaultAllow {
 		return nil
 	}
 	return auth.ErrUnauthorized
+}
+
+// Watch starts a goroutine that reloads the config when its
+// source file changes. Returns nil immediately on success — the
+// watcher runs until ctx is canceled. Returns an error
+// synchronously if the authorizer was built via New (no source
+// path) or fsnotify failed to initialize.
+//
+// Watch is designed for kubernetes ConfigMap volume mounts. K8s
+// updates a ConfigMap by writing a new timestamped directory
+// alongside the existing one and atomically renaming the
+// "..data" symlink — the file path operators reference
+// (/etc/ocifactory/authz.yaml) is itself a symlink to
+// "..data/authz.yaml", so its inode changes on every update and
+// fsnotify on the file path alone misses the swap. We watch the
+// containing directory, debounce the burst of events, and
+// re-read the original path so the symlink chain resolves to the
+// new file.
+//
+// Reload errors (file unreadable, YAML parse failure, regex
+// invalid) are logged at WARN and discarded — the previously
+// loaded rules stay in effect so a typo on disk doesn't take
+// authorization down.
+func (a *Authorizer) Watch(ctx context.Context) error {
+	if a.path == "" {
+		return errors.New("staticauthz: Watch requires Authorizer built via Load (no source path on this instance)")
+	}
+	abs, err := filepath.Abs(a.path)
+	if err != nil {
+		return fmt.Errorf("staticauthz: resolve %q: %w", a.path, err)
+	}
+	dir := filepath.Dir(abs)
+
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("staticauthz: fsnotify: %w", err)
+	}
+	if err := w.Add(dir); err != nil {
+		_ = w.Close()
+		return fmt.Errorf("staticauthz: watch %q: %w", dir, err)
+	}
+
+	logger := logging.FromContext(ctx)
+	go a.watchLoop(ctx, w, logger)
+	return nil
+}
+
+// watchLoop is the goroutine spun up by Watch. It coalesces the
+// burst of fsnotify events k8s emits during a ConfigMap rotation
+// into a single reload after reloadDebounce of quiet, and exits
+// when ctx is canceled.
+func (a *Authorizer) watchLoop(ctx context.Context, w *fsnotify.Watcher, logger *slog.Logger) {
+	defer w.Close()
+
+	var (
+		timer  *time.Timer
+		timerC <-chan time.Time
+	)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case _, ok := <-w.Events:
+			if !ok {
+				return
+			}
+			// Any event in the directory could indicate the
+			// file was rewritten in place or that the k8s
+			// "..data" symlink was swapped. We don't filter on
+			// event Name because the symlink chain hides the
+			// actual filename being touched; reloading is
+			// cheap and idempotent.
+			if timer == nil {
+				timer = time.NewTimer(reloadDebounce)
+				timerC = timer.C
+			} else {
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				timer.Reset(reloadDebounce)
+			}
+		case <-timerC:
+			timer = nil
+			timerC = nil
+			a.reload(ctx, logger)
+		case err, ok := <-w.Errors:
+			if !ok {
+				return
+			}
+			logger.WarnContext(ctx, "staticauthz: fsnotify error", "error", err, "path", a.path)
+		}
+	}
+}
+
+// reload re-reads the source file and atomically swaps the
+// rule set on success. Failures are logged and the previous
+// rule set stays in effect.
+func (a *Authorizer) reload(ctx context.Context, logger *slog.Logger) {
+	rs, err := loadRuleset(a.path)
+	if err != nil {
+		logger.WarnContext(ctx, "staticauthz: reload failed; keeping previous policy", "error", err, "path", a.path)
+		return
+	}
+	a.rules.Store(rs)
+	logger.InfoContext(ctx, "staticauthz: policy reloaded", "path", a.path, "rules", len(rs.rules))
 }
 
 func (s compiledSubject) matches(ac *auth.AuthContext) bool {

--- a/pkg/auth/staticauthz/staticauthz.go
+++ b/pkg/auth/staticauthz/staticauthz.go
@@ -1,0 +1,354 @@
+// Package staticauthz is a config-file backed implementation of
+// auth.Authorizer. Operators describe which authenticated subjects
+// are allowed to perform which (repo, format, op) actions in a
+// YAML file mounted at a path passed via --authz-config.
+//
+// The implementation is intentionally narrow: subject matchers are
+// equality / regex against fields of *auth.AuthContext, action
+// matchers are simple globs against (repo, format, op), evaluation
+// is first-match-wins, and the default decision is deny. Operators
+// who need more (negative rules, priority overrides, remote
+// lookups, OPA / Casbin / Rego, ...) implement auth.Authorizer
+// themselves and pass it in from a custom main.
+//
+// File format:
+//
+//	default: deny             # deny | allow (default: deny)
+//	rules:
+//	  - subject:
+//	      issuer: https://token.actions.githubusercontent.com
+//	      sub_match: "^repo:my-org/build-bot:.*"
+//	    allow:
+//	      - { repo: "packages/*", format: python, op: write }
+//	      - { repo: "packages/*", format: python, op: read  }
+//	  - subject:
+//	      email: build-sa@project.iam.gserviceaccount.com
+//	    allow:
+//	      - { repo: "*", format: "*", op: "*" }
+//
+// Glob semantics for repo / format / op patterns:
+//   - "*"  matches any single path segment (no "/")
+//   - "**" matches across path segments (including "/")
+//   - exact strings match exactly
+//   - empty matcher field = match anything (equivalent to "*")
+//
+// Subject matchers (all optional, all must match if set):
+//   - issuer: exact string match against AuthContext.Issuer
+//   - sub_match: regex matched against AuthContext.ID
+//   - email: exact match against AuthContext.Email
+//   - claims_match: map of claim name -> regex matched against
+//     the claim value (must be a string in the verified Claims map)
+package staticauthz
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/yolocs/ocifactory/pkg/auth"
+	"gopkg.in/yaml.v3"
+)
+
+// Default determines the fall-through decision when no rule
+// matches. defaultDeny is the strongly-recommended setting.
+type Default string
+
+const (
+	DefaultDeny  Default = "deny"
+	DefaultAllow Default = "allow"
+)
+
+// Config is the parsed YAML structure. Exported so callers
+// embedding the static authorizer in their own programs can build
+// it up programmatically without round-tripping through YAML.
+type Config struct {
+	Default Default `yaml:"default"`
+	Rules   []Rule  `yaml:"rules"`
+}
+
+// Rule pairs a subject matcher with the actions that subject is
+// allowed to perform. A request is allowed by a rule when the
+// subject matcher matches the AuthContext AND any entry in Allow
+// matches the Action.
+type Rule struct {
+	Subject SubjectMatcher  `yaml:"subject"`
+	Allow   []ActionMatcher `yaml:"allow"`
+}
+
+// SubjectMatcher matches against an *auth.AuthContext. A field
+// left empty is treated as "don't care" — only set fields
+// participate in matching, and all set fields must match for the
+// matcher to fire. An empty SubjectMatcher (every field zero)
+// matches every authenticated subject.
+type SubjectMatcher struct {
+	Issuer      string            `yaml:"issuer"`
+	SubMatch    string            `yaml:"sub_match"`
+	Email       string            `yaml:"email"`
+	ClaimsMatch map[string]string `yaml:"claims_match"`
+}
+
+// ActionMatcher matches against an auth.Action. Every field
+// supports glob ("*", "**") or exact match; an empty field means
+// "any". Op may also be the literal string "read", "write", or "*".
+type ActionMatcher struct {
+	Repo   string `yaml:"repo"`
+	Format string `yaml:"format"`
+	Op     string `yaml:"op"`
+}
+
+// Authorizer is the auth.Authorizer implementation. Construct via
+// New (from raw Config) or Load (from a YAML file on disk).
+type Authorizer struct {
+	def   Default
+	rules []compiledRule
+}
+
+type compiledRule struct {
+	subject compiledSubject
+	allow   []compiledAction
+}
+
+type compiledSubject struct {
+	hasIssuer   bool
+	issuer      string
+	hasSubMatch bool
+	subMatch    *regexp.Regexp
+	hasEmail    bool
+	email       string
+	claims      []compiledClaim
+}
+
+type compiledClaim struct {
+	name string
+	re   *regexp.Regexp
+}
+
+type compiledAction struct {
+	repo   *globPattern
+	format *globPattern
+	op     *globPattern
+}
+
+// Load reads the YAML config at path, parses it, validates it,
+// compiles every regex / glob, and returns an Authorizer ready to
+// answer Authorize calls.
+func Load(path string) (*Authorizer, error) {
+	if path == "" {
+		return nil, errors.New("staticauthz: empty config path")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("staticauthz: read %q: %w", path, err)
+	}
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("staticauthz: parse %q: %w", path, err)
+	}
+	a, err := New(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("staticauthz: invalid config %q: %w", path, err)
+	}
+	return a, nil
+}
+
+// New builds an Authorizer from an in-memory Config. Useful for
+// tests and for callers building rules programmatically.
+func New(cfg Config) (*Authorizer, error) {
+	def := cfg.Default
+	switch def {
+	case "":
+		def = DefaultDeny
+	case DefaultDeny, DefaultAllow:
+	default:
+		return nil, fmt.Errorf("default %q is not allowed (must be %q or %q)", def, DefaultDeny, DefaultAllow)
+	}
+
+	rules := make([]compiledRule, 0, len(cfg.Rules))
+	for i, r := range cfg.Rules {
+		cr, err := compileRule(r)
+		if err != nil {
+			return nil, fmt.Errorf("rule[%d]: %w", i, err)
+		}
+		rules = append(rules, cr)
+	}
+	return &Authorizer{def: def, rules: rules}, nil
+}
+
+func compileRule(r Rule) (compiledRule, error) {
+	cs, err := compileSubject(r.Subject)
+	if err != nil {
+		return compiledRule{}, fmt.Errorf("subject: %w", err)
+	}
+	allow := make([]compiledAction, 0, len(r.Allow))
+	for j, a := range r.Allow {
+		ca, err := compileAction(a)
+		if err != nil {
+			return compiledRule{}, fmt.Errorf("allow[%d]: %w", j, err)
+		}
+		allow = append(allow, ca)
+	}
+	return compiledRule{subject: cs, allow: allow}, nil
+}
+
+func compileSubject(s SubjectMatcher) (compiledSubject, error) {
+	out := compiledSubject{}
+	if s.Issuer != "" {
+		out.hasIssuer = true
+		out.issuer = s.Issuer
+	}
+	if s.SubMatch != "" {
+		re, err := regexp.Compile(s.SubMatch)
+		if err != nil {
+			return compiledSubject{}, fmt.Errorf("sub_match %q: %w", s.SubMatch, err)
+		}
+		out.hasSubMatch = true
+		out.subMatch = re
+	}
+	if s.Email != "" {
+		out.hasEmail = true
+		out.email = s.Email
+	}
+	for name, expr := range s.ClaimsMatch {
+		if name == "" {
+			return compiledSubject{}, errors.New("claims_match: empty claim name")
+		}
+		re, err := regexp.Compile(expr)
+		if err != nil {
+			return compiledSubject{}, fmt.Errorf("claims_match[%q] %q: %w", name, expr, err)
+		}
+		out.claims = append(out.claims, compiledClaim{name: name, re: re})
+	}
+	return out, nil
+}
+
+func compileAction(a ActionMatcher) (compiledAction, error) {
+	repo, err := compileGlob(a.Repo)
+	if err != nil {
+		return compiledAction{}, fmt.Errorf("repo %q: %w", a.Repo, err)
+	}
+	format, err := compileGlob(a.Format)
+	if err != nil {
+		return compiledAction{}, fmt.Errorf("format %q: %w", a.Format, err)
+	}
+	op, err := compileGlob(a.Op)
+	if err != nil {
+		return compiledAction{}, fmt.Errorf("op %q: %w", a.Op, err)
+	}
+	return compiledAction{repo: repo, format: format, op: op}, nil
+}
+
+// Authorize implements auth.Authorizer. It walks rules in order;
+// the first rule whose subject matches and whose Allow list
+// includes the action wins. If no rule matches, the configured
+// default decides.
+func (a *Authorizer) Authorize(_ context.Context, ac *auth.AuthContext, act auth.Action) error {
+	if ac == nil {
+		// Defensive — auth.Check filters this out, but a caller
+		// invoking the authorizer directly shouldn't crash.
+		return auth.ErrUnauthorized
+	}
+	for _, r := range a.rules {
+		if !r.subject.matches(ac) {
+			continue
+		}
+		for _, allow := range r.allow {
+			if allow.matches(act) {
+				return nil
+			}
+		}
+	}
+	if a.def == DefaultAllow {
+		return nil
+	}
+	return auth.ErrUnauthorized
+}
+
+func (s compiledSubject) matches(ac *auth.AuthContext) bool {
+	if s.hasIssuer && s.issuer != ac.Issuer {
+		return false
+	}
+	if s.hasSubMatch && !s.subMatch.MatchString(ac.ID) {
+		return false
+	}
+	if s.hasEmail && s.email != ac.Email {
+		return false
+	}
+	for _, c := range s.claims {
+		raw, ok := ac.Claims[c.name]
+		if !ok {
+			return false
+		}
+		v, ok := raw.(string)
+		if !ok {
+			return false
+		}
+		if !c.re.MatchString(v) {
+			return false
+		}
+	}
+	return true
+}
+
+func (a compiledAction) matches(act auth.Action) bool {
+	if !a.repo.match(act.Repo) {
+		return false
+	}
+	if !a.format.match(act.Format) {
+		return false
+	}
+	if !a.op.match(string(act.Op)) {
+		return false
+	}
+	return true
+}
+
+// globPattern is a tiny "*" / "**" matcher. "*" matches any run
+// of characters that does not contain "/"; "**" matches anything,
+// including "/". An empty pattern matches anything (equivalent to
+// "**"). Other characters match literally.
+//
+// A full glob library would be overkill — operators write these
+// by hand and only need a handful of shapes (prefix wildcards,
+// scoped namespaces). The semantics are documented in
+// docs/auth.md so users know what to expect.
+type globPattern struct {
+	re *regexp.Regexp
+}
+
+func compileGlob(pat string) (*globPattern, error) {
+	if pat == "" {
+		// Match anything — the unset / "don't care" case.
+		return &globPattern{re: regexp.MustCompile("^.*$")}, nil
+	}
+	var b strings.Builder
+	b.WriteString("^")
+	for i := 0; i < len(pat); i++ {
+		switch c := pat[i]; c {
+		case '*':
+			if i+1 < len(pat) && pat[i+1] == '*' {
+				b.WriteString(".*")
+				i++ // consume the second '*'
+			} else {
+				b.WriteString("[^/]*")
+			}
+		case '.', '+', '(', ')', '|', '^', '$', '{', '}', '[', ']', '\\', '?':
+			b.WriteByte('\\')
+			b.WriteByte(c)
+		default:
+			b.WriteByte(c)
+		}
+	}
+	b.WriteString("$")
+	re, err := regexp.Compile(b.String())
+	if err != nil {
+		return nil, fmt.Errorf("compile glob: %w", err)
+	}
+	return &globPattern{re: re}, nil
+}
+
+func (g *globPattern) match(s string) bool {
+	return g.re.MatchString(s)
+}

--- a/pkg/auth/staticauthz/staticauthz_test.go
+++ b/pkg/auth/staticauthz/staticauthz_test.go
@@ -1,0 +1,332 @@
+package staticauthz
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/yolocs/ocifactory/pkg/auth"
+)
+
+func TestGlobMatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		pattern string
+		input   string
+		want    bool
+	}{
+		{name: "empty matches anything", pattern: "", input: "anything/here", want: true},
+		{name: "exact match", pattern: "packages/foo", input: "packages/foo", want: true},
+		{name: "exact mismatch", pattern: "packages/foo", input: "packages/bar", want: false},
+
+		{name: "* matches segment", pattern: "packages/*", input: "packages/foo", want: true},
+		{name: "* does not cross slash", pattern: "packages/*", input: "packages/foo/bar", want: false},
+		{name: "* empty segment", pattern: "packages/*", input: "packages/", want: true},
+		{name: "* mid-pattern", pattern: "*/foo", input: "bar/foo", want: true},
+
+		{name: "** matches one segment", pattern: "**", input: "foo", want: true},
+		{name: "** matches across slashes", pattern: "**", input: "a/b/c", want: true},
+		{name: "** prefix", pattern: "packages/**", input: "packages/foo/bar", want: true},
+		{name: "** prefix mismatch", pattern: "packages/**", input: "other/foo", want: false},
+
+		{name: "regex special characters are literal (dot)", pattern: "foo.bar", input: "fooXbar", want: false},
+		{name: "regex special characters are literal (parens)", pattern: "(foo)", input: "(foo)", want: true},
+		{name: "single star vs literal star is glob", pattern: "*", input: "anything", want: true},
+		{name: "single star does not match slash", pattern: "*", input: "a/b", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g, err := compileGlob(tc.pattern)
+			if err != nil {
+				t.Fatalf("compileGlob(%q) error = %v", tc.pattern, err)
+			}
+			if got := g.match(tc.input); got != tc.want {
+				t.Errorf("compileGlob(%q).match(%q) = %v, want %v", tc.pattern, tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAuthorize(t *testing.T) {
+	t.Parallel()
+
+	const ghaIssuer = "https://token.actions.githubusercontent.com"
+	const googleIssuer = "https://accounts.google.com"
+
+	cfg := Config{
+		Default: DefaultDeny,
+		Rules: []Rule{
+			{
+				Subject: SubjectMatcher{
+					Issuer:   ghaIssuer,
+					SubMatch: `^repo:my-org/build-bot:.*`,
+				},
+				Allow: []ActionMatcher{
+					{Repo: "packages/*", Format: "python", Op: "write"},
+					{Repo: "packages/*", Format: "python", Op: "read"},
+				},
+			},
+			{
+				Subject: SubjectMatcher{
+					Issuer:   ghaIssuer,
+					SubMatch: `^repo:my-org/.*`,
+				},
+				Allow: []ActionMatcher{
+					{Repo: "**", Format: "*", Op: "read"},
+				},
+			},
+			{
+				Subject: SubjectMatcher{
+					Issuer: googleIssuer,
+					Email:  "build-sa@project.iam.gserviceaccount.com",
+				},
+				Allow: []ActionMatcher{
+					{Repo: "**", Format: "*", Op: "*"},
+				},
+			},
+			{
+				Subject: SubjectMatcher{
+					Issuer: googleIssuer,
+					ClaimsMatch: map[string]string{
+						"hd": `^example\.com$`,
+					},
+				},
+				Allow: []ActionMatcher{
+					{Repo: "**", Op: "read"},
+				},
+			},
+		},
+	}
+
+	a, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		ac      *auth.AuthContext
+		act     auth.Action
+		wantErr error
+	}{
+		{
+			name: "build-bot writes its own packages",
+			ac:   &auth.AuthContext{Issuer: ghaIssuer, ID: "repo:my-org/build-bot:ref:refs/heads/main"},
+			act:  auth.Action{Repo: "packages/foo", Format: "python", Op: auth.OpWrite},
+		},
+		{
+			name:    "build-bot cannot write maven",
+			ac:      &auth.AuthContext{Issuer: ghaIssuer, ID: "repo:my-org/build-bot:ref:refs/heads/main"},
+			act:     auth.Action{Repo: "com/example/foo", Format: "maven", Op: auth.OpWrite},
+			wantErr: auth.ErrUnauthorized,
+		},
+		{
+			name: "any my-org repo can read across formats",
+			ac:   &auth.AuthContext{Issuer: ghaIssuer, ID: "repo:my-org/some-other-repo:ref:refs/heads/main"},
+			act:  auth.Action{Repo: "com/example/whatever", Format: "maven", Op: auth.OpRead},
+		},
+		{
+			name:    "outside-org repo denied entirely",
+			ac:      &auth.AuthContext{Issuer: ghaIssuer, ID: "repo:not-my-org/whatever:ref:refs/heads/main"},
+			act:     auth.Action{Repo: "packages/foo", Format: "python", Op: auth.OpRead},
+			wantErr: auth.ErrUnauthorized,
+		},
+		{
+			name: "google service account allowed everywhere",
+			ac:   &auth.AuthContext{Issuer: googleIssuer, ID: "111", Email: "build-sa@project.iam.gserviceaccount.com"},
+			act:  auth.Action{Repo: "anything/here/at/all", Format: "maven", Op: auth.OpWrite},
+		},
+		{
+			name:    "google account without email denied write",
+			ac:      &auth.AuthContext{Issuer: googleIssuer, ID: "222", Email: "alice@example.com", Claims: map[string]any{"hd": "example.com"}},
+			act:     auth.Action{Repo: "packages/foo", Format: "python", Op: auth.OpWrite},
+			wantErr: auth.ErrUnauthorized,
+		},
+		{
+			name: "claims match works",
+			ac:   &auth.AuthContext{Issuer: googleIssuer, ID: "222", Email: "alice@example.com", Claims: map[string]any{"hd": "example.com"}},
+			act:  auth.Action{Repo: "packages/foo", Format: "python", Op: auth.OpRead},
+		},
+		{
+			name:    "missing claim denies",
+			ac:      &auth.AuthContext{Issuer: googleIssuer, ID: "222", Email: "bob@elsewhere.com"},
+			act:     auth.Action{Repo: "packages/foo", Format: "python", Op: auth.OpRead},
+			wantErr: auth.ErrUnauthorized,
+		},
+		{
+			name:    "wrong issuer denies even with right email",
+			ac:      &auth.AuthContext{Issuer: "https://other.example.com", Email: "build-sa@project.iam.gserviceaccount.com"},
+			act:     auth.Action{Repo: "packages/foo", Format: "python", Op: auth.OpRead},
+			wantErr: auth.ErrUnauthorized,
+		},
+		{
+			name:    "nil ac denies",
+			ac:      nil,
+			act:     auth.Action{Repo: "packages/foo", Format: "python", Op: auth.OpRead},
+			wantErr: auth.ErrUnauthorized,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := a.Authorize(t.Context(), tc.ac, tc.act)
+			if tc.wantErr == nil && err != nil {
+				t.Errorf("Authorize() = %v, want nil", err)
+			}
+			if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
+				t.Errorf("Authorize() = %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestDefaultAllow(t *testing.T) {
+	t.Parallel()
+
+	a, err := New(Config{Default: DefaultAllow})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := a.Authorize(t.Context(), &auth.AuthContext{Issuer: "i", ID: "u"}, auth.Action{Repo: "x", Format: "y", Op: auth.OpWrite}); err != nil {
+		t.Errorf("default allow denied: %v", err)
+	}
+}
+
+func TestDefaultDenyEmptyRules(t *testing.T) {
+	t.Parallel()
+
+	a, err := New(Config{}) // default = deny, no rules
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	err = a.Authorize(t.Context(), &auth.AuthContext{Issuer: "i", ID: "u"}, auth.Action{Repo: "x", Format: "y", Op: auth.OpRead})
+	if !errors.Is(err, auth.ErrUnauthorized) {
+		t.Errorf("Authorize() = %v, want ErrUnauthorized", err)
+	}
+}
+
+func TestNewRejectsBadDefault(t *testing.T) {
+	t.Parallel()
+
+	if _, err := New(Config{Default: Default("bogus")}); err == nil {
+		t.Errorf("New() with bogus default succeeded; want error")
+	}
+}
+
+func TestNewRejectsBadRegex(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  Config
+	}{
+		{
+			name: "bad sub_match",
+			cfg: Config{Rules: []Rule{
+				{Subject: SubjectMatcher{SubMatch: "[invalid"}},
+			}},
+		},
+		{
+			name: "bad claims_match",
+			cfg: Config{Rules: []Rule{
+				{Subject: SubjectMatcher{ClaimsMatch: map[string]string{"x": "[invalid"}}},
+			}},
+		},
+		{
+			name: "empty claim name",
+			cfg: Config{Rules: []Rule{
+				{Subject: SubjectMatcher{ClaimsMatch: map[string]string{"": "x"}}},
+			}},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := New(tc.cfg); err == nil {
+				t.Errorf("New() succeeded; want error")
+			}
+		})
+	}
+}
+
+func TestLoad(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	tests := []struct {
+		name    string
+		content string
+		wantErr bool
+		assert  func(t *testing.T, a *Authorizer)
+	}{
+		{
+			name: "valid config",
+			content: `
+default: allow
+rules:
+  - subject:
+      issuer: https://example.com
+    allow:
+      - { repo: "*", format: "*", op: "*" }
+`,
+			assert: func(t *testing.T, a *Authorizer) {
+				err := a.Authorize(t.Context(), &auth.AuthContext{Issuer: "https://example.com", ID: "u"}, auth.Action{Repo: "x", Format: "python", Op: auth.OpRead})
+				if err != nil {
+					t.Errorf("Authorize: %v", err)
+				}
+			},
+		},
+		{
+			name:    "invalid yaml",
+			content: "default: [oops",
+			wantErr: true,
+		},
+		{
+			name:    "bad default",
+			content: "default: maybe\n",
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(dir, tc.name+".yaml")
+			if err := os.WriteFile(path, []byte(tc.content), 0o644); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			a, err := Load(path)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("Load() succeeded, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if tc.assert != nil {
+				tc.assert(t, a)
+			}
+		})
+	}
+
+	t.Run("empty path", func(t *testing.T) {
+		t.Parallel()
+		if _, err := Load(""); err == nil {
+			t.Errorf("Load(\"\") succeeded, want error")
+		}
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		t.Parallel()
+		if _, err := Load(filepath.Join(dir, "does-not-exist.yaml")); err == nil {
+			t.Errorf("Load(missing) succeeded, want error")
+		}
+	})
+}

--- a/pkg/auth/staticauthz/watch_test.go
+++ b/pkg/auth/staticauthz/watch_test.go
@@ -1,0 +1,310 @@
+package staticauthz
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/yolocs/ocifactory/pkg/auth"
+)
+
+// reloadWaitTimeout is how long the tests wait for a Watch
+// reload to land. Generous so a slow CI runner doesn't flake;
+// the actual debounce is reloadDebounce, which is much shorter.
+const reloadWaitTimeout = 5 * time.Second
+
+// waitForDecision polls until the authorizer's verdict on the
+// probe action matches wantAllow, or the timeout fires. Tests
+// use this instead of sleeping for the debounce window because
+// debounce + fsnotify latency varies across kernels and CI
+// environments.
+func waitForDecision(t *testing.T, a *Authorizer, ac *auth.AuthContext, act auth.Action, wantAllow bool) {
+	t.Helper()
+	deadline := time.Now().Add(reloadWaitTimeout)
+	for time.Now().Before(deadline) {
+		err := a.Authorize(t.Context(), ac, act)
+		got := err == nil
+		if got == wantAllow {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("authorizer never reached wantAllow=%v within %s", wantAllow, reloadWaitTimeout)
+}
+
+func writeFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %q: %v", path, err)
+	}
+}
+
+const denyConfig = `default: deny
+rules: []
+`
+
+const allowAllConfig = `default: allow
+rules: []
+`
+
+const allowExampleConfig = `default: deny
+rules:
+  - subject:
+      issuer: https://example.com
+    allow:
+      - { repo: "**", format: "*", op: "*" }
+`
+
+// TestWatch_PicksUpInPlaceEdit confirms the simplest case: an
+// operator overwrites the file in place and the watcher reloads.
+func TestWatch_PicksUpInPlaceEdit(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "authz.yaml")
+	writeFile(t, path, denyConfig)
+
+	a, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	if err := a.Watch(ctx); err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	ac := &auth.AuthContext{Issuer: "https://example.com", ID: "u"}
+	act := auth.Action{Repo: "packages/foo", Format: "python", Op: auth.OpRead}
+
+	// Sanity: deny config rejects.
+	if err := a.Authorize(ctx, ac, act); !errors.Is(err, auth.ErrUnauthorized) {
+		t.Fatalf("pre-reload Authorize() = %v, want ErrUnauthorized", err)
+	}
+
+	writeFile(t, path, allowExampleConfig)
+	waitForDecision(t, a, ac, act, true)
+}
+
+// TestWatch_KubernetesConfigMapSymlinkSwap simulates the
+// kubernetes ConfigMap atomic-rename pattern:
+//
+//	<dir>/authz.yaml -> ..data/authz.yaml          (stable symlink)
+//	<dir>/..data     -> ..2026_05_09_12_00_00.0/   (rotated symlink)
+//
+// On update, k8s creates a new timestamped directory, points a
+// ..data_tmp symlink at it, and renames ..data_tmp -> ..data.
+// fsnotify watching the file path alone misses this because the
+// path's inode changes. Watch on the parent directory + re-read
+// via the original path is the reliable shape.
+func TestWatch_KubernetesConfigMapSymlinkSwap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on windows; reload still works on linux/darwin")
+	}
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "authz.yaml")
+
+	// Initial state: timestamped data dir, ..data symlink at it,
+	// authz.yaml symlink to ..data/authz.yaml.
+	dataV1 := filepath.Join(dir, "..2026_05_09_12_00_00.0")
+	if err := os.Mkdir(dataV1, 0o755); err != nil {
+		t.Fatalf("mkdir v1: %v", err)
+	}
+	writeFile(t, filepath.Join(dataV1, "authz.yaml"), denyConfig)
+	if err := os.Symlink(filepath.Base(dataV1), filepath.Join(dir, "..data")); err != nil {
+		t.Fatalf("symlink ..data: %v", err)
+	}
+	if err := os.Symlink("..data/authz.yaml", path); err != nil {
+		t.Fatalf("symlink authz.yaml: %v", err)
+	}
+
+	a, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	if err := a.Watch(ctx); err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	ac := &auth.AuthContext{Issuer: "https://example.com", ID: "u"}
+	act := auth.Action{Repo: "x", Format: "python", Op: auth.OpRead}
+	if err := a.Authorize(ctx, ac, act); !errors.Is(err, auth.ErrUnauthorized) {
+		t.Fatalf("pre-rotation Authorize() = %v, want ErrUnauthorized", err)
+	}
+
+	// Simulate a kubelet ConfigMap rotation: write a new
+	// timestamped dir, create ..data_tmp pointing at it, then
+	// atomically rename ..data_tmp -> ..data. The "authz.yaml"
+	// symlink in the parent directory does not move — it
+	// resolves to the new content because ..data does.
+	dataV2 := filepath.Join(dir, "..2026_05_09_12_00_05.0")
+	if err := os.Mkdir(dataV2, 0o755); err != nil {
+		t.Fatalf("mkdir v2: %v", err)
+	}
+	writeFile(t, filepath.Join(dataV2, "authz.yaml"), allowExampleConfig)
+	tmpLink := filepath.Join(dir, "..data_tmp")
+	if err := os.Symlink(filepath.Base(dataV2), tmpLink); err != nil {
+		t.Fatalf("symlink ..data_tmp: %v", err)
+	}
+	if err := os.Rename(tmpLink, filepath.Join(dir, "..data")); err != nil {
+		t.Fatalf("rename ..data_tmp -> ..data: %v", err)
+	}
+	// k8s also removes the old timestamped dir; do the same so
+	// any final RemoveDir event is exercised.
+	_ = os.RemoveAll(dataV1)
+
+	waitForDecision(t, a, ac, act, true)
+}
+
+// TestWatch_BadFileKeepsPreviousPolicy confirms that writing
+// invalid YAML does NOT replace the in-memory rules — operators
+// shouldn't be able to brick authorization with a typo.
+func TestWatch_BadFileKeepsPreviousPolicy(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "authz.yaml")
+	writeFile(t, path, allowAllConfig)
+
+	a, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	if err := a.Watch(ctx); err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	ac := &auth.AuthContext{Issuer: "https://example.com", ID: "u"}
+	act := auth.Action{Repo: "x", Format: "python", Op: auth.OpRead}
+	if err := a.Authorize(ctx, ac, act); err != nil {
+		t.Fatalf("baseline Authorize: %v", err)
+	}
+
+	// Write garbage. Watcher must NOT replace the loaded rules.
+	writeFile(t, path, "default: ::not yaml::")
+
+	// Wait long enough for any reload to settle, then confirm
+	// the original allow-all is still in effect.
+	time.Sleep(reloadDebounce + 200*time.Millisecond)
+	if err := a.Authorize(ctx, ac, act); err != nil {
+		t.Errorf("after bad reload, Authorize() = %v, want nil (old policy should remain)", err)
+	}
+}
+
+// TestWatch_RejectsNoPathInstance confirms an Authorizer built
+// with New (programmatic, no source path) fails Watch loudly
+// rather than silently doing nothing.
+func TestWatch_RejectsNoPathInstance(t *testing.T) {
+	t.Parallel()
+
+	a, err := New(Config{Default: DefaultDeny})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := a.Watch(t.Context()); err == nil {
+		t.Errorf("Watch on no-path Authorizer succeeded; want error")
+	}
+}
+
+// TestWatch_StopsOnContextCancel confirms canceling the context
+// shuts the goroutine down. We can't easily probe goroutine
+// lifetime from outside, but we can confirm Watch returns and
+// that subsequent edits do NOT trigger reloads (a reasonable
+// proxy: the watcher is gone).
+func TestWatch_StopsOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "authz.yaml")
+	writeFile(t, path, denyConfig)
+
+	a, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	if err := a.Watch(ctx); err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	cancel()
+	// Give the goroutine a moment to notice cancel.
+	time.Sleep(50 * time.Millisecond)
+
+	// Edit the file. If the watcher is still alive it would
+	// reload to allow-all; if it stopped, the policy stays as
+	// deny.
+	writeFile(t, path, allowAllConfig)
+	time.Sleep(reloadDebounce + 200*time.Millisecond)
+
+	ac := &auth.AuthContext{Issuer: "i", ID: "u"}
+	act := auth.Action{Repo: "x", Format: "y", Op: auth.OpRead}
+	if err := a.Authorize(t.Context(), ac, act); !errors.Is(err, auth.ErrUnauthorized) {
+		t.Errorf("after cancel, Authorize() = %v, want ErrUnauthorized (watcher should have stopped)", err)
+	}
+}
+
+// TestWatch_ConcurrentReadDuringSwap stresses the atomic.Pointer
+// hand-off: reads run continuously while reload swaps the rule
+// set, and every read must see a self-consistent verdict (never
+// a torn state). Asserts at minimum that no goroutine panics
+// under -race.
+func TestWatch_ConcurrentReadDuringSwap(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "authz.yaml")
+	writeFile(t, path, denyConfig)
+
+	a, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	if err := a.Watch(ctx); err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	var stop atomic.Bool
+	done := make(chan struct{})
+	go func() {
+		ac := &auth.AuthContext{Issuer: "https://example.com", ID: "u"}
+		act := auth.Action{Repo: "x", Format: "python", Op: auth.OpRead}
+		for !stop.Load() {
+			_ = a.Authorize(ctx, ac, act)
+		}
+		close(done)
+	}()
+
+	// Toggle policies a handful of times so the reload path
+	// exercises the atomic swap repeatedly while reads are in
+	// flight.
+	for i := 0; i < 4; i++ {
+		if i%2 == 0 {
+			writeFile(t, path, allowExampleConfig)
+		} else {
+			writeFile(t, path, denyConfig)
+		}
+		time.Sleep(reloadDebounce + 200*time.Millisecond)
+	}
+
+	stop.Store(true)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("reader goroutine did not exit")
+	}
+}
+

--- a/pkg/commands/serve.go
+++ b/pkg/commands/serve.go
@@ -16,6 +16,7 @@ import (
 	"github.com/yolocs/ocifactory/pkg/auth/backend"
 	"github.com/yolocs/ocifactory/pkg/auth/chain"
 	"github.com/yolocs/ocifactory/pkg/auth/oidc"
+	"github.com/yolocs/ocifactory/pkg/auth/staticauthz"
 	"github.com/yolocs/ocifactory/pkg/handler"
 	"github.com/yolocs/ocifactory/pkg/handler/echo"
 	"github.com/yolocs/ocifactory/pkg/handler/maven"
@@ -79,6 +80,7 @@ const (
 	flagBackendAuthStaticEnvUserEnv     = "backend-auth-staticenv-user-env"
 	flagBackendAuthStaticEnvPasswordEnv = "backend-auth-staticenv-password-env"
 	flagBackendAuthDockerConfigPath     = "backend-auth-dockerconfig-path"
+	flagAuthzConfig                     = "authz-config"
 )
 
 // serveConfig is the typed view of the resolved CLI/env/default
@@ -108,6 +110,8 @@ type serveConfig struct {
 	BackendAuthStaticEnvUserEnv     string   `mapstructure:"backend-auth-staticenv-user-env"`
 	BackendAuthStaticEnvPasswordEnv string   `mapstructure:"backend-auth-staticenv-password-env"`
 	BackendAuthDockerConfigPath     string   `mapstructure:"backend-auth-dockerconfig-path"`
+
+	AuthzConfig string `mapstructure:"authz-config"`
 
 	// RegistryURL is computed by Validate from BackendRegistry. Not
 	// populated by Unmarshal — the `-` tag tells mapstructure to
@@ -310,6 +314,15 @@ func registerServeFlags(flags *pflag.FlagSet) {
 	flags.String(flagBackendAuthDockerConfigPath, "",
 		"Path to a docker-format config.json for the dockerconfig backend "+
 			"auth kind. Empty = ~/.docker/config.json.")
+
+	// Authorization (config-file policy).
+	flags.String(flagAuthzConfig, "",
+		"Path to a YAML authorization policy file. When set, every "+
+			"per-format route consults the resulting Authorizer with a "+
+			"(repo, format, op) Action and returns 403 on deny. When "+
+			"empty, no authorization check runs and every authenticated "+
+			"caller can read and write everything — fine for local dev "+
+			"but not for production. See docs/auth.md for the file format.")
 }
 
 func runServe(ctx context.Context, cfg *serveConfig) error {
@@ -320,6 +333,11 @@ func runServe(ctx context.Context, cfg *serveConfig) error {
 		return fmt.Errorf("failed to build authenticator: %w", err)
 	}
 	authMW := auth.Middleware(authn)
+
+	authz, err := buildAuthz(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("failed to build authorizer: %w", err)
+	}
 
 	bp, err := buildBackendAuth(ctx, cfg)
 	if err != nil {
@@ -348,7 +366,10 @@ func runServe(ctx context.Context, cfg *serveConfig) error {
 		if err != nil {
 			return fmt.Errorf("failed to create registry: %w", err)
 		}
-		mh, err := maven.NewHandler(r, maven.WithAuthMiddleware(authMW))
+		mh, err := maven.NewHandler(r,
+			maven.WithAuthMiddleware(authMW),
+			maven.WithAuthorizer(authz),
+		)
 		if err != nil {
 			return fmt.Errorf("failed to create maven handler: %w", err)
 		}
@@ -365,6 +386,7 @@ func runServe(ctx context.Context, cfg *serveConfig) error {
 			python.WithSimpleIndexCacheTTL(cfg.SimpleIndexCacheTTL),
 			python.WithMaxUploadBytes(cfg.PythonMaxUploadBytes),
 			python.WithAuthMiddleware(authMW),
+			python.WithAuthorizer(authz),
 		)
 		if err != nil {
 			return fmt.Errorf("failed to create python handler: %w", err)
@@ -375,7 +397,10 @@ func runServe(ctx context.Context, cfg *serveConfig) error {
 		// backend, so reg stays nil — ObservabilityHandler treats a
 		// nil pinger as "no backend configured" and /readyz collapses
 		// to liveness, which is what we want.
-		eh := echo.NewHandler(echo.WithAuthMiddleware(authMW))
+		eh := echo.NewHandler(
+			echo.WithAuthMiddleware(authMW),
+			echo.WithAuthorizer(authz),
+		)
 		format, h = echo.RepoType, eh.Mux()
 	default:
 		return fmt.Errorf("repo-type %q is not supported", cfg.RepoType)
@@ -445,6 +470,30 @@ func buildAuthn(ctx context.Context, cfg *serveConfig) (auth.Authenticator, erro
 		// clean error.
 		return nil, fmt.Errorf("authn-kind %q is not supported (allowed: %v)", cfg.AuthnKind, supportedAuthnKinds)
 	}
+}
+
+// buildAuthz constructs the auth.Authorizer applied to every
+// per-format route. When --authz-config is empty the function
+// returns nil and a startup warning is logged — handlers treat a
+// nil authorizer as "every authenticated caller is allowed",
+// which is fine for local dev but not production. When the flag
+// is set the static config file is loaded; any parse / regex
+// error fails the startup so policy mistakes never silently let
+// callers through.
+func buildAuthz(ctx context.Context, cfg *serveConfig) (auth.Authorizer, error) {
+	logger := logging.NewFromEnv("OCIFACTORY_")
+	if cfg.AuthzConfig == "" {
+		logger.WarnContext(ctx, "no authorization policy configured (set --authz-config / "+
+			"OCIFACTORY_AUTHZ_CONFIG). Every authenticated caller can read and write everything — "+
+			"only safe for local development.")
+		return nil, nil
+	}
+	a, err := staticauthz.Load(cfg.AuthzConfig)
+	if err != nil {
+		return nil, fmt.Errorf("load authz config %q: %w", cfg.AuthzConfig, err)
+	}
+	logger.InfoContext(ctx, "authorization policy loaded", "path", cfg.AuthzConfig)
+	return a, nil
 }
 
 // buildBackendAuth constructs the credential provider ocifactory

--- a/pkg/commands/serve.go
+++ b/pkg/commands/serve.go
@@ -480,6 +480,12 @@ func buildAuthn(ctx context.Context, cfg *serveConfig) (auth.Authenticator, erro
 // is set the static config file is loaded; any parse / regex
 // error fails the startup so policy mistakes never silently let
 // callers through.
+//
+// On success a goroutine is spun up to watch the config file and
+// reload on changes. The watcher is wired against the request
+// context so it shuts down with the rest of the server. The
+// reloader handles kubernetes ConfigMap volume mounts (atomic
+// symlink swap on update) — see staticauthz.Authorizer.Watch.
 func buildAuthz(ctx context.Context, cfg *serveConfig) (auth.Authorizer, error) {
 	logger := logging.NewFromEnv("OCIFACTORY_")
 	if cfg.AuthzConfig == "" {
@@ -492,7 +498,10 @@ func buildAuthz(ctx context.Context, cfg *serveConfig) (auth.Authorizer, error) 
 	if err != nil {
 		return nil, fmt.Errorf("load authz config %q: %w", cfg.AuthzConfig, err)
 	}
-	logger.InfoContext(ctx, "authorization policy loaded", "path", cfg.AuthzConfig)
+	if err := a.Watch(logging.WithLogger(ctx, logger)); err != nil {
+		return nil, fmt.Errorf("watch authz config %q: %w", cfg.AuthzConfig, err)
+	}
+	logger.InfoContext(ctx, "authorization policy loaded; watching for changes", "path", cfg.AuthzConfig)
 	return a, nil
 }
 

--- a/pkg/commands/serve_test.go
+++ b/pkg/commands/serve_test.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -10,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/yolocs/ocifactory/pkg/auth"
 	"github.com/yolocs/ocifactory/pkg/handler/python"
 	"github.com/yolocs/ocifactory/pkg/testutil"
 )
@@ -184,6 +187,7 @@ func TestServeCmd_Flags(t *testing.T) {
 		{name: flagBackendAuthStaticEnvUserEnv, flagName: flagBackendAuthStaticEnvUserEnv},
 		{name: flagBackendAuthStaticEnvPasswordEnv, flagName: flagBackendAuthStaticEnvPasswordEnv},
 		{name: flagBackendAuthDockerConfigPath, flagName: flagBackendAuthDockerConfigPath},
+		{name: flagAuthzConfig, flagName: flagAuthzConfig},
 	}
 
 	for _, tc := range tests {
@@ -198,6 +202,57 @@ func TestServeCmd_Flags(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildAuthz(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty config returns nil authorizer", func(t *testing.T) {
+		t.Parallel()
+		got, err := buildAuthz(t.Context(), &serveConfig{AuthzConfig: ""})
+		if err != nil {
+			t.Fatalf("buildAuthz: %v", err)
+		}
+		if got != nil {
+			t.Errorf("buildAuthz returned %T, want nil", got)
+		}
+	})
+
+	t.Run("loads config file", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "authz.yaml")
+		body := `default: deny
+rules:
+  - subject:
+      issuer: https://example.com
+    allow:
+      - { repo: "*", format: "*", op: read }
+`
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		got, err := buildAuthz(t.Context(), &serveConfig{AuthzConfig: path})
+		if err != nil {
+			t.Fatalf("buildAuthz: %v", err)
+		}
+		if got == nil {
+			t.Fatal("buildAuthz returned nil; want a real Authorizer")
+		}
+		// Sanity-check the rule actually loaded.
+		ac := &auth.AuthContext{Issuer: "https://example.com", ID: "u"}
+		if err := got.Authorize(t.Context(), ac, auth.Action{Repo: "anything", Format: "python", Op: auth.OpRead}); err != nil {
+			t.Errorf("Authorize: %v", err)
+		}
+	})
+
+	t.Run("missing file errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := buildAuthz(t.Context(), &serveConfig{AuthzConfig: filepath.Join(t.TempDir(), "nope.yaml")})
+		if err == nil {
+			t.Errorf("buildAuthz with missing file succeeded; want error")
+		}
+	})
 }
 
 // TestServeCmd_EnvVarBindings exercises viper's resolution chain end

--- a/pkg/handler/echo/authz_test.go
+++ b/pkg/handler/echo/authz_test.go
@@ -1,0 +1,74 @@
+package echo
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/yolocs/ocifactory/pkg/auth"
+)
+
+// TestAuthz_PerRoute proves both echo routes call the authorizer
+// with (Repo: "echo", Format: RepoType, Op: read).
+func TestAuthz_PerRoute(t *testing.T) {
+	t.Parallel()
+
+	installCtx := auth.Middleware(auth.AuthenticatorFunc(func(*http.Request) (*auth.AuthContext, error) {
+		return &auth.AuthContext{Issuer: "test", ID: "alice"}, nil
+	}))
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "echo", path: "/echo/hello"},
+		{name: "whoami", path: "/whoami"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got auth.Action
+			authz := auth.AuthorizerFunc(func(_ context.Context, _ *auth.AuthContext, act auth.Action) error {
+				got = act
+				return auth.ErrUnauthorized
+			})
+			h := NewHandler(WithAuthMiddleware(installCtx), WithAuthorizer(authz))
+			r := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			w := httptest.NewRecorder()
+			h.Mux().ServeHTTP(w, r)
+
+			if w.Code != http.StatusForbidden {
+				t.Errorf("status = %d, want 403 (body: %s)", w.Code, w.Body.String())
+			}
+			want := auth.Action{Repo: "echo", Format: RepoType, Op: auth.OpRead}
+			if got != want {
+				t.Errorf("authorizer Action = %+v, want %+v", got, want)
+			}
+		})
+	}
+}
+
+// TestAuthz_InternalError confirms a non-sentinel authz error
+// becomes 500.
+func TestAuthz_InternalError(t *testing.T) {
+	t.Parallel()
+
+	installCtx := auth.Middleware(auth.AuthenticatorFunc(func(*http.Request) (*auth.AuthContext, error) {
+		return &auth.AuthContext{Issuer: "test", ID: "alice"}, nil
+	}))
+
+	authz := auth.AuthorizerFunc(func(context.Context, *auth.AuthContext, auth.Action) error {
+		return errors.New("authz down")
+	})
+	h := NewHandler(WithAuthMiddleware(installCtx), WithAuthorizer(authz))
+	r := httptest.NewRequest(http.MethodGet, "/whoami", nil)
+	w := httptest.NewRecorder()
+	h.Mux().ServeHTTP(w, r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500 (body: %s)", w.Code, w.Body.String())
+	}
+}

--- a/pkg/handler/echo/handler.go
+++ b/pkg/handler/echo/handler.go
@@ -16,6 +16,7 @@ package echo
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -29,6 +30,7 @@ const RepoType = "echo"
 // Handler serves the echo routes.
 type Handler struct {
 	authMW func(http.Handler) http.Handler
+	authz  auth.Authorizer
 }
 
 // Option configures optional Handler behaviour.
@@ -36,6 +38,7 @@ type Option func(*handlerConfig)
 
 type handlerConfig struct {
 	authMW func(http.Handler) http.Handler
+	authz  auth.Authorizer
 }
 
 // WithAuthMiddleware installs an authentication middleware on every
@@ -47,13 +50,23 @@ func WithAuthMiddleware(mw func(http.Handler) http.Handler) Option {
 	}
 }
 
+// WithAuthorizer installs an auth.Authorizer that the echo routes
+// consult after authentication. The CI OIDC end-to-end job uses
+// this to assert authz wiring runs against a real verified
+// AuthContext.
+func WithAuthorizer(a auth.Authorizer) Option {
+	return func(c *handlerConfig) {
+		c.authz = a
+	}
+}
+
 // NewHandler creates a new echo Handler.
 func NewHandler(opts ...Option) *Handler {
 	var cfg handlerConfig
 	for _, opt := range opts {
 		opt(&cfg)
 	}
-	return &Handler{authMW: cfg.authMW}
+	return &Handler{authMW: cfg.authMW, authz: cfg.authz}
 }
 
 // Mux returns the echo router. Both routes are auth-gated when
@@ -94,6 +107,9 @@ type callerSummary struct {
 }
 
 func (h *Handler) handleEcho(w http.ResponseWriter, r *http.Request) {
+	if !h.authorize(w, r, auth.Action{Repo: "echo", Format: RepoType, Op: auth.OpRead}) {
+		return
+	}
 	msg := mux.Vars(r)["message"]
 	writeJSON(w, http.StatusOK, echoResponse{
 		Message: msg,
@@ -102,9 +118,27 @@ func (h *Handler) handleEcho(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleWhoami(w http.ResponseWriter, r *http.Request) {
+	if !h.authorize(w, r, auth.Action{Repo: "echo", Format: RepoType, Op: auth.OpRead}) {
+		return
+	}
 	writeJSON(w, http.StatusOK, whoamiResponse{
 		Caller: callerFromContext(r),
 	})
+}
+
+// authorize translates the configured Authorizer's decision into
+// an HTTP response. Returns true on allow, false after writing an
+// error response.
+func (h *Handler) authorize(w http.ResponseWriter, r *http.Request, act auth.Action) bool {
+	if err := auth.Check(r.Context(), h.authz, act); err != nil {
+		if errors.Is(err, auth.ErrUnauthorized) {
+			http.Error(w, "forbidden", http.StatusForbidden)
+		} else {
+			http.Error(w, "authorization error", http.StatusInternalServerError)
+		}
+		return false
+	}
+	return true
 }
 
 func callerFromContext(r *http.Request) *callerSummary {

--- a/pkg/handler/maven/authz_test.go
+++ b/pkg/handler/maven/authz_test.go
@@ -1,0 +1,157 @@
+package maven
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/yolocs/ocifactory/pkg/auth"
+	"github.com/yolocs/ocifactory/pkg/oci"
+)
+
+// TestAuthz_PerRoute proves every Maven route translates the
+// inbound HTTP request into the expected (Repo, Format, Op)
+// Action and that auth.ErrUnauthorized maps to 403.
+func TestAuthz_PerRoute(t *testing.T) {
+	t.Parallel()
+
+	installCtx := auth.Middleware(auth.AuthenticatorFunc(func(*http.Request) (*auth.AuthContext, error) {
+		return &auth.AuthContext{Issuer: "test", ID: "alice"}, nil
+	}))
+
+	tests := []struct {
+		name    string
+		method  string
+		path    string
+		wantAct auth.Action
+	}{
+		{
+			name:    "archetype catalog read",
+			method:  http.MethodGet,
+			path:    "/archetype-catalog.xml",
+			wantAct: auth.Action{Repo: "archetype", Format: RepoType, Op: auth.OpRead},
+		},
+		{
+			name:    "archetype catalog write",
+			method:  http.MethodPut,
+			path:    "/archetype-catalog.xml",
+			wantAct: auth.Action{Repo: "archetype", Format: RepoType, Op: auth.OpWrite},
+		},
+		{
+			name:    "snapshot metadata read",
+			method:  http.MethodGet,
+			path:    "/com/example/foo/1.0-SNAPSHOT/maven-metadata.xml",
+			wantAct: auth.Action{Repo: "com/example/foo", Format: RepoType, Op: auth.OpRead},
+		},
+		{
+			name:    "snapshot metadata write",
+			method:  http.MethodPut,
+			path:    "/com/example/foo/1.0-SNAPSHOT/maven-metadata.xml",
+			wantAct: auth.Action{Repo: "com/example/foo", Format: RepoType, Op: auth.OpWrite},
+		},
+		{
+			name:    "release metadata read",
+			method:  http.MethodGet,
+			path:    "/com/example/foo/maven-metadata.xml",
+			wantAct: auth.Action{Repo: "com/example/foo", Format: RepoType, Op: auth.OpRead},
+		},
+		{
+			name:    "regular artifact read",
+			method:  http.MethodGet,
+			path:    "/com/example/foo/1.0/foo-1.0.jar",
+			wantAct: auth.Action{Repo: "com/example/foo", Format: RepoType, Op: auth.OpRead},
+		},
+		{
+			name:    "regular artifact write",
+			method:  http.MethodPut,
+			path:    "/com/example/foo/1.0/foo-1.0.jar",
+			wantAct: auth.Action{Repo: "com/example/foo", Format: RepoType, Op: auth.OpWrite},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got auth.Action
+			authz := auth.AuthorizerFunc(func(_ context.Context, _ *auth.AuthContext, act auth.Action) error {
+				got = act
+				return auth.ErrUnauthorized
+			})
+			h, err := NewHandler(oci.NewFakeRegistry(),
+				WithAuthMiddleware(installCtx),
+				WithAuthorizer(authz),
+			)
+			if err != nil {
+				t.Fatalf("NewHandler: %v", err)
+			}
+			srv := h.Mux()
+
+			r := httptest.NewRequest(tc.method, tc.path, strings.NewReader(""))
+			w := httptest.NewRecorder()
+			srv.ServeHTTP(w, r)
+
+			if w.Code != http.StatusForbidden {
+				t.Errorf("status = %d, want 403 (body: %s)", w.Code, w.Body.String())
+			}
+			if got != tc.wantAct {
+				t.Errorf("authorizer Action = %+v, want %+v", got, tc.wantAct)
+			}
+		})
+	}
+}
+
+// TestAuthz_NoAuthorizerOpen confirms omitting WithAuthorizer
+// leaves routes open. Production wiring always supplies one.
+func TestAuthz_NoAuthorizerOpen(t *testing.T) {
+	t.Parallel()
+
+	installCtx := auth.Middleware(auth.AuthenticatorFunc(func(*http.Request) (*auth.AuthContext, error) {
+		return &auth.AuthContext{Issuer: "test", ID: "alice"}, nil
+	}))
+
+	h, err := NewHandler(oci.NewFakeRegistry(), WithAuthMiddleware(installCtx))
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	srv := h.Mux()
+
+	r := httptest.NewRequest(http.MethodGet, "/archetype-catalog.xml", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+	if w.Code == http.StatusForbidden {
+		t.Errorf("status = 403 with no authorizer; default should be open (body: %s)", w.Body.String())
+	}
+}
+
+// TestAuthz_InternalError maps a non-ErrUnauthorized authorizer
+// error to 500 rather than 403.
+func TestAuthz_InternalError(t *testing.T) {
+	t.Parallel()
+
+	installCtx := auth.Middleware(auth.AuthenticatorFunc(func(*http.Request) (*auth.AuthContext, error) {
+		return &auth.AuthContext{Issuer: "test", ID: "alice"}, nil
+	}))
+
+	authz := auth.AuthorizerFunc(func(context.Context, *auth.AuthContext, auth.Action) error {
+		return errors.New("authz backend down")
+	})
+	h, err := NewHandler(oci.NewFakeRegistry(),
+		WithAuthMiddleware(installCtx),
+		WithAuthorizer(authz),
+	)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	srv := h.Mux()
+
+	r := httptest.NewRequest(http.MethodGet, "/archetype-catalog.xml", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500 (body: %s)", w.Code, w.Body.String())
+	}
+}

--- a/pkg/handler/maven/handler.go
+++ b/pkg/handler/maven/handler.go
@@ -2,6 +2,7 @@ package maven
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -10,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
+	"github.com/yolocs/ocifactory/pkg/auth"
 	"github.com/yolocs/ocifactory/pkg/handler"
 	"github.com/yolocs/ocifactory/pkg/logging"
 	"github.com/yolocs/ocifactory/pkg/oci"
@@ -49,6 +51,7 @@ var (
 type Handler struct {
 	registry handler.Registry
 	authMW   func(http.Handler) http.Handler
+	authz    auth.Authorizer
 }
 
 // Option configures optional Handler behaviour.
@@ -56,6 +59,7 @@ type Option func(*handlerConfig)
 
 type handlerConfig struct {
 	authMW func(http.Handler) http.Handler
+	authz  auth.Authorizer
 }
 
 // WithAuthMiddleware installs an authentication middleware on
@@ -67,12 +71,46 @@ func WithAuthMiddleware(mw func(http.Handler) http.Handler) Option {
 	}
 }
 
+// WithAuthorizer installs an auth.Authorizer that every Maven
+// route consults after authentication. See python.WithAuthorizer
+// for the full contract — the wiring here is symmetric.
+func WithAuthorizer(a auth.Authorizer) Option {
+	return func(c *handlerConfig) {
+		c.authz = a
+	}
+}
+
 func NewHandler(registry handler.Registry, opts ...Option) (*Handler, error) {
 	cfg := handlerConfig{}
 	for _, opt := range opts {
 		opt(&cfg)
 	}
-	return &Handler{registry: registry, authMW: cfg.authMW}, nil
+	return &Handler{registry: registry, authMW: cfg.authMW, authz: cfg.authz}, nil
+}
+
+// authorize translates the configured Authorizer's decision into
+// an HTTP response. Returns true when the caller should proceed,
+// false when an error response has been written.
+func (h *Handler) authorize(ctx context.Context, w http.ResponseWriter, act auth.Action) bool {
+	err := auth.Check(ctx, h.authz, act)
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, auth.ErrUnauthorized) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return false
+	}
+	handler.WriteError(ctx, w, http.StatusInternalServerError, err, "authorization error")
+	return false
+}
+
+// opForMethod maps an HTTP method onto an auth.Op. PUT/POST are
+// writes; everything else (GET/HEAD) is a read.
+func opForMethod(m string) auth.Op {
+	if m == http.MethodPut || m == http.MethodPost {
+		return auth.OpWrite
+	}
+	return auth.OpRead
 }
 
 func (h *Handler) Mux() http.Handler {
@@ -113,6 +151,9 @@ func (h *Handler) handleArchetypeCatalog(w http.ResponseWriter, req *http.Reques
 		Name:       "archetype-catalog.xml",
 		MediaType:  "text/xml",
 	}
+	if !h.authorize(req.Context(), w, auth.Action{Repo: f.OwningRepo, Format: RepoType, Op: opForMethod(req.Method)}) {
+		return
+	}
 	if req.Method == http.MethodPut || req.Method == http.MethodPost {
 		h.handlePut(w, req, f)
 	} else { // GET, HEAD
@@ -137,6 +178,9 @@ func (h *Handler) handleSnapshotMetadata(w http.ResponseWriter, req *http.Reques
 		Name:       "maven-metadata.xml",
 		MediaType:  "text/xml",
 	}
+	if !h.authorize(req.Context(), w, auth.Action{Repo: f.OwningRepo, Format: RepoType, Op: opForMethod(req.Method)}) {
+		return
+	}
 	if req.Method == http.MethodPut || req.Method == http.MethodPost {
 		h.handlePut(w, req, f)
 	} else { // GET, HEAD
@@ -159,6 +203,9 @@ func (h *Handler) handleArtifactMetadata(w http.ResponseWriter, req *http.Reques
 		OwningTag:  "metadata", // For release artifact or version metadata
 		Name:       "maven-metadata.xml",
 		MediaType:  "text/xml",
+	}
+	if !h.authorize(req.Context(), w, auth.Action{Repo: f.OwningRepo, Format: RepoType, Op: opForMethod(req.Method)}) {
+		return
 	}
 	if req.Method == http.MethodPut || req.Method == http.MethodPost {
 		h.handlePut(w, req, f)
@@ -184,6 +231,9 @@ func (h *Handler) handleRegularArtifact(w http.ResponseWriter, req *http.Request
 		OwningTag:  version,
 		Name:       filename,
 		MediaType:  detectMediaType(filename),
+	}
+	if !h.authorize(req.Context(), w, auth.Action{Repo: f.OwningRepo, Format: RepoType, Op: opForMethod(req.Method)}) {
+		return
 	}
 	if req.Method == http.MethodPut || req.Method == http.MethodPost {
 		h.handlePut(w, req, f)

--- a/pkg/handler/python/authz_test.go
+++ b/pkg/handler/python/authz_test.go
@@ -1,0 +1,209 @@
+package python
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/yolocs/ocifactory/pkg/auth"
+	"github.com/yolocs/ocifactory/pkg/oci"
+)
+
+// TestAuthz_PerRoute proves every routed handler calls the
+// authorizer with the right (Repo, Format, Op) Action and that
+// auth.ErrUnauthorized comes back as 403 (not 401). The
+// authentication middleware always installs an AuthContext so
+// the authorizer is the only thing deciding the verdict.
+func TestAuthz_PerRoute(t *testing.T) {
+	t.Parallel()
+
+	const subjectIssuer = "test"
+	installCtx := auth.Middleware(auth.AuthenticatorFunc(func(*http.Request) (*auth.AuthContext, error) {
+		return &auth.AuthContext{Issuer: subjectIssuer, ID: "alice"}, nil
+	}))
+
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		body       func() (io.Reader, string) // returns body + content-type
+		wantAct    auth.Action
+		wantStatus int // when the authorizer denies
+	}{
+		{
+			name:       "simple index list",
+			method:     http.MethodGet,
+			path:       "/simple/",
+			wantAct:    auth.Action{Repo: "index", Format: RepoType, Op: auth.OpRead},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "package index read",
+			method:     http.MethodGet,
+			path:       "/simple/foo/",
+			wantAct:    auth.Action{Repo: "packages/foo", Format: RepoType, Op: auth.OpRead},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "file get",
+			method:     http.MethodGet,
+			path:       "/packages/foo/1.0/foo-1.0.tar.gz",
+			wantAct:    auth.Action{Repo: "packages/foo", Format: RepoType, Op: auth.OpRead},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:   "upload write",
+			method: http.MethodPost,
+			path:   "/",
+			body: func() (io.Reader, string) {
+				var b bytes.Buffer
+				mw := multipart.NewWriter(&b)
+				_ = mw.WriteField("name", "Foo")
+				_ = mw.WriteField("version", "1.0")
+				fw, _ := mw.CreateFormFile("content", "foo-1.0.tar.gz")
+				_, _ = fw.Write([]byte("payload"))
+				_ = mw.Close()
+				return &b, mw.FormDataContentType()
+			},
+			wantAct:    auth.Action{Repo: "packages/foo", Format: RepoType, Op: auth.OpWrite},
+			wantStatus: http.StatusForbidden,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got auth.Action
+			authz := auth.AuthorizerFunc(func(_ context.Context, ac *auth.AuthContext, act auth.Action) error {
+				got = act
+				if ac.Issuer != subjectIssuer {
+					t.Errorf("subject issuer = %q, want %q", ac.Issuer, subjectIssuer)
+				}
+				return auth.ErrUnauthorized
+			})
+
+			h, err := NewHandler(oci.NewFakeRegistry(),
+				WithAuthMiddleware(installCtx),
+				WithAuthorizer(authz),
+			)
+			if err != nil {
+				t.Fatalf("NewHandler: %v", err)
+			}
+			srv := h.Mux()
+
+			var body io.Reader
+			contentType := ""
+			if tc.body != nil {
+				body, contentType = tc.body()
+			}
+			r := httptest.NewRequest(tc.method, tc.path, body)
+			if contentType != "" {
+				r.Header.Set("Content-Type", contentType)
+			}
+			w := httptest.NewRecorder()
+			srv.ServeHTTP(w, r)
+
+			if w.Code != tc.wantStatus {
+				t.Errorf("status = %d, want %d (body: %s)", w.Code, tc.wantStatus, w.Body.String())
+			}
+			if got != tc.wantAct {
+				t.Errorf("authorizer Action = %+v, want %+v", got, tc.wantAct)
+			}
+		})
+	}
+}
+
+// TestAuthz_AllowsRequest confirms that returning nil from the
+// Authorizer lets the request through to the route handler.
+func TestAuthz_AllowsRequest(t *testing.T) {
+	t.Parallel()
+
+	installCtx := auth.Middleware(auth.AuthenticatorFunc(func(*http.Request) (*auth.AuthContext, error) {
+		return &auth.AuthContext{Issuer: "test", ID: "alice"}, nil
+	}))
+
+	h, err := NewHandler(oci.NewFakeRegistry(),
+		WithAuthMiddleware(installCtx),
+		WithAuthorizer(auth.AllowAll),
+	)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	srv := h.Mux()
+
+	r := httptest.NewRequest(http.MethodGet, "/simple/", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	if w.Code == http.StatusForbidden || w.Code == http.StatusUnauthorized {
+		t.Errorf("status = %d; AllowAll authorizer should let the request through (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+// TestAuthz_NoAuthorizerOpen confirms that omitting WithAuthorizer
+// leaves routes open. The serve command always supplies one in
+// production, so this case applies to tests and to operators
+// running behind another authz layer.
+func TestAuthz_NoAuthorizerOpen(t *testing.T) {
+	t.Parallel()
+
+	installCtx := auth.Middleware(auth.AuthenticatorFunc(func(*http.Request) (*auth.AuthContext, error) {
+		return &auth.AuthContext{Issuer: "test", ID: "alice"}, nil
+	}))
+
+	h, err := NewHandler(oci.NewFakeRegistry(), WithAuthMiddleware(installCtx))
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	srv := h.Mux()
+
+	r := httptest.NewRequest(http.MethodGet, "/simple/", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	if w.Code == http.StatusForbidden {
+		t.Errorf("status = 403 with no authorizer configured; default should be open (body: %s)", w.Body.String())
+	}
+}
+
+// TestAuthz_InternalError maps a non-ErrUnauthorized authorizer
+// error to 500 rather than 403 so transient authorization-system
+// failures don't look like a legitimate policy denial.
+func TestAuthz_InternalError(t *testing.T) {
+	t.Parallel()
+
+	installCtx := auth.Middleware(auth.AuthenticatorFunc(func(*http.Request) (*auth.AuthContext, error) {
+		return &auth.AuthContext{Issuer: "test", ID: "alice"}, nil
+	}))
+
+	authz := auth.AuthorizerFunc(func(context.Context, *auth.AuthContext, auth.Action) error {
+		return errInternal
+	})
+	h, err := NewHandler(oci.NewFakeRegistry(),
+		WithAuthMiddleware(installCtx),
+		WithAuthorizer(authz),
+	)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	srv := h.Mux()
+
+	r := httptest.NewRequest(http.MethodGet, "/simple/", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500 (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+// errInternal is a deliberate non-sentinel error returned by the
+// internal-error authz fake — confirms Check passes through
+// arbitrary errors as 500.
+var errInternal = errors.New("authz backend down")

--- a/pkg/handler/python/handler.go
+++ b/pkg/handler/python/handler.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/yolocs/ocifactory/pkg/auth"
 	"github.com/yolocs/ocifactory/pkg/handler"
 	"github.com/yolocs/ocifactory/pkg/logging"
 	"github.com/yolocs/ocifactory/pkg/oci"
@@ -93,6 +94,7 @@ type Handler struct {
 	renderer       *renderer.Renderer
 	indexCache     *simpleIndexCache
 	authMW         func(http.Handler) http.Handler
+	authz          auth.Authorizer
 	maxUploadBytes int64
 }
 
@@ -102,6 +104,7 @@ type Option func(*handlerConfig)
 type handlerConfig struct {
 	simpleIndexCacheTTL time.Duration
 	authMW              func(http.Handler) http.Handler
+	authz               auth.Authorizer
 	maxUploadBytes      int64
 }
 
@@ -140,6 +143,23 @@ func WithAuthMiddleware(mw func(http.Handler) http.Handler) Option {
 	}
 }
 
+// WithAuthorizer installs an auth.Authorizer that every route in
+// this handler consults after the request has been authenticated.
+// Each route translates the inbound HTTP request into an
+// auth.Action (Repo / Format / Op) and calls auth.Check; failures
+// short-circuit with 403 (auth.ErrUnauthorized) or 500 (any other
+// authorization-system error).
+//
+// Pass nil (or omit the option) to skip authorization entirely —
+// useful for tests and for deployments running behind another
+// authz layer. The serve command always supplies an authorizer
+// so production wiring fails closed.
+func WithAuthorizer(a auth.Authorizer) Option {
+	return func(c *handlerConfig) {
+		c.authz = a
+	}
+}
+
 // NewHandler creates a new Handler.
 func NewHandler(registry handler.Registry, opts ...Option) (*Handler, error) {
 	cfg := handlerConfig{
@@ -158,8 +178,26 @@ func NewHandler(registry handler.Registry, opts ...Option) (*Handler, error) {
 		renderer:       r,
 		indexCache:     newSimpleIndexCache(cfg.simpleIndexCacheTTL),
 		authMW:         cfg.authMW,
+		authz:          cfg.authz,
 		maxUploadBytes: cfg.maxUploadBytes,
 	}, nil
+}
+
+// authorize checks the action against the configured Authorizer
+// (if any) and writes the matching HTTP response on failure.
+// Returns true when the caller should proceed, false when an
+// error response has already been written.
+func (h *Handler) authorize(ctx context.Context, w http.ResponseWriter, act auth.Action) bool {
+	err := auth.Check(ctx, h.authz, act)
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, auth.ErrUnauthorized) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return false
+	}
+	handler.WriteError(ctx, w, http.StatusInternalServerError, err, "authorization error")
+	return false
 }
 
 // Mux returns a new ServeMux that handles the Python handler's routes.
@@ -201,6 +239,9 @@ func (h *Handler) Mux() http.Handler {
 // (already-normalized) package name; ListTags is enough to enumerate
 // them.
 func (h *Handler) handleSimpleIndex(w http.ResponseWriter, req *http.Request) {
+	if !h.authorize(req.Context(), w, auth.Action{Repo: "index", Format: RepoType, Op: auth.OpRead}) {
+		return
+	}
 	tags, err := h.registry.ListTags(req.Context(), "index")
 	if err != nil && !errors.Is(err, errdef.ErrNotFound) {
 		handler.WriteError(req.Context(), w, http.StatusInternalServerError, err, "failed to list package index")
@@ -338,6 +379,10 @@ func (h *Handler) handleFilePut(w http.ResponseWriter, req *http.Request) {
 	}
 
 	normalizedName := normalize(pkgName)
+
+	if !h.authorize(ctx, w, auth.Action{Repo: "packages/" + normalizedName, Format: RepoType, Op: auth.OpWrite}) {
+		return
+	}
 
 	wheelRF := &oci.RepoFile{
 		OwningRepo: "packages/" + normalizedName,
@@ -509,6 +554,9 @@ func (h *Handler) handleFileGet(w http.ResponseWriter, req *http.Request) {
 	}
 
 	pkg = normalize(pkg)
+	if !h.authorize(req.Context(), w, auth.Action{Repo: "packages/" + pkg, Format: RepoType, Op: auth.OpRead}) {
+		return
+	}
 	f := &oci.RepoFile{
 		OwningRepo: "packages/" + pkg,
 		OwningTag:  version,
@@ -527,6 +575,10 @@ func (h *Handler) handlePackageIndex(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	pkg = normalize(pkg)
+
+	if !h.authorize(req.Context(), w, auth.Action{Repo: "packages/" + pkg, Format: RepoType, Op: auth.OpRead}) {
+		return
+	}
 
 	files, ok := h.indexCache.get(pkg)
 	if !ok {


### PR DESCRIPTION
Defines the Authorizer interface (Action, Op{Read,Write}, Check
helper, ErrUnauthorized) in pkg/auth and ships a config-file
backed implementation in pkg/auth/staticauthz with subject and
action matchers (issuer, sub_match, email, claims_match,
glob-based repo/format/op, default deny). Wires per-route
authorization into the python, maven, and echo handlers via a
new WithAuthorizer option, and exposes the policy file path via
--authz-config / OCIFACTORY_AUTHZ_CONFIG. Read/write granularity
matches the surface ocifactory exposes today; richer operations
fall behind a custom Authorizer.

Per-format handlers translate the inbound request into an
auth.Action whose Repo matches the OCI repo pkg/oci.RepoFile
already uses, so policies are written against the same names
operators see in the backend OCI registry. ErrUnauthorized maps
to 403 (distinct from the authentication 401 path); any other
authz error maps to 500.

Updates docs/auth.md with the policy schema, glob semantics, and
401 vs 403 split, and refreshes the AGENTS.md status table and
new-format checklist so future handlers wire the authorizer the
same way.

https://claude.ai/code/session_0119dLru4vxfbdqaBkF17yLG
Signed-off-by: Claude <noreply@anthropic.com>