### PR TITLE
Add pluggable Authorizer and per-namespace policy evaluator

### DIFF
--- a/pkg/auth/allowall.go
+++ b/pkg/auth/allowall.go
@@ -1,0 +1,15 @@
+package auth
+
+import "context"
+
+// AllowAll is an [Authorizer] that permits every request, regardless
+// of the [AuthContext] or [Op]. It is intended for tests and for the
+// `--default-namespace-allow-all` operator escape hatch in the data
+// plane. Production deployments must not wire this in directly.
+var AllowAll Authorizer = allowAllAuthorizer{}
+
+type allowAllAuthorizer struct{}
+
+func (allowAllAuthorizer) Authorize(_ context.Context, _ *AuthContext, _ Op) error {
+	return nil
+}

--- a/pkg/auth/authz.go
+++ b/pkg/auth/authz.go
@@ -54,6 +54,15 @@ func (f AuthorizerFunc) Authorize(ctx context.Context, ac *AuthContext, op Op) e
 // caller can use [errors.Is].
 var ErrUnauthorized = errors.New("unauthorized")
 
+// ErrUnknownOp signals that an [Authorizer] was asked about an [Op]
+// it does not recognize. This is a programmer / wiring error
+// (e.g. a handler passing a custom op string an authorizer was not
+// configured for), not an authorization failure — callers should
+// surface it as 5xx, not 403, so the bug is visible. Distinct from
+// [ErrUnauthorized] so a "fail closed" deny doesn't silently mask
+// a misconfiguration.
+var ErrUnknownOp = errors.New("unknown op")
+
 // String returns a stable per-caller identity suitable for audit
 // logs, of the form "<issuer>#<id>". Empty fields are preserved so
 // the output is unambiguous when one side is missing

--- a/pkg/auth/authz.go
+++ b/pkg/auth/authz.go
@@ -1,0 +1,68 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// Op is the coarse operation an authenticated subject is asking to
+// perform on a namespace. v1 ships only OpRead and OpWrite; finer
+// granularity is left to operators who plug in their own
+// [Authorizer].
+type Op string
+
+const (
+	// OpRead covers all artifact-fetch traffic on a namespace
+	// (pip download, mvn dependency resolution, npm install, etc.).
+	OpRead Op = "read"
+
+	// OpWrite covers all artifact-publish traffic on a namespace
+	// (twine upload, mvn deploy, npm publish, etc.).
+	OpWrite Op = "write"
+)
+
+// Authorizer decides whether the authenticated caller in ac may
+// perform op. It returns nil when the operation is allowed, or an
+// error wrapping [ErrUnauthorized] when it is denied. Other errors
+// indicate an operational failure (regex compile, backend lookup)
+// and should be treated as 5xx by callers.
+//
+// Implementations MUST treat a nil ac as deny: an unauthenticated
+// request never satisfies a non-empty policy in v1. The auth
+// middleware already returns 401 for missing credentials, so a nil
+// ac reaching an Authorizer is a defensive case rather than a hot
+// path.
+type Authorizer interface {
+	Authorize(ctx context.Context, ac *AuthContext, op Op) error
+}
+
+// AuthorizerFunc adapts a plain function to the [Authorizer]
+// interface. Useful in tests and for one-off authorizers that
+// don't carry state.
+type AuthorizerFunc func(ctx context.Context, ac *AuthContext, op Op) error
+
+// Authorize calls f(ctx, ac, op).
+func (f AuthorizerFunc) Authorize(ctx context.Context, ac *AuthContext, op Op) error {
+	return f(ctx, ac, op)
+}
+
+// ErrUnauthorized is the sentinel for authorization failures. The
+// HTTP layer maps an error wrapping ErrUnauthorized to 403 (the
+// caller is authenticated but not permitted). Authorizer
+// implementations should wrap with %w when signalling deny so the
+// caller can use [errors.Is].
+var ErrUnauthorized = errors.New("unauthorized")
+
+// String returns a stable per-caller identity suitable for audit
+// logs, of the form "<issuer>#<id>". Empty fields are preserved so
+// the output is unambiguous when one side is missing
+// (e.g. "anonymous#anonymous", "https://accounts.google.com#"). A
+// nil receiver renders as the empty string so log lines about
+// unauthenticated callers still print cleanly.
+func (a *AuthContext) String() string {
+	if a == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s#%s", a.Issuer, a.ID)
+}

--- a/pkg/auth/authz_test.go
+++ b/pkg/auth/authz_test.go
@@ -1,0 +1,120 @@
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/yolocs/ocifactory/pkg/auth"
+)
+
+func TestAuthContext_String(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ac   *auth.AuthContext
+		want string
+	}{
+		{
+			name: "nil",
+			ac:   nil,
+			want: "",
+		},
+		{
+			name: "issuer-and-id",
+			ac:   &auth.AuthContext{Issuer: "https://accounts.google.com", ID: "112233"},
+			want: "https://accounts.google.com#112233",
+		},
+		{
+			name: "anonymous",
+			ac:   &auth.AuthContext{Issuer: "anonymous", ID: "anonymous"},
+			want: "anonymous#anonymous",
+		},
+		{
+			name: "empty-id",
+			ac:   &auth.AuthContext{Issuer: "https://accounts.google.com"},
+			want: "https://accounts.google.com#",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.ac.String(); got != tc.want {
+				t.Errorf("String() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAllowAll(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ac   *auth.AuthContext
+		op   auth.Op
+	}{
+		{name: "nil-subject-read", ac: nil, op: auth.OpRead},
+		{name: "nil-subject-write", ac: nil, op: auth.OpWrite},
+		{name: "subject-read", ac: &auth.AuthContext{Issuer: "x", ID: "y"}, op: auth.OpRead},
+		{name: "subject-write", ac: &auth.AuthContext{Issuer: "x", ID: "y"}, op: auth.OpWrite},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if err := auth.AllowAll.Authorize(t.Context(), tc.ac, tc.op); err != nil {
+				t.Errorf("AllowAll.Authorize: %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestDenyAll(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ac   *auth.AuthContext
+		op   auth.Op
+	}{
+		{name: "nil-subject", ac: nil, op: auth.OpRead},
+		{name: "with-subject-read", ac: &auth.AuthContext{Issuer: "x", ID: "y"}, op: auth.OpRead},
+		{name: "with-subject-write", ac: &auth.AuthContext{Issuer: "x", ID: "y"}, op: auth.OpWrite},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := auth.DenyAll.Authorize(t.Context(), tc.ac, tc.op)
+			if err == nil {
+				t.Fatalf("DenyAll.Authorize: nil error, want one wrapping ErrUnauthorized")
+			}
+			if !errors.Is(err, auth.ErrUnauthorized) {
+				t.Errorf("DenyAll.Authorize = %v, want errors.Is(ErrUnauthorized)", err)
+			}
+		})
+	}
+}
+
+func TestAuthorizerFunc(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	var f auth.Authorizer = auth.AuthorizerFunc(func(_ context.Context, _ *auth.AuthContext, op auth.Op) error {
+		called = true
+		if op != auth.OpRead {
+			t.Errorf("op = %s, want %s", op, auth.OpRead)
+		}
+		return nil
+	})
+
+	if err := f.Authorize(t.Context(), nil, auth.OpRead); err != nil {
+		t.Fatalf("Authorize: %v", err)
+	}
+	if !called {
+		t.Fatal("AuthorizerFunc was not invoked")
+	}
+}

--- a/pkg/auth/denyall.go
+++ b/pkg/auth/denyall.go
@@ -1,0 +1,18 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+)
+
+// DenyAll is an [Authorizer] that rejects every request with an
+// error wrapping [ErrUnauthorized]. It exists for tests and for
+// fallback paths where the operator wants an unmistakable deny
+// rather than a missing-policy ambiguity.
+var DenyAll Authorizer = denyAllAuthorizer{}
+
+type denyAllAuthorizer struct{}
+
+func (denyAllAuthorizer) Authorize(_ context.Context, ac *AuthContext, op Op) error {
+	return fmt.Errorf("deny-all authorizer rejected %s for %s: %w", op, ac, ErrUnauthorized)
+}

--- a/pkg/namespace/namespace.go
+++ b/pkg/namespace/namespace.go
@@ -27,21 +27,3 @@ type Spec struct {
 	// dropped by an older one.
 	Format map[string]json.RawMessage `json:"format,omitempty"`
 }
-
-// Policy is the authz block of a [Spec].
-type Policy struct {
-	Readers []SubjectMatcher `json:"readers,omitempty"`
-	Writers []SubjectMatcher `json:"writers,omitempty"`
-}
-
-// SubjectMatcher matches an authenticated subject. All non-empty
-// fields must match for the matcher to apply.
-type SubjectMatcher struct {
-	Issuer      string            `json:"issuer,omitempty"`
-	SubMatch    string            `json:"sub_match,omitempty"`
-	Email       string            `json:"email,omitempty"`
-	ClaimsMatch map[string]string `json:"claims_match,omitempty"`
-	// Kind selects the credential family. "oidc" (default) matches
-	// OIDC identities; "basictoken" matches static-token identities.
-	Kind string `json:"kind,omitempty"`
-}

--- a/pkg/namespace/policy.go
+++ b/pkg/namespace/policy.go
@@ -1,0 +1,141 @@
+package namespace
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+// KindOIDC is the default value for [SubjectMatcher.Kind] — an
+// OIDC-authenticated caller. It is the only kind supported in v1;
+// see [KindBasicToken].
+const KindOIDC = "oidc"
+
+// KindBasicToken is reserved for future static-token authenticators
+// but is rejected by [SubjectMatcher.Validate] in v1, since no
+// in-tree authenticator produces a basictoken [auth.AuthContext]
+// today. Operators writing rules that target it would silently never
+// match; rejecting at validation time avoids that footgun.
+const KindBasicToken = "basictoken"
+
+// ErrInvalidPolicy is the sentinel for [Policy.Validate] failures.
+// Specific causes (empty matcher, regex syntax, unsupported kind)
+// wrap it via fmt.Errorf("...: %w", ErrInvalidPolicy).
+var ErrInvalidPolicy = errors.New("invalid policy")
+
+// Policy is the authz block of a [Spec]. An empty Policy is
+// deny-all: a caller is allowed to perform an op only if at least
+// one [SubjectMatcher] in the corresponding list matches them. The
+// Readers and Writers lists are independent; granting write does
+// not implicitly grant read.
+type Policy struct {
+	Readers []SubjectMatcher `json:"readers,omitempty"`
+	Writers []SubjectMatcher `json:"writers,omitempty"`
+}
+
+// SubjectMatcher matches an authenticated subject. A subject
+// matches iff every populated field on the matcher matches the
+// corresponding field on the subject (fields are ANDed). An empty
+// matcher (no fields populated) is invalid and rejected by
+// [Policy.Validate].
+type SubjectMatcher struct {
+	// Issuer matches [auth.AuthContext.Issuer] exactly. Required
+	// for "oidc" matchers in practice — an OIDC sub is only
+	// meaningful in the context of its issuer.
+	Issuer string `json:"issuer,omitempty"`
+
+	// SubMatch is an RE2 regex matched against
+	// [auth.AuthContext.ID]. The pattern is anchored at both ends
+	// (^pattern$) so callers don't accidentally allow
+	// "^repo:org/repo$" matching "evil-repo:org/repo:suffix".
+	SubMatch string `json:"sub_match,omitempty"`
+
+	// Email matches [auth.AuthContext.Email] exactly.
+	Email string `json:"email,omitempty"`
+
+	// ClaimsMatch maps a claim name to an RE2 regex that the
+	// claim's value must match. Each claim's value is JSON-encoded
+	// (with sorted keys for objects) before matching, so non-string
+	// values match against their JSON representation. Patterns are
+	// anchored at both ends.
+	ClaimsMatch map[string]string `json:"claims_match,omitempty"`
+
+	// Kind selects the credential family. "" defaults to "oidc".
+	// "basictoken" is reserved but rejected at validation in v1
+	// (see [KindBasicToken]).
+	Kind string `json:"kind,omitempty"`
+}
+
+// Validate returns nil iff every [SubjectMatcher] in p is valid:
+// non-empty, regex fields compile under RE2, and Kind is a
+// supported value. Errors wrap [ErrInvalidPolicy] and identify the
+// offending list ("readers"/"writers") and index.
+//
+// An entirely empty Policy is valid and means deny-all.
+func (p *Policy) Validate() error {
+	if p == nil {
+		return nil
+	}
+	for i := range p.Readers {
+		if err := p.Readers[i].Validate(); err != nil {
+			return fmt.Errorf("readers[%d]: %w", i, err)
+		}
+	}
+	for i := range p.Writers {
+		if err := p.Writers[i].Validate(); err != nil {
+			return fmt.Errorf("writers[%d]: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// Validate returns nil iff m has at least one populated field, all
+// regex fields compile under RE2, and Kind is supported. Errors
+// wrap [ErrInvalidPolicy].
+func (m *SubjectMatcher) Validate() error {
+	if m.Issuer == "" && m.SubMatch == "" && m.Email == "" && len(m.ClaimsMatch) == 0 && m.Kind == "" {
+		return fmt.Errorf("%w: matcher must populate at least one field", ErrInvalidPolicy)
+	}
+
+	switch m.Kind {
+	case "", KindOIDC:
+		// supported.
+	case KindBasicToken:
+		return fmt.Errorf("%w: kind %q is reserved but not yet supported", ErrInvalidPolicy, KindBasicToken)
+	default:
+		return fmt.Errorf("%w: unknown kind %q", ErrInvalidPolicy, m.Kind)
+	}
+
+	if m.SubMatch != "" {
+		if _, err := regexp.Compile(anchorRegex(m.SubMatch)); err != nil {
+			return fmt.Errorf("%w: sub_match %q: %v", ErrInvalidPolicy, m.SubMatch, err)
+		}
+	}
+
+	for claim, pat := range m.ClaimsMatch {
+		if claim == "" {
+			return fmt.Errorf("%w: claims_match key must not be empty", ErrInvalidPolicy)
+		}
+		if _, err := regexp.Compile(anchorRegex(pat)); err != nil {
+			return fmt.Errorf("%w: claims_match[%q] %q: %v", ErrInvalidPolicy, claim, pat, err)
+		}
+	}
+
+	return nil
+}
+
+// anchorRegex wraps pat in ^...$ so matches are full-string. If pat
+// already begins with ^ or ends with $ the corresponding anchor is
+// not duplicated; this keeps operator-written rules predictable
+// regardless of whether they remembered to anchor.
+func anchorRegex(pat string) string {
+	prefix := "^"
+	if len(pat) > 0 && pat[0] == '^' {
+		prefix = ""
+	}
+	suffix := "$"
+	if len(pat) > 0 && pat[len(pat)-1] == '$' {
+		suffix = ""
+	}
+	return prefix + pat + suffix
+}

--- a/pkg/namespace/policy_test.go
+++ b/pkg/namespace/policy_test.go
@@ -1,0 +1,143 @@
+package namespace_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/yolocs/ocifactory/pkg/namespace"
+)
+
+func TestPolicy_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		policy  namespace.Policy
+		wantErr bool
+	}{
+		{
+			name:   "empty-policy-is-valid",
+			policy: namespace.Policy{},
+		},
+		{
+			name: "issuer-only",
+			policy: namespace.Policy{
+				Readers: []namespace.SubjectMatcher{{Issuer: "https://accounts.google.com"}},
+			},
+		},
+		{
+			name: "email-only",
+			policy: namespace.Policy{
+				Readers: []namespace.SubjectMatcher{{Email: "alice@example.com"}},
+			},
+		},
+		{
+			name: "sub-match-only",
+			policy: namespace.Policy{
+				Readers: []namespace.SubjectMatcher{{SubMatch: "repo:org/.*"}},
+			},
+		},
+		{
+			name: "claims-match-only",
+			policy: namespace.Policy{
+				Readers: []namespace.SubjectMatcher{{ClaimsMatch: map[string]string{"repository_owner": "yolocs"}}},
+			},
+		},
+		{
+			name: "kind-only-oidc",
+			policy: namespace.Policy{
+				Readers: []namespace.SubjectMatcher{{Kind: namespace.KindOIDC}},
+			},
+		},
+		{
+			name: "all-fields",
+			policy: namespace.Policy{
+				Writers: []namespace.SubjectMatcher{{
+					Issuer:      "https://token.actions.githubusercontent.com",
+					SubMatch:    "repo:yolocs/.*",
+					Email:       "ci@yolocs.dev",
+					ClaimsMatch: map[string]string{"ref": "refs/heads/main"},
+					Kind:        namespace.KindOIDC,
+				}},
+			},
+		},
+		{
+			name: "empty-matcher-rejected",
+			policy: namespace.Policy{
+				Readers: []namespace.SubjectMatcher{{}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "kind-basictoken-rejected",
+			policy: namespace.Policy{
+				Writers: []namespace.SubjectMatcher{{Kind: namespace.KindBasicToken, SubMatch: "ci-bot"}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "kind-unknown-rejected",
+			policy: namespace.Policy{
+				Writers: []namespace.SubjectMatcher{{Kind: "saml", Issuer: "x"}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "sub-match-bad-regex",
+			policy: namespace.Policy{
+				Readers: []namespace.SubjectMatcher{{SubMatch: "(unclosed"}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "claims-match-bad-regex",
+			policy: namespace.Policy{
+				Readers: []namespace.SubjectMatcher{{ClaimsMatch: map[string]string{"repo": "(bad"}}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "claims-match-empty-key",
+			policy: namespace.Policy{
+				Readers: []namespace.SubjectMatcher{{ClaimsMatch: map[string]string{"": "x"}}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "writers-list-error-reported",
+			policy: namespace.Policy{
+				Readers: []namespace.SubjectMatcher{{Issuer: "ok"}},
+				Writers: []namespace.SubjectMatcher{{}},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.policy.Validate()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("Validate() = nil, want error wrapping ErrInvalidPolicy")
+				}
+				if !errors.Is(err, namespace.ErrInvalidPolicy) {
+					t.Errorf("Validate() = %v, want errors.Is(ErrInvalidPolicy)", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Validate() = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestPolicy_Validate_NilReceiver(t *testing.T) {
+	t.Parallel()
+
+	var p *namespace.Policy
+	if err := p.Validate(); err != nil {
+		t.Errorf("(*Policy)(nil).Validate() = %v, want nil", err)
+	}
+}

--- a/pkg/namespace/policyauthz.go
+++ b/pkg/namespace/policyauthz.go
@@ -1,0 +1,159 @@
+package namespace
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+
+	"github.com/yolocs/ocifactory/pkg/auth"
+)
+
+// NewPolicyAuthorizer compiles p into an [auth.Authorizer] bound to
+// a single namespace's [Policy]. Regex compilation happens once
+// here so [auth.Authorizer.Authorize] is allocation-light on the
+// hot path. The wrapper in #70 will hold one of these per cached
+// namespace.
+//
+// An error is returned iff p does not pass [Policy.Validate].
+func NewPolicyAuthorizer(p Policy) (auth.Authorizer, error) {
+	if err := p.Validate(); err != nil {
+		return nil, err
+	}
+	pa := &policyAuthorizer{}
+	for _, m := range p.Readers {
+		cm, err := compileMatcher(m)
+		if err != nil {
+			return nil, err
+		}
+		pa.readers = append(pa.readers, cm)
+	}
+	for _, m := range p.Writers {
+		cm, err := compileMatcher(m)
+		if err != nil {
+			return nil, err
+		}
+		pa.writers = append(pa.writers, cm)
+	}
+	return pa, nil
+}
+
+// policyAuthorizer is the v1 matcher-based [auth.Authorizer]
+// implementation. The compiled regex set lives here, not on the
+// [Policy] struct, so the JSON shape stays a plain DTO.
+type policyAuthorizer struct {
+	readers []compiledMatcher
+	writers []compiledMatcher
+}
+
+// Authorize iterates the matcher list for op and returns nil on the
+// first match. An empty list, or no match across all matchers,
+// returns an error wrapping [auth.ErrUnauthorized]. A nil ac (no
+// authenticated caller) is always denied.
+func (a *policyAuthorizer) Authorize(_ context.Context, ac *auth.AuthContext, op auth.Op) error {
+	if ac == nil {
+		return fmt.Errorf("no authenticated subject for %s: %w", op, auth.ErrUnauthorized)
+	}
+	var matchers []compiledMatcher
+	switch op {
+	case auth.OpRead:
+		matchers = a.readers
+	case auth.OpWrite:
+		matchers = a.writers
+	default:
+		return fmt.Errorf("unknown op %q for %s: %w", op, ac, auth.ErrUnauthorized)
+	}
+	for _, m := range matchers {
+		if m.matches(ac) {
+			return nil
+		}
+	}
+	return fmt.Errorf("subject %s denied for %s: %w", ac, op, auth.ErrUnauthorized)
+}
+
+type compiledMatcher struct {
+	issuer   string
+	subRE    *regexp.Regexp
+	email    string
+	claimsRE map[string]*regexp.Regexp
+	kind     string
+}
+
+func compileMatcher(m SubjectMatcher) (compiledMatcher, error) {
+	out := compiledMatcher{
+		issuer: m.Issuer,
+		email:  m.Email,
+		kind:   m.Kind,
+	}
+	if out.kind == "" {
+		out.kind = KindOIDC
+	}
+	if m.SubMatch != "" {
+		re, err := regexp.Compile(anchorRegex(m.SubMatch))
+		if err != nil {
+			return compiledMatcher{}, fmt.Errorf("%w: sub_match %q: %v", ErrInvalidPolicy, m.SubMatch, err)
+		}
+		out.subRE = re
+	}
+	if len(m.ClaimsMatch) > 0 {
+		out.claimsRE = make(map[string]*regexp.Regexp, len(m.ClaimsMatch))
+		for claim, pat := range m.ClaimsMatch {
+			re, err := regexp.Compile(anchorRegex(pat))
+			if err != nil {
+				return compiledMatcher{}, fmt.Errorf("%w: claims_match[%q] %q: %v", ErrInvalidPolicy, claim, pat, err)
+			}
+			out.claimsRE[claim] = re
+		}
+	}
+	return out, nil
+}
+
+func (m compiledMatcher) matches(ac *auth.AuthContext) bool {
+	// kind: every in-tree authenticator today produces an OIDC-shaped
+	// AuthContext, so we check kind only against the matcher's
+	// declared family. Other kinds are rejected at Validate time.
+	if m.kind != KindOIDC {
+		return false
+	}
+	if m.issuer != "" && m.issuer != ac.Issuer {
+		return false
+	}
+	if m.email != "" && m.email != ac.Email {
+		return false
+	}
+	if m.subRE != nil && !m.subRE.MatchString(ac.ID) {
+		return false
+	}
+	for claim, re := range m.claimsRE {
+		v, ok := ac.Claims[claim]
+		if !ok {
+			return false
+		}
+		s, err := claimValueString(v)
+		if err != nil {
+			return false
+		}
+		if !re.MatchString(s) {
+			return false
+		}
+	}
+	return true
+}
+
+// claimValueString renders a claim value as the canonical string
+// used for regex matching. Strings pass through verbatim; everything
+// else is JSON-encoded with sorted object keys (Go's encoding/json
+// already sorts map keys when marshalling). Operators writing rules
+// against array or object claims see the JSON form; this is
+// documented as a v1 surprise on the [SubjectMatcher.ClaimsMatch]
+// field.
+func claimValueString(v any) (string, error) {
+	if s, ok := v.(string); ok {
+		return s, nil
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/pkg/namespace/policyauthz.go
+++ b/pkg/namespace/policyauthz.go
@@ -61,7 +61,7 @@ func (a *policyAuthorizer) Authorize(_ context.Context, ac *auth.AuthContext, op
 	case auth.OpWrite:
 		matchers = a.writers
 	default:
-		return fmt.Errorf("unknown op %q for %s: %w", op, ac, auth.ErrUnauthorized)
+		return fmt.Errorf("policyAuthorizer: %q: %w", op, auth.ErrUnknownOp)
 	}
 	for _, m := range matchers {
 		if m.matches(ac) {

--- a/pkg/namespace/policyauthz_test.go
+++ b/pkg/namespace/policyauthz_test.go
@@ -10,6 +10,30 @@ import (
 
 const ghIssuer = "https://token.actions.githubusercontent.com"
 
+func TestPolicyAuthorizer_UnknownOpReturnsErrUnknownOp(t *testing.T) {
+	t.Parallel()
+
+	a, err := namespace.NewPolicyAuthorizer(namespace.Policy{
+		Readers: []namespace.SubjectMatcher{{Issuer: ghIssuer}},
+		Writers: []namespace.SubjectMatcher{{Issuer: ghIssuer}},
+	})
+	if err != nil {
+		t.Fatalf("NewPolicyAuthorizer: %v", err)
+	}
+	ac := &auth.AuthContext{Issuer: ghIssuer, ID: "x"}
+
+	err = a.Authorize(t.Context(), ac, auth.Op("delete"))
+	if err == nil {
+		t.Fatalf("Authorize(unknown op): nil, want error wrapping ErrUnknownOp")
+	}
+	if !errors.Is(err, auth.ErrUnknownOp) {
+		t.Errorf("Authorize(unknown op) = %v, want errors.Is(ErrUnknownOp)", err)
+	}
+	if errors.Is(err, auth.ErrUnauthorized) {
+		t.Errorf("Authorize(unknown op) = %v, must NOT wrap ErrUnauthorized", err)
+	}
+}
+
 func TestNewPolicyAuthorizer_RejectsInvalidPolicy(t *testing.T) {
 	t.Parallel()
 
@@ -258,13 +282,70 @@ func TestPolicyAuthorizer_Authorize(t *testing.T) {
 			wantAllow: true,
 		},
 		{
-			name: "unknown-op-denied",
+			// Numeric claims arrive as float64 from encoding/json.
+			// json.Marshal renders them without trailing ".0" when
+			// integral, so the regex matches the bare digits.
+			name: "claims-match-numeric",
 			policy: namespace.Policy{
-				Readers: []namespace.SubjectMatcher{{Issuer: ghIssuer}},
-				Writers: []namespace.SubjectMatcher{{Issuer: ghIssuer}},
+				Writers: []namespace.SubjectMatcher{{
+					Issuer:      ghIssuer,
+					ClaimsMatch: map[string]string{"iat": `[0-9]+`},
+				}},
 			},
-			ac: &auth.AuthContext{Issuer: ghIssuer, ID: "x"},
-			op: auth.Op("delete"),
+			ac: &auth.AuthContext{
+				Issuer: ghIssuer,
+				ID:     "x",
+				Claims: map[string]any{"iat": float64(1234567890)},
+			},
+			op:        auth.OpWrite,
+			wantAllow: true,
+		},
+		{
+			name: "claims-match-numeric-mismatch",
+			policy: namespace.Policy{
+				Writers: []namespace.SubjectMatcher{{
+					Issuer:      ghIssuer,
+					ClaimsMatch: map[string]string{"iat": "999"},
+				}},
+			},
+			ac: &auth.AuthContext{
+				Issuer: ghIssuer,
+				ID:     "x",
+				Claims: map[string]any{"iat": float64(1234567890)},
+			},
+			op: auth.OpWrite,
+		},
+		{
+			name: "claims-match-boolean",
+			policy: namespace.Policy{
+				Readers: []namespace.SubjectMatcher{{
+					Issuer:      ghIssuer,
+					ClaimsMatch: map[string]string{"email_verified": "true"},
+				}},
+			},
+			ac: &auth.AuthContext{
+				Issuer: ghIssuer,
+				ID:     "x",
+				Claims: map[string]any{"email_verified": true},
+			},
+			op:        auth.OpRead,
+			wantAllow: true,
+		},
+		{
+			name: "claims-match-null-mismatch",
+			policy: namespace.Policy{
+				Readers: []namespace.SubjectMatcher{{
+					Issuer:      ghIssuer,
+					ClaimsMatch: map[string]string{"nbf": "[0-9]+"},
+				}},
+			},
+			ac: &auth.AuthContext{
+				Issuer: ghIssuer,
+				ID:     "x",
+				// JSON null encodes as "null", which won't match a digits regex.
+				Claims: map[string]any{"nbf": nil},
+			},
+			op: auth.OpRead,
 		},
 	}
 

--- a/pkg/namespace/policyauthz_test.go
+++ b/pkg/namespace/policyauthz_test.go
@@ -1,0 +1,294 @@
+package namespace_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/yolocs/ocifactory/pkg/auth"
+	"github.com/yolocs/ocifactory/pkg/namespace"
+)
+
+const ghIssuer = "https://token.actions.githubusercontent.com"
+
+func TestNewPolicyAuthorizer_RejectsInvalidPolicy(t *testing.T) {
+	t.Parallel()
+
+	_, err := namespace.NewPolicyAuthorizer(namespace.Policy{
+		Readers: []namespace.SubjectMatcher{{}},
+	})
+	if err == nil {
+		t.Fatalf("NewPolicyAuthorizer: nil, want error wrapping ErrInvalidPolicy")
+	}
+	if !errors.Is(err, namespace.ErrInvalidPolicy) {
+		t.Errorf("NewPolicyAuthorizer = %v, want errors.Is(ErrInvalidPolicy)", err)
+	}
+}
+
+func TestPolicyAuthorizer_Authorize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		policy    namespace.Policy
+		ac        *auth.AuthContext
+		op        auth.Op
+		wantAllow bool
+	}{
+		{
+			name:   "empty-policy-deny-read",
+			policy: namespace.Policy{},
+			ac:     &auth.AuthContext{Issuer: ghIssuer, ID: "anything"},
+			op:     auth.OpRead,
+		},
+		{
+			name:   "empty-policy-deny-write",
+			policy: namespace.Policy{},
+			ac:     &auth.AuthContext{Issuer: ghIssuer, ID: "anything"},
+			op:     auth.OpWrite,
+		},
+		{
+			name: "nil-subject-denied",
+			policy: namespace.Policy{
+				Readers: []namespace.SubjectMatcher{{Issuer: ghIssuer}},
+			},
+			ac: nil,
+			op: auth.OpRead,
+		},
+		{
+			name: "issuer-only-match",
+			policy: namespace.Policy{
+				Readers: []namespace.SubjectMatcher{{Issuer: ghIssuer}},
+			},
+			ac:        &auth.AuthContext{Issuer: ghIssuer, ID: "anyone"},
+			op:        auth.OpRead,
+			wantAllow: true,
+		},
+		{
+			name: "issuer-only-mismatch",
+			policy: namespace.Policy{
+				Readers: []namespace.SubjectMatcher{{Issuer: ghIssuer}},
+			},
+			ac: &auth.AuthContext{Issuer: "https://accounts.google.com", ID: "anyone"},
+			op: auth.OpRead,
+		},
+		{
+			name: "email-only-match",
+			policy: namespace.Policy{
+				Readers: []namespace.SubjectMatcher{{Email: "alice@example.com"}},
+			},
+			ac:        &auth.AuthContext{Issuer: "x", ID: "y", Email: "alice@example.com"},
+			op:        auth.OpRead,
+			wantAllow: true,
+		},
+		{
+			name: "email-only-mismatch",
+			policy: namespace.Policy{
+				Readers: []namespace.SubjectMatcher{{Email: "alice@example.com"}},
+			},
+			ac: &auth.AuthContext{Issuer: "x", ID: "y", Email: "bob@example.com"},
+			op: auth.OpRead,
+		},
+		{
+			name: "sub-match-regex",
+			policy: namespace.Policy{
+				Writers: []namespace.SubjectMatcher{{SubMatch: "repo:yolocs/.*:ref:refs/heads/main"}},
+			},
+			ac:        &auth.AuthContext{Issuer: ghIssuer, ID: "repo:yolocs/ocifactory:ref:refs/heads/main"},
+			op:        auth.OpWrite,
+			wantAllow: true,
+		},
+		{
+			name: "sub-match-anchored-rejects-suffix",
+			policy: namespace.Policy{
+				Writers: []namespace.SubjectMatcher{{SubMatch: "repo:yolocs/ocifactory"}},
+			},
+			ac: &auth.AuthContext{Issuer: ghIssuer, ID: "repo:yolocs/ocifactory:ref:refs/heads/main"},
+			op: auth.OpWrite,
+		},
+		{
+			name: "sub-match-anchored-rejects-prefix",
+			policy: namespace.Policy{
+				Writers: []namespace.SubjectMatcher{{SubMatch: "yolocs/ocifactory"}},
+			},
+			ac: &auth.AuthContext{Issuer: ghIssuer, ID: "evil-yolocs/ocifactory"},
+			op: auth.OpWrite,
+		},
+		{
+			name: "anded-fields-all-match",
+			policy: namespace.Policy{
+				Writers: []namespace.SubjectMatcher{{
+					Issuer:   ghIssuer,
+					SubMatch: "repo:yolocs/.*",
+					Email:    "ci@yolocs.dev",
+				}},
+			},
+			ac: &auth.AuthContext{
+				Issuer: ghIssuer,
+				ID:     "repo:yolocs/ocifactory:ref:refs/heads/main",
+				Email:  "ci@yolocs.dev",
+			},
+			op:        auth.OpWrite,
+			wantAllow: true,
+		},
+		{
+			name: "anded-fields-one-mismatch",
+			policy: namespace.Policy{
+				Writers: []namespace.SubjectMatcher{{
+					Issuer: ghIssuer,
+					Email:  "ci@yolocs.dev",
+				}},
+			},
+			ac: &auth.AuthContext{Issuer: ghIssuer, ID: "x", Email: "other@yolocs.dev"},
+			op: auth.OpWrite,
+		},
+		{
+			name: "ored-list-second-matches",
+			policy: namespace.Policy{
+				Readers: []namespace.SubjectMatcher{
+					{Issuer: ghIssuer, Email: "alice@example.com"},
+					{Issuer: ghIssuer, Email: "bob@example.com"},
+				},
+			},
+			ac:        &auth.AuthContext{Issuer: ghIssuer, ID: "x", Email: "bob@example.com"},
+			op:        auth.OpRead,
+			wantAllow: true,
+		},
+		{
+			name: "ored-list-none-match",
+			policy: namespace.Policy{
+				Readers: []namespace.SubjectMatcher{
+					{Issuer: ghIssuer, Email: "alice@example.com"},
+					{Issuer: ghIssuer, Email: "bob@example.com"},
+				},
+			},
+			ac: &auth.AuthContext{Issuer: ghIssuer, ID: "x", Email: "carol@example.com"},
+			op: auth.OpRead,
+		},
+		{
+			name: "read-not-implied-by-write",
+			policy: namespace.Policy{
+				Writers: []namespace.SubjectMatcher{{Issuer: ghIssuer}},
+			},
+			ac: &auth.AuthContext{Issuer: ghIssuer, ID: "x"},
+			op: auth.OpRead,
+		},
+		{
+			name: "claims-match-string",
+			policy: namespace.Policy{
+				Writers: []namespace.SubjectMatcher{{
+					Issuer:      ghIssuer,
+					ClaimsMatch: map[string]string{"repository_owner": "yolocs"},
+				}},
+			},
+			ac: &auth.AuthContext{
+				Issuer: ghIssuer,
+				ID:     "x",
+				Claims: map[string]any{"repository_owner": "yolocs"},
+			},
+			op:        auth.OpWrite,
+			wantAllow: true,
+		},
+		{
+			name: "claims-match-string-mismatch",
+			policy: namespace.Policy{
+				Writers: []namespace.SubjectMatcher{{
+					Issuer:      ghIssuer,
+					ClaimsMatch: map[string]string{"repository_owner": "yolocs"},
+				}},
+			},
+			ac: &auth.AuthContext{
+				Issuer: ghIssuer,
+				ID:     "x",
+				Claims: map[string]any{"repository_owner": "someoneelse"},
+			},
+			op: auth.OpWrite,
+		},
+		{
+			name: "claims-match-missing-claim",
+			policy: namespace.Policy{
+				Writers: []namespace.SubjectMatcher{{
+					Issuer:      ghIssuer,
+					ClaimsMatch: map[string]string{"repository_owner": "yolocs"},
+				}},
+			},
+			ac: &auth.AuthContext{Issuer: ghIssuer, ID: "x", Claims: map[string]any{}},
+			op: auth.OpWrite,
+		},
+		{
+			name: "claims-match-array-json-form",
+			policy: namespace.Policy{
+				Writers: []namespace.SubjectMatcher{{
+					Issuer: ghIssuer,
+					// Arrays render as JSON; the regex matches against
+					// the literal JSON shape.
+					ClaimsMatch: map[string]string{"groups": `\["admins","ops"\]`},
+				}},
+			},
+			ac: &auth.AuthContext{
+				Issuer: ghIssuer,
+				ID:     "x",
+				Claims: map[string]any{"groups": []any{"admins", "ops"}},
+			},
+			op:        auth.OpWrite,
+			wantAllow: true,
+		},
+		{
+			name: "claims-match-object-json-form",
+			policy: namespace.Policy{
+				Writers: []namespace.SubjectMatcher{{
+					Issuer:      ghIssuer,
+					ClaimsMatch: map[string]string{"meta": `\{"a":1,"b":2\}`},
+				}},
+			},
+			ac: &auth.AuthContext{
+				Issuer: ghIssuer,
+				ID:     "x",
+				Claims: map[string]any{"meta": map[string]any{"b": 2, "a": 1}},
+			},
+			op:        auth.OpWrite,
+			wantAllow: true,
+		},
+		{
+			name: "default-kind-oidc-matches",
+			policy: namespace.Policy{
+				Readers: []namespace.SubjectMatcher{{Issuer: ghIssuer, Kind: namespace.KindOIDC}},
+			},
+			ac:        &auth.AuthContext{Issuer: ghIssuer, ID: "x"},
+			op:        auth.OpRead,
+			wantAllow: true,
+		},
+		{
+			name: "unknown-op-denied",
+			policy: namespace.Policy{
+				Readers: []namespace.SubjectMatcher{{Issuer: ghIssuer}},
+				Writers: []namespace.SubjectMatcher{{Issuer: ghIssuer}},
+			},
+			ac: &auth.AuthContext{Issuer: ghIssuer, ID: "x"},
+			op: auth.Op("delete"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a, err := namespace.NewPolicyAuthorizer(tc.policy)
+			if err != nil {
+				t.Fatalf("NewPolicyAuthorizer: %v", err)
+			}
+			err = a.Authorize(t.Context(), tc.ac, tc.op)
+			if tc.wantAllow {
+				if err != nil {
+					t.Errorf("Authorize: %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Authorize: nil, want error wrapping ErrUnauthorized")
+			}
+			if !errors.Is(err, auth.ErrUnauthorized) {
+				t.Errorf("Authorize = %v, want errors.Is(ErrUnauthorized)", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implements the per-namespace authz layer described in #68:

- pkg/auth: Authorizer interface, OpRead/OpWrite, ErrUnauthorized
  sentinel, AuthorizerFunc adapter, AuthContext.String() ("issuer#id"
  audit form), and AllowAll/DenyAll test fixtures.
- pkg/namespace: Policy/SubjectMatcher moved from namespace.go to
  policy.go alongside Validate(); KindOIDC/KindBasicToken constants;
  ErrInvalidPolicy sentinel.
- pkg/namespace.NewPolicyAuthorizer compiles a Policy into a matcher-
  based Authorizer with per-authorizer-cached regexes. Subject-ID and
  claim-value patterns are anchored as ^pattern$ to avoid surprise
  partial matches; non-string claim values are JSON-encoded before
  matching. kind:basictoken is rejected at validation in v1; nil
  subjects and empty matcher lists deny.

Tests cover empty/required-field combinations, RE2 syntax errors,
ANDed-conjunction, ORed-list precedence, claims_match across
string/array/object values, and the deny defaults.

No new top-level dependencies. #70 can drop in NewPolicyAuthorizer
without further changes here.

Signed-off-by: Claude <noreply@anthropic.com>