### PR TITLE
Add pkg/namespace.Registry wrapper with per-namespace package index

### DIFF
--- a/pkg/namespace/cache.go
+++ b/pkg/namespace/cache.go
@@ -1,0 +1,83 @@
+package namespace
+
+import (
+	"time"
+
+	"github.com/hashicorp/golang-lru/v2/expirable"
+
+	"github.com/yolocs/ocifactory/pkg/auth"
+)
+
+// DefaultPolicyCacheTTL is the default lifetime of a single entry in
+// the data-plane authz policy cache. Picked short enough that an
+// operator's `PUT namespace` lands in front of in-flight clients
+// within a one-minute window without explicit invalidation, long
+// enough that a hot namespace pulling thousands of artifacts a minute
+// pays for one Store.Get + Policy compile rather than one per request.
+const DefaultPolicyCacheTTL = 60 * time.Second
+
+// DefaultPolicyCacheSize bounds the number of distinct namespaces the
+// policy cache holds. Sized generously so even multi-tenant
+// deployments with hundreds of namespaces never evict in practice;
+// the cap exists to put a hard ceiling on memory rather than as a
+// tuning knob. A value <= 0 disables the size bound for the
+// underlying LRU and is rejected by [NewRegistry].
+const DefaultPolicyCacheSize = 1024
+
+// cachedPolicy is the value stored per namespace name in the policy
+// cache. notFound carries a negative result from [Store.Get] so a
+// burst of requests against a missing namespace doesn't repeatedly
+// hit the metadata backend.
+type cachedPolicy struct {
+	authorizer auth.Authorizer
+	notFound   bool
+}
+
+// policyCache memoises the per-namespace [auth.Authorizer] compiled
+// from the namespace's Policy. Backed by hashicorp/golang-lru's
+// expirable LRU, which gives us TTL expiry plus a bounded entry count
+// for free.
+//
+// A ttl of zero or negative disables caching entirely; lookup always
+// reports a miss. The wrapper's Invalidate path is still wired so
+// flipping TTL on at startup does not require code changes elsewhere.
+type policyCache struct {
+	lru *expirable.LRU[string, cachedPolicy]
+}
+
+func newPolicyCache(size int, ttl time.Duration) *policyCache {
+	if ttl <= 0 {
+		return &policyCache{}
+	}
+	return &policyCache{
+		lru: expirable.NewLRU[string, cachedPolicy](size, nil, ttl),
+	}
+}
+
+func (c *policyCache) get(name string) (cachedPolicy, bool) {
+	if c.lru == nil {
+		return cachedPolicy{}, false
+	}
+	return c.lru.Get(name)
+}
+
+func (c *policyCache) put(name string, v cachedPolicy) {
+	if c.lru == nil {
+		return
+	}
+	c.lru.Add(name, v)
+}
+
+func (c *policyCache) invalidate(name string) {
+	if c.lru == nil {
+		return
+	}
+	c.lru.Remove(name)
+}
+
+func (c *policyCache) purge() {
+	if c.lru == nil {
+		return
+	}
+	c.lru.Purge()
+}

--- a/pkg/namespace/cache.go
+++ b/pkg/namespace/cache.go
@@ -8,22 +8,6 @@ import (
 	"github.com/yolocs/ocifactory/pkg/auth"
 )
 
-// DefaultPolicyCacheTTL is the default lifetime of a single entry in
-// the data-plane authz policy cache. Picked short enough that an
-// operator's `PUT namespace` lands in front of in-flight clients
-// within a one-minute window without explicit invalidation, long
-// enough that a hot namespace pulling thousands of artifacts a minute
-// pays for one Store.Get + Policy compile rather than one per request.
-const DefaultPolicyCacheTTL = 60 * time.Second
-
-// DefaultPolicyCacheSize bounds the number of distinct namespaces the
-// policy cache holds. Sized generously so even multi-tenant
-// deployments with hundreds of namespaces never evict in practice;
-// the cap exists to put a hard ceiling on memory rather than as a
-// tuning knob. A value <= 0 disables the size bound for the
-// underlying LRU and is rejected by [NewRegistry].
-const DefaultPolicyCacheSize = 1024
-
 // cachedPolicy is the value stored per namespace name in the policy
 // cache. notFound carries a negative result from [Store.Get] so a
 // burst of requests against a missing namespace doesn't repeatedly

--- a/pkg/namespace/cache_test.go
+++ b/pkg/namespace/cache_test.go
@@ -1,0 +1,84 @@
+package namespace
+
+import (
+	"testing"
+	"time"
+
+	"github.com/yolocs/ocifactory/pkg/auth"
+)
+
+func TestPolicyCache_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	c := newPolicyCache(8, time.Minute)
+	az := auth.AllowAll
+	c.put("alpha", cachedPolicy{authorizer: az})
+
+	got, ok := c.get("alpha")
+	if !ok {
+		t.Fatalf("get(alpha) miss, want hit")
+	}
+	if got.authorizer != az {
+		t.Errorf("get(alpha) authorizer = %v, want %v", got.authorizer, az)
+	}
+	if got.notFound {
+		t.Errorf("get(alpha) notFound = true, want false")
+	}
+}
+
+func TestPolicyCache_NegativeEntry(t *testing.T) {
+	t.Parallel()
+
+	c := newPolicyCache(8, time.Minute)
+	c.put("missing", cachedPolicy{notFound: true})
+
+	got, ok := c.get("missing")
+	if !ok {
+		t.Fatalf("get(missing) miss, want hit")
+	}
+	if !got.notFound {
+		t.Errorf("get(missing) notFound = false, want true")
+	}
+}
+
+func TestPolicyCache_Invalidate(t *testing.T) {
+	t.Parallel()
+
+	c := newPolicyCache(8, time.Minute)
+	c.put("alpha", cachedPolicy{authorizer: auth.AllowAll})
+	c.invalidate("alpha")
+
+	if _, ok := c.get("alpha"); ok {
+		t.Errorf("get(alpha) hit after invalidate, want miss")
+	}
+}
+
+// TestPolicyCache_DisabledByZeroTTL pins the documented contract that
+// ttl=0 means "no caching at all". Operators flip this on in tests
+// where a fresh Put must take effect on the very next request without
+// sleeping out the TTL.
+func TestPolicyCache_DisabledByZeroTTL(t *testing.T) {
+	t.Parallel()
+
+	c := newPolicyCache(8, 0)
+	c.put("alpha", cachedPolicy{authorizer: auth.AllowAll})
+	if _, ok := c.get("alpha"); ok {
+		t.Errorf("get(alpha) hit on disabled cache, want miss")
+	}
+}
+
+func TestPolicyCache_Purge(t *testing.T) {
+	t.Parallel()
+
+	c := newPolicyCache(8, time.Minute)
+	c.put("alpha", cachedPolicy{authorizer: auth.AllowAll})
+	c.put("beta", cachedPolicy{authorizer: auth.AllowAll})
+	c.purge()
+
+	if _, ok := c.get("alpha"); ok {
+		t.Errorf("get(alpha) hit after purge, want miss")
+	}
+	if _, ok := c.get("beta"); ok {
+		t.Errorf("get(beta) hit after purge, want miss")
+	}
+}

--- a/pkg/namespace/registry.go
+++ b/pkg/namespace/registry.go
@@ -3,6 +3,7 @@ package namespace
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/golang-lru/v2/expirable"
+	"golang.org/x/sync/singleflight"
 	"oras.land/oras-go/v2/errdef"
 
 	"github.com/yolocs/ocifactory/pkg/auth"
@@ -20,16 +22,17 @@ import (
 )
 
 const (
-	// DefaultPackageIndexSuffix names the per-namespace OCI repo whose
+	// defaultPackageIndexSuffix names the per-namespace OCI repo whose
 	// tags enumerate every owning-repo the wrapper has ever recorded a
 	// write for. The repo lives at "<namespace>/_packages" by default
 	// — operators who already park a real artifact under that name can
 	// relocate it via [WithPackageIndexSuffix].
-	DefaultPackageIndexSuffix = "_packages"
+	defaultPackageIndexSuffix = "_packages"
 
-	// indexSentinelFile is the file name written under the package
-	// index repo. The body is constant — the tag's existence is the
-	// record — so a re-add of an existing tag is a backend no-op.
+	// packageIndexSentinelFile is the file name written under the
+	// package index repo. The body is constant — the tag's existence
+	// is the record — so a re-add of an existing tag is a backend
+	// no-op.
 	packageIndexSentinelFile = "present"
 
 	// packageIndexedReposCacheSize bounds the in-process set of
@@ -39,13 +42,23 @@ const (
 	// pay one idempotent backend write.
 	packageIndexedReposCacheSize = 4096
 
-	// tagSlashEscape is the OCI-tag-safe substitution for the '/'
-	// character. OCI tag names allow [A-Za-z0-9_.-] only, so we encode
-	// every '/' in an owning-repo name as "__" and decode on read.
-	// Documented next to the constant so a future maintainer doesn't
-	// reinvent the escape and break round-tripping.
-	tagSlashEscape = "__"
+	// defaultPolicyCacheSize bounds the number of distinct namespaces
+	// the policy cache holds. Sized generously so even multi-tenant
+	// deployments with hundreds of namespaces never evict in
+	// practice; the cap exists to put a hard ceiling on memory rather
+	// than as a tuning knob.
+	defaultPolicyCacheSize = 1024
 )
+
+// DefaultPolicyCacheTTL is the default lifetime of a single entry in
+// the data-plane authz policy cache. Picked short enough that an
+// operator's `PUT namespace` lands in front of in-flight clients
+// within a one-minute window even without explicit invalidation,
+// long enough that a hot namespace pulling thousands of artifacts a
+// minute pays for one Store.Get + Policy compile rather than one per
+// request. Admin-side mutations (Store.Put / Store.Delete) skip the
+// TTL via the mutation-hook invalidation path.
+const DefaultPolicyCacheTTL = 60 * time.Second
 
 var packageIndexSentinelBody = []byte("present\n")
 
@@ -58,6 +71,12 @@ type AuthzFactory func(Policy) (auth.Authorizer, error)
 // RegistryBackend is the subset of *pkg/oci.Registry the wrapper
 // needs. Pinned as an interface so tests can substitute the in-memory
 // [oci.FakeRegistry]; production passes *oci.Registry directly.
+//
+// DeleteTagFiles is included even though no in-tree handler reaches
+// for it today — keeping the interface a strict superset of the
+// metadata-store [Backend] avoids two parallel interfaces and lets
+// future yank semantics (single-version delete) plug in without
+// reshaping the surface.
 type RegistryBackend interface {
 	AddFile(ctx context.Context, f *oci.RepoFile, ro io.Reader) (*oci.FileDescriptor, error)
 	ReadFile(ctx context.Context, f *oci.RepoFile) (*oci.FileDescriptor, io.ReadCloser, error)
@@ -66,21 +85,24 @@ type RegistryBackend interface {
 	ListFiles(ctx context.Context, repo string) ([]*oci.RepoFile, error)
 	AppendRefs(ctx context.Context, repo string, canonicalTag string, refs ...string) error
 	DeleteRepoFiles(ctx context.Context, repo string) error
+	DeleteTagFiles(ctx context.Context, repo string, tag string) error
 }
 
 // Registry is the data-plane wrapper that namespace-scopes every OCI
 // operation. It:
 //
-//   - Prefixes every OwningRepo with the namespace name so writes from
-//     namespace "alpha" land under "alpha/<owning-repo>" and cannot be
-//     read from namespace "beta".
+//   - Reads [oci.RepoFile.Namespace] from the caller-supplied file
+//     and prefixes OwningRepo with it so writes from namespace
+//     "alpha" land under "alpha/<owning-repo>" and cannot be read
+//     from namespace "beta".
 //   - Enforces the namespace's authz policy on every call. The
-//     compiled authorizer is cached behind a TTL+LRU so the hot path
-//     is one map lookup per request.
+//     compiled authorizer is cached behind a TTL+LRU and a
+//     singleflight collapse so the hot path is one map lookup per
+//     request and a cold-start burst pays for one compile, not N.
 //   - Maintains a per-namespace package index at
 //     "<namespace>/_packages" (one tag per owning-repo) so cascade
 //     delete and namespace listing don't depend on the OCI _catalog
-//     endpoint, which is optional and inconsistently implemented.
+//     endpoint.
 //
 // Handlers consume *Registry instead of *oci.Registry so authz
 // enforcement is a structural guarantee — a future format author
@@ -94,17 +116,26 @@ type Registry struct {
 	factory     AuthzFactory
 	cacheTTL    time.Duration
 
+	// flight collapses concurrent first-misses for the same namespace
+	// so a cold-start burst pays one Store.Get + factory(...) rather
+	// than N. Keyed by namespace name.
+	flight singleflight.Group
+
 	// indexLocks serialises index writes per (ns, owning-repo) pair so
-	// a burst of concurrent first-writes pays for one OCI round-trip
-	// instead of N. The locks are dropped after the write succeeds —
-	// repeat writers short-circuit on the indexed LRU above.
+	// a burst of concurrent first-writers pays for one OCI round-trip
+	// instead of N. Entries are NOT deleted after use: the LRU
+	// re-check inside the critical section is what carries
+	// correctness, and deleting the mutex while another goroutine is
+	// still holding a reference would leave two unrelated mutexes
+	// claiming to guard the same key. The lock map is bounded by the
+	// indexed-LRU size in steady state.
 	indexLocks sync.Map
 }
 
 // RegistryOption customises a [Registry].
 type RegistryOption func(*Registry)
 
-// WithPackageIndexSuffix overrides [DefaultPackageIndexSuffix].
+// WithPackageIndexSuffix overrides the default ("_packages").
 // Operators set this when their backend already has a top-level
 // "_packages" repo they want to keep — extremely unlikely, but cheap
 // to make configurable.
@@ -127,19 +158,23 @@ func WithPolicyCacheTTL(ttl time.Duration) RegistryOption {
 }
 
 // NewRegistry wraps inner in a namespace [Registry] backed by store
-// for namespace metadata.
+// for namespace metadata. The wrapper installs a mutation hook on
+// store so admin-side Put / Delete calls invalidate the cached
+// authorizer — failing to use NewRegistry (e.g. constructing the
+// fields by hand in a test) means admin mutations only take effect
+// after the cache TTL expires.
 func NewRegistry(inner RegistryBackend, store *Store, opts ...RegistryOption) *Registry {
 	r := &Registry{
 		inner:       inner,
 		store:       store,
-		indexSuffix: DefaultPackageIndexSuffix,
+		indexSuffix: defaultPackageIndexSuffix,
 		factory:     NewPolicyAuthorizer,
 		cacheTTL:    DefaultPolicyCacheTTL,
 	}
 	for _, o := range opts {
 		o(r)
 	}
-	r.cache = newPolicyCache(DefaultPolicyCacheSize, r.cacheTTL)
+	r.cache = newPolicyCache(defaultPolicyCacheSize, r.cacheTTL)
 	// Indexed-repos cache exists purely to short-circuit duplicate
 	// AddFile calls into the package index. Its lifetime is the
 	// process — entries should not age out under normal operation
@@ -147,13 +182,15 @@ func NewRegistry(inner RegistryBackend, store *Store, opts ...RegistryOption) *R
 	// expirable.NewLRU means "10-year TTL" (effectively no expiry),
 	// which is what we want; bounded size is the only ceiling.
 	r.indexed = expirable.NewLRU[string, struct{}](packageIndexedReposCacheSize, nil, 0)
+	store.SetMutationHook(r.InvalidatePolicy)
 	return r
 }
 
 // InvalidatePolicy drops the cached authorizer for name so the next
-// request re-fetches the namespace spec. Admin-side handlers that
-// mutate a namespace call this to make their write visible without
-// waiting out the cache TTL. A name that wasn't cached is a no-op.
+// request re-fetches the namespace spec. The Store calls this
+// automatically after a successful Put or Delete; admin-side code
+// that bypasses the Store can call it directly. A name that wasn't
+// cached is a no-op.
 func (r *Registry) InvalidatePolicy(name string) { r.cache.invalidate(name) }
 
 // authorize loads (cached or freshly compiled) the namespace's
@@ -163,14 +200,23 @@ func (r *Registry) InvalidatePolicy(name string) { r.cache.invalidate(name) }
 //   - nil on allow.
 //   - an error wrapping [ErrNotFound] when the namespace is unknown
 //     (and caches the negative result).
-//   - an error wrapping [auth.ErrUnauthorized] on policy deny.
+//   - an error wrapping [auth.ErrUnauthorized] on policy deny or on
+//     a missing AuthContext.
 //   - any other error from the store / authorizer compile, unwrapped.
+//
+// The nil-AuthContext check lives here, not in the plugin
+// authorizer, because the wrapper is the trust boundary: a
+// third-party [AuthzFactory] that forgets to deny nil would
+// otherwise turn into an auth bypass.
 func (r *Registry) authorize(ctx context.Context, namespace string, op auth.Op) error {
 	az, err := r.authorizerFor(ctx, namespace)
 	if err != nil {
 		return err
 	}
-	ac, _ := auth.FromContext(ctx)
+	ac, ok := auth.FromContext(ctx)
+	if !ok || ac == nil {
+		return fmt.Errorf("no authenticated subject for %s on namespace %q: %w", op, namespace, auth.ErrUnauthorized)
+	}
 	return az.Authorize(ctx, ac, op)
 }
 
@@ -182,114 +228,203 @@ func (r *Registry) authorizerFor(ctx context.Context, namespace string) (auth.Au
 		return v.authorizer, nil
 	}
 
-	ns, err := r.store.Get(ctx, namespace)
-	if err != nil {
-		if errors.Is(err, ErrNotFound) {
-			r.cache.put(namespace, cachedPolicy{notFound: true})
+	// singleflight collapses concurrent misses for the same namespace
+	// onto one Store.Get + factory(...) compile. The closure return
+	// value is the *cachedPolicy we then cache locally; the
+	// follower goroutines all observe the same value via singleflight.
+	v, err, _ := r.flight.Do(namespace, func() (any, error) {
+		// Re-check the cache inside the singleflight: another
+		// goroutine may have populated it between our first miss
+		// and our turn at the leader spot.
+		if v, ok := r.cache.get(namespace); ok {
+			return v, nil
 		}
+		ns, err := r.store.Get(ctx, namespace)
+		if err != nil {
+			if errors.Is(err, ErrNotFound) {
+				neg := cachedPolicy{notFound: true}
+				r.cache.put(namespace, neg)
+				return neg, err
+			}
+			return cachedPolicy{}, err
+		}
+		az, ferr := r.factory(ns.Spec.Policy)
+		if ferr != nil {
+			// Compile errors signal misconfiguration the operator
+			// must fix (e.g. an admin Put that bypassed validation).
+			// Don't cache — repeat requests should keep surfacing
+			// the error until the spec is corrected.
+			return cachedPolicy{}, fmt.Errorf("compile authorizer for %q: %w", namespace, ferr)
+		}
+		entry := cachedPolicy{authorizer: az}
+		r.cache.put(namespace, entry)
+		return entry, nil
+	})
+	if err != nil {
 		return nil, err
 	}
-
-	az, err := r.factory(ns.Spec.Policy)
-	if err != nil {
-		// Compile errors signal misconfiguration the operator must fix
-		// (e.g. an admin Put that bypassed validation). Don't cache —
-		// repeat requests should keep surfacing the error until the
-		// spec is corrected.
-		return nil, fmt.Errorf("compile authorizer for %q: %w", namespace, err)
+	cp := v.(cachedPolicy)
+	if cp.notFound {
+		return nil, fmt.Errorf("%w: %s", ErrNotFound, namespace)
 	}
-	r.cache.put(namespace, cachedPolicy{authorizer: az})
-	return az, nil
+	return cp.authorizer, nil
 }
 
-// repoIn returns the namespace-prefixed OCI repo path for owningRepo.
-// "" stays "" so callers passing an empty owning repo (e.g. a probe)
-// still see a deterministic path under the namespace.
-func (r *Registry) repoIn(namespace, owningRepo string) string {
-	return path.Join(namespace, owningRepo)
+// resolveRepo validates the (namespace, owningRepo) pair against the
+// namespace-escape attack and returns the joined backend repo path.
+// Any owningRepo that doesn't path.Clean to itself, contains a "..",
+// or is absolute is rejected as malformed — without this check
+// path.Join("alpha", "../beta/foo") collapses to "beta/foo" and
+// silently lands traffic in another namespace.
+func (r *Registry) resolveRepo(namespace, owningRepo string) (string, error) {
+	if owningRepo == "" {
+		// An empty owning repo is a meaningful root for some
+		// operations (e.g. an admin "list everything in this
+		// namespace"); we accept it and resolve to just the
+		// namespace.
+		return namespace, nil
+	}
+	if path.IsAbs(owningRepo) {
+		return "", fmt.Errorf("%w: owning repo %q is absolute", ErrInvalidOwningRepo, owningRepo)
+	}
+	cleaned := path.Clean(owningRepo)
+	if cleaned != owningRepo {
+		return "", fmt.Errorf("%w: owning repo %q is not in canonical form (clean: %q)", ErrInvalidOwningRepo, owningRepo, cleaned)
+	}
+	// path.Clean turns "" → "." but we already returned for empty;
+	// any "." or ".." here is a real escape attempt.
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") || strings.Contains(cleaned, "/../") || strings.HasSuffix(cleaned, "/..") {
+		return "", fmt.Errorf("%w: owning repo %q escapes namespace", ErrInvalidOwningRepo, owningRepo)
+	}
+	return path.Join(namespace, cleaned), nil
 }
+
+// ErrInvalidOwningRepo is returned when an owning-repo string is
+// malformed or attempts to escape the namespace it was scoped to.
+// Handlers should map this to 400.
+var ErrInvalidOwningRepo = errors.New("invalid owning repo")
 
 func (r *Registry) packageIndexRepo(namespace string) string {
 	return path.Join(namespace, r.indexSuffix)
 }
 
-// AddFile authorizes namespace for write, prefixes f.OwningRepo with
-// the namespace, forwards to the inner registry, and (best-effort)
-// records the owning-repo in the namespace's package index so
-// [ListPackages] can enumerate it later.
-func (r *Registry) AddFile(ctx context.Context, namespace string, f *oci.RepoFile, body io.Reader) (*oci.FileDescriptor, error) {
-	if err := r.authorize(ctx, namespace, auth.OpWrite); err != nil {
+// requireFile centralises the nil-pointer + namespace-required
+// guards so each public method is one line shorter.
+func requireFile(f *oci.RepoFile) error {
+	if f == nil {
+		return errors.New("RepoFile must not be nil")
+	}
+	if f.Namespace == "" {
+		return errors.New("RepoFile.Namespace must not be empty")
+	}
+	return nil
+}
+
+// AddFile authorizes f.Namespace for write, prefixes f.OwningRepo
+// with the namespace, forwards to the inner registry, and (best-
+// effort) records the owning-repo in the namespace's package index
+// so [ListPackages] can enumerate it later.
+func (r *Registry) AddFile(ctx context.Context, f *oci.RepoFile, body io.Reader) (*oci.FileDescriptor, error) {
+	if err := requireFile(f); err != nil {
 		return nil, err
 	}
-	if f == nil {
-		return nil, errors.New("RepoFile must not be nil")
+	if err := r.authorize(ctx, f.Namespace, auth.OpWrite); err != nil {
+		return nil, err
 	}
-	owningRepo := f.OwningRepo
-	scoped := *f
-	scoped.OwningRepo = r.repoIn(namespace, owningRepo)
-	desc, err := r.inner.AddFile(ctx, &scoped, body)
+	scoped, err := r.scopedFile(f)
 	if err != nil {
 		return nil, err
 	}
-	r.recordPackage(ctx, namespace, owningRepo)
+	desc, err := r.inner.AddFile(ctx, scoped, body)
+	if err != nil {
+		return nil, err
+	}
+	r.recordPackage(ctx, f.Namespace, f.OwningRepo)
 	return desc, nil
 }
 
-// ReadFile authorizes namespace for read and forwards to the inner
-// registry with the owning repo prefixed.
-func (r *Registry) ReadFile(ctx context.Context, namespace string, f *oci.RepoFile) (*oci.FileDescriptor, io.ReadCloser, error) {
-	if err := r.authorize(ctx, namespace, auth.OpRead); err != nil {
+// ReadFile authorizes f.Namespace for read and forwards to the inner
+// registry with OwningRepo prefixed.
+func (r *Registry) ReadFile(ctx context.Context, f *oci.RepoFile) (*oci.FileDescriptor, io.ReadCloser, error) {
+	if err := requireFile(f); err != nil {
 		return nil, nil, err
 	}
-	if f == nil {
-		return nil, nil, errors.New("RepoFile must not be nil")
+	if err := r.authorize(ctx, f.Namespace, auth.OpRead); err != nil {
+		return nil, nil, err
 	}
-	scoped := *f
-	scoped.OwningRepo = r.repoIn(namespace, f.OwningRepo)
-	return r.inner.ReadFile(ctx, &scoped)
+	scoped, err := r.scopedFile(f)
+	if err != nil {
+		return nil, nil, err
+	}
+	return r.inner.ReadFile(ctx, scoped)
 }
 
-// BlobRedirectURL authorizes namespace for read and forwards to the
-// inner registry with the owning repo prefixed. Returns ("", nil) when
-// the backend serves blobs inline, mirroring [oci.Registry].
-func (r *Registry) BlobRedirectURL(ctx context.Context, namespace string, f *oci.RepoFile) (string, error) {
-	if err := r.authorize(ctx, namespace, auth.OpRead); err != nil {
+// BlobRedirectURL authorizes f.Namespace for read and forwards to
+// the inner registry with OwningRepo prefixed. Returns ("", nil)
+// when the backend serves blobs inline, mirroring [oci.Registry].
+func (r *Registry) BlobRedirectURL(ctx context.Context, f *oci.RepoFile) (string, error) {
+	if err := requireFile(f); err != nil {
 		return "", err
 	}
-	if f == nil {
-		return "", errors.New("RepoFile must not be nil")
+	if err := r.authorize(ctx, f.Namespace, auth.OpRead); err != nil {
+		return "", err
 	}
-	scoped := *f
-	scoped.OwningRepo = r.repoIn(namespace, f.OwningRepo)
-	return r.inner.BlobRedirectURL(ctx, &scoped)
+	scoped, err := r.scopedFile(f)
+	if err != nil {
+		return "", err
+	}
+	return r.inner.BlobRedirectURL(ctx, scoped)
 }
 
-// ListTags authorizes namespace for read and returns the canonical
-// tags for owningRepo within the namespace.
-func (r *Registry) ListTags(ctx context.Context, namespace, owningRepo string) ([]string, error) {
-	if err := r.authorize(ctx, namespace, auth.OpRead); err != nil {
+// ListTags authorizes f.Namespace for read and returns the canonical
+// tags for f.OwningRepo within the namespace. f need only carry
+// Namespace and OwningRepo; other fields are ignored.
+func (r *Registry) ListTags(ctx context.Context, f *oci.RepoFile) ([]string, error) {
+	if err := requireFile(f); err != nil {
 		return nil, err
 	}
-	return r.inner.ListTags(ctx, r.repoIn(namespace, owningRepo))
-}
-
-// ListFiles authorizes namespace for read and returns every file
-// across every canonical version of owningRepo within the namespace.
-// The OwningRepo on each returned [oci.RepoFile] is rewritten back to
-// the namespace-relative form so callers don't see the namespace
-// prefix leak through.
-func (r *Registry) ListFiles(ctx context.Context, namespace, owningRepo string) ([]*oci.RepoFile, error) {
-	if err := r.authorize(ctx, namespace, auth.OpRead); err != nil {
+	if err := r.authorize(ctx, f.Namespace, auth.OpRead); err != nil {
 		return nil, err
 	}
-	files, err := r.inner.ListFiles(ctx, r.repoIn(namespace, owningRepo))
+	scoped, err := r.resolveRepo(f.Namespace, f.OwningRepo)
 	if err != nil {
 		return nil, err
 	}
-	for _, fl := range files {
-		fl.OwningRepo = stripPrefix(fl.OwningRepo, namespace)
+	return r.inner.ListTags(ctx, scoped)
+}
+
+// ListFiles authorizes f.Namespace for read and returns every file
+// across every canonical version of f.OwningRepo within the
+// namespace. The OwningRepo on each returned [oci.RepoFile] is
+// rewritten back to the namespace-relative form and the Namespace
+// field is set, so callers don't see the raw backend prefix leak
+// through. Returned slices and pointers are freshly allocated by the
+// inner registry; the wrapper makes a defensive copy of each
+// element before mutating to keep any future inner-side caching
+// safe.
+func (r *Registry) ListFiles(ctx context.Context, f *oci.RepoFile) ([]*oci.RepoFile, error) {
+	if err := requireFile(f); err != nil {
+		return nil, err
 	}
-	return files, nil
+	if err := r.authorize(ctx, f.Namespace, auth.OpRead); err != nil {
+		return nil, err
+	}
+	scoped, err := r.resolveRepo(f.Namespace, f.OwningRepo)
+	if err != nil {
+		return nil, err
+	}
+	files, err := r.inner.ListFiles(ctx, scoped)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*oci.RepoFile, len(files))
+	for i, src := range files {
+		copyF := *src
+		copyF.Namespace = f.Namespace
+		copyF.OwningRepo = stripPrefix(copyF.OwningRepo, f.Namespace)
+		out[i] = &copyF
+	}
+	return out, nil
 }
 
 // ListPackages authorizes namespace for read and returns every
@@ -311,41 +446,111 @@ func (r *Registry) ListPackages(ctx context.Context, namespace string) ([]string
 	}
 	out := make([]string, 0, len(tags))
 	for _, t := range tags {
-		out = append(out, decodeTag(t))
+		decoded, derr := decodeTag(t)
+		if derr != nil {
+			// A tag that doesn't decode means an admin or a previous
+			// ocifactory version wrote a non-encoded tag. Skip it
+			// rather than failing the whole listing — the contract
+			// is "best-effort enumeration" and a stray tag is no
+			// reason to deny callers their other packages.
+			logging.FromContext(ctx).WarnContext(ctx, "namespace package index: skipping undecodable tag",
+				"namespace", namespace, "tag", t, "error", derr,
+			)
+			continue
+		}
+		out = append(out, decoded)
 	}
 	return out, nil
 }
 
-// AppendRefs authorizes namespace for write and forwards to the inner
-// registry with owningRepo prefixed.
-func (r *Registry) AppendRefs(ctx context.Context, namespace, owningRepo, canonicalTag string, refs ...string) error {
-	if err := r.authorize(ctx, namespace, auth.OpWrite); err != nil {
+// AppendRefs authorizes f.Namespace for write and forwards to the
+// inner registry with OwningRepo prefixed. f need only carry
+// Namespace, OwningRepo, and OwningTag (treated as the canonical
+// tag); other fields are ignored.
+func (r *Registry) AppendRefs(ctx context.Context, f *oci.RepoFile, refs ...string) error {
+	if err := requireFile(f); err != nil {
 		return err
 	}
-	return r.inner.AppendRefs(ctx, r.repoIn(namespace, owningRepo), canonicalTag, refs...)
+	if f.OwningTag == "" {
+		return errors.New("RepoFile.OwningTag must be set for AppendRefs")
+	}
+	if err := r.authorize(ctx, f.Namespace, auth.OpWrite); err != nil {
+		return err
+	}
+	scoped, err := r.resolveRepo(f.Namespace, f.OwningRepo)
+	if err != nil {
+		return err
+	}
+	return r.inner.AppendRefs(ctx, scoped, f.OwningTag, refs...)
 }
 
-// DeleteRepoFiles authorizes namespace for write and forwards to the
-// inner registry with owningRepo prefixed. The package index entry
-// for owningRepo is best-effort cleared after the inner delete
-// succeeds; failure is logged at WARN and does not fail the call.
-func (r *Registry) DeleteRepoFiles(ctx context.Context, namespace, owningRepo string) error {
-	if err := r.authorize(ctx, namespace, auth.OpWrite); err != nil {
+// DeleteRepoFiles authorizes f.Namespace for write and forwards to
+// the inner registry with OwningRepo prefixed. The package index
+// entry for f.OwningRepo is cleared after the inner delete succeeds
+// — both the in-process indexed marker AND the backend index tag —
+// so [ListPackages] no longer reports the now-empty repo. Index
+// cleanup failures are logged at WARN and do not fail the call.
+func (r *Registry) DeleteRepoFiles(ctx context.Context, f *oci.RepoFile) error {
+	if err := requireFile(f); err != nil {
 		return err
 	}
-	if err := r.inner.DeleteRepoFiles(ctx, r.repoIn(namespace, owningRepo)); err != nil {
+	if err := r.authorize(ctx, f.Namespace, auth.OpWrite); err != nil {
 		return err
 	}
-	r.indexed.Remove(indexedKey(namespace, owningRepo))
+	scoped, err := r.resolveRepo(f.Namespace, f.OwningRepo)
+	if err != nil {
+		return err
+	}
+	if err := r.inner.DeleteRepoFiles(ctx, scoped); err != nil {
+		return err
+	}
+	r.indexed.Remove(indexedKey(f.Namespace, f.OwningRepo))
+	encoded, encErr := encodeTag(f.OwningRepo)
+	if encErr != nil {
+		// The owning-repo passed authorize() and resolveRepo() so
+		// this should never fail; treat as bug-not-vuln and log.
+		logging.FromContext(ctx).WarnContext(ctx, "namespace package index: encode failed on delete",
+			"namespace", f.Namespace, "owning_repo", f.OwningRepo, "error", encErr,
+		)
+		return nil
+	}
+	if err := r.inner.DeleteTagFiles(ctx, r.packageIndexRepo(f.Namespace), encoded); err != nil && !errors.Is(err, errdef.ErrNotFound) {
+		logging.FromContext(ctx).WarnContext(ctx, "namespace package index sweep failed",
+			"namespace", f.Namespace, "owning_repo", f.OwningRepo, "error", err,
+		)
+	}
 	return nil
+}
+
+// scopedFile returns a copy of f with OwningRepo rewritten to the
+// namespace-prefixed backend form and Namespace cleared (the inner
+// OCI registry doesn't know about namespaces). Returns
+// [ErrInvalidOwningRepo] when the input would escape the namespace.
+func (r *Registry) scopedFile(f *oci.RepoFile) (*oci.RepoFile, error) {
+	scoped := *f
+	scoped.Namespace = ""
+	resolved, err := r.resolveRepo(f.Namespace, f.OwningRepo)
+	if err != nil {
+		return nil, err
+	}
+	scoped.OwningRepo = resolved
+	return &scoped, nil
 }
 
 // recordPackage best-effort marks owningRepo as present in the
 // namespace's package index. Index updates run after the inner write
 // already succeeded so the visible state never includes "indexed but
 // no data". A failed update is logged at WARN — the index is a hint
-// for cascade delete and listing, not a transactional ledger; a stale
-// miss is rectified by the next write or a manual reindex.
+// for cascade delete and listing, not a transactional ledger; a
+// stale miss is rectified by the next write.
+//
+// Concurrency: a per-key sync.Mutex serialises concurrent first-
+// writers. Mutex entries are NOT deleted from indexLocks after use:
+// deleting while another goroutine still references the same
+// *sync.Mutex would let an arriving third goroutine LoadOrStore a
+// fresh mutex for the same key, "guarding" with two unrelated
+// mutexes. The map is bounded by the indexed-LRU's eviction (entries
+// never used again age out as the LRU evicts).
 func (r *Registry) recordPackage(ctx context.Context, namespace, owningRepo string) {
 	if owningRepo == "" {
 		return
@@ -355,26 +560,33 @@ func (r *Registry) recordPackage(ctx context.Context, namespace, owningRepo stri
 		return
 	}
 
-	// Per-key lock so concurrent first-writers pay for one backend
-	// AddFile, not N. Stored value is unused; we only need the
-	// uniqueness of *Mutex per key. LoadOrStore guarantees at most one
-	// goroutine creates a fresh mutex; the rest contend on it.
 	muAny, _ := r.indexLocks.LoadOrStore(key, &sync.Mutex{})
 	mu := muAny.(*sync.Mutex)
 	mu.Lock()
 	defer mu.Unlock()
-	defer r.indexLocks.Delete(key)
 
 	// Re-check after acquiring the lock: an earlier holder may have
 	// just populated the indexed-set, in which case our backend write
-	// is wasted work the LRU would otherwise catch on the next pass.
+	// is wasted work the LRU re-check catches here. This re-check is
+	// the load-bearing dedupe — without it, a later concurrent
+	// arriver under a different mutex (impossible today thanks to
+	// the no-delete invariant on indexLocks, but enforced by belt-
+	// and-braces here) would race a redundant AddFile to the
+	// backend.
 	if _, ok := r.indexed.Get(key); ok {
 		return
 	}
 
+	encoded, err := encodeTag(owningRepo)
+	if err != nil {
+		logging.FromContext(ctx).WarnContext(ctx, "namespace package index: encode failed",
+			"namespace", namespace, "owning_repo", owningRepo, "error", err,
+		)
+		return
+	}
 	rf := &oci.RepoFile{
 		OwningRepo: r.packageIndexRepo(namespace),
-		OwningTag:  encodeTag(owningRepo),
+		OwningTag:  encoded,
 		Name:       packageIndexSentinelFile,
 		MediaType:  "text/plain",
 		Size:       int64(len(packageIndexSentinelBody)),
@@ -390,10 +602,16 @@ func (r *Registry) recordPackage(ctx context.Context, namespace, owningRepo stri
 	r.indexed.Add(key, struct{}{})
 }
 
-// stripPrefix removes a leading "<namespace>/" from owningRepo. Used
-// by [ListFiles] so callers don't see the namespace prefix leak
-// through in the returned [oci.RepoFile.OwningRepo].
+// stripPrefix removes a leading "<namespace>/" from owningRepo. The
+// trailing slash is required so namespace "alpha" doesn't strip a
+// repo from sibling namespace "alpha-foo". A namespace-equal
+// owningRepo (i.e. the namespace's "root") is collapsed to "" so
+// callers see a stable representation independent of whether they
+// originally passed "" or the explicit "<namespace>".
 func stripPrefix(owningRepo, namespace string) string {
+	if owningRepo == namespace {
+		return ""
+	}
 	prefix := namespace + "/"
 	if strings.HasPrefix(owningRepo, prefix) {
 		return owningRepo[len(prefix):]
@@ -401,20 +619,70 @@ func stripPrefix(owningRepo, namespace string) string {
 	return owningRepo
 }
 
-// encodeTag escapes '/' characters in an owning-repo name so it can
-// serve as an OCI tag name (which allows [A-Za-z0-9_.-] only). See
-// [tagSlashEscape] for the exact substitution.
-func encodeTag(owningRepo string) string {
-	return strings.ReplaceAll(owningRepo, "/", tagSlashEscape)
+// encodeTag escapes owningRepo into a string usable as an OCI tag
+// name. OCI tags allow [A-Za-z0-9_.-] only, so '/' must be escaped.
+// We use a percent-style encoding (every '_' becomes "_5F" and every
+// '/' becomes "_2F") rather than a substring like "__" because the
+// substring approach silently collides: encodeTag("a/b") and
+// encodeTag("a__b") would otherwise both produce "a__b". The
+// encoding is lossless for any input over the OCI repo charset and
+// round-trips exactly.
+func encodeTag(owningRepo string) (string, error) {
+	var b strings.Builder
+	b.Grow(len(owningRepo))
+	for _, r := range owningRepo {
+		switch {
+		case r == '_':
+			b.WriteString("_5F")
+		case r == '/':
+			b.WriteString("_2F")
+		case r == '.' || r == '-':
+			b.WriteRune(r)
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			// OCI repo paths are lowercase alnum + ".-_/" per the
+			// distribution spec; anything else means the caller is
+			// constructing a malformed owning-repo. Surface it
+			// rather than silently mangling.
+			return "", fmt.Errorf("%w: owning repo %q contains invalid character %q", ErrInvalidOwningRepo, owningRepo, r)
+		}
+	}
+	if b.Len() == 0 {
+		return "", fmt.Errorf("%w: owning repo must not be empty", ErrInvalidOwningRepo)
+	}
+	if b.Len() > 128 {
+		// OCI tag spec: 1-128 chars. Most realistic repo names fit
+		// after escaping; extremely long ones don't.
+		return "", fmt.Errorf("%w: encoded owning repo exceeds 128-char OCI tag limit", ErrInvalidOwningRepo)
+	}
+	return b.String(), nil
 }
 
-// decodeTag reverses [encodeTag]. Owning-repo names produced by
-// callers must not themselves contain the escape sequence; this is a
-// constraint we accept rather than escape recursively because it
-// would push the encoding into territory that operators inspecting
-// the OCI registry can no longer eyeball.
-func decodeTag(tag string) string {
-	return strings.ReplaceAll(tag, tagSlashEscape, "/")
+// decodeTag reverses [encodeTag]. Any "_HH" sequence (where HH is
+// a two-char hex pair) is replaced by the corresponding byte; a
+// stray '_' not followed by valid hex is a malformed encoding and
+// surfaces as an error.
+func decodeTag(tag string) (string, error) {
+	var b strings.Builder
+	b.Grow(len(tag))
+	for i := 0; i < len(tag); i++ {
+		c := tag[i]
+		if c != '_' {
+			b.WriteByte(c)
+			continue
+		}
+		if i+2 >= len(tag) {
+			return "", fmt.Errorf("malformed escape at %d: trailing underscore", i)
+		}
+		decoded, err := hex.DecodeString(tag[i+1 : i+3])
+		if err != nil {
+			return "", fmt.Errorf("malformed escape at %d: %w", i, err)
+		}
+		b.WriteByte(decoded[0])
+		i += 2
+	}
+	return b.String(), nil
 }
 
 func indexedKey(namespace, owningRepo string) string {

--- a/pkg/namespace/registry.go
+++ b/pkg/namespace/registry.go
@@ -1,0 +1,422 @@
+package namespace
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/golang-lru/v2/expirable"
+	"oras.land/oras-go/v2/errdef"
+
+	"github.com/yolocs/ocifactory/pkg/auth"
+	"github.com/yolocs/ocifactory/pkg/logging"
+	"github.com/yolocs/ocifactory/pkg/oci"
+)
+
+const (
+	// DefaultPackageIndexSuffix names the per-namespace OCI repo whose
+	// tags enumerate every owning-repo the wrapper has ever recorded a
+	// write for. The repo lives at "<namespace>/_packages" by default
+	// — operators who already park a real artifact under that name can
+	// relocate it via [WithPackageIndexSuffix].
+	DefaultPackageIndexSuffix = "_packages"
+
+	// indexSentinelFile is the file name written under the package
+	// index repo. The body is constant — the tag's existence is the
+	// record — so a re-add of an existing tag is a backend no-op.
+	packageIndexSentinelFile = "present"
+
+	// packageIndexedReposCacheSize bounds the in-process set of
+	// (namespace, owning-repo) pairs the wrapper has already recorded
+	// in the index. The set is a hot-path optimisation: a hit skips
+	// the redundant AddFile call entirely. Misses are safe and just
+	// pay one idempotent backend write.
+	packageIndexedReposCacheSize = 4096
+
+	// tagSlashEscape is the OCI-tag-safe substitution for the '/'
+	// character. OCI tag names allow [A-Za-z0-9_.-] only, so we encode
+	// every '/' in an owning-repo name as "__" and decode on read.
+	// Documented next to the constant so a future maintainer doesn't
+	// reinvent the escape and break round-tripping.
+	tagSlashEscape = "__"
+)
+
+var packageIndexSentinelBody = []byte("present\n")
+
+// AuthzFactory builds an [auth.Authorizer] from a namespace [Policy].
+// Operators wire in alternative implementations (OPA, Casbin, Cedar,
+// ...) by passing one to [WithAuthzFactory]; the default is
+// [NewPolicyAuthorizer].
+type AuthzFactory func(Policy) (auth.Authorizer, error)
+
+// RegistryBackend is the subset of *pkg/oci.Registry the wrapper
+// needs. Pinned as an interface so tests can substitute the in-memory
+// [oci.FakeRegistry]; production passes *oci.Registry directly.
+type RegistryBackend interface {
+	AddFile(ctx context.Context, f *oci.RepoFile, ro io.Reader) (*oci.FileDescriptor, error)
+	ReadFile(ctx context.Context, f *oci.RepoFile) (*oci.FileDescriptor, io.ReadCloser, error)
+	BlobRedirectURL(ctx context.Context, f *oci.RepoFile) (string, error)
+	ListTags(ctx context.Context, repo string) ([]string, error)
+	ListFiles(ctx context.Context, repo string) ([]*oci.RepoFile, error)
+	AppendRefs(ctx context.Context, repo string, canonicalTag string, refs ...string) error
+	DeleteRepoFiles(ctx context.Context, repo string) error
+}
+
+// Registry is the data-plane wrapper that namespace-scopes every OCI
+// operation. It:
+//
+//   - Prefixes every OwningRepo with the namespace name so writes from
+//     namespace "alpha" land under "alpha/<owning-repo>" and cannot be
+//     read from namespace "beta".
+//   - Enforces the namespace's authz policy on every call. The
+//     compiled authorizer is cached behind a TTL+LRU so the hot path
+//     is one map lookup per request.
+//   - Maintains a per-namespace package index at
+//     "<namespace>/_packages" (one tag per owning-repo) so cascade
+//     delete and namespace listing don't depend on the OCI _catalog
+//     endpoint, which is optional and inconsistently implemented.
+//
+// Handlers consume *Registry instead of *oci.Registry so authz
+// enforcement is a structural guarantee — a future format author
+// cannot forget to call the authorizer.
+type Registry struct {
+	inner       RegistryBackend
+	store       *Store
+	cache       *policyCache
+	indexed     *expirable.LRU[string, struct{}]
+	indexSuffix string
+	factory     AuthzFactory
+	cacheTTL    time.Duration
+
+	// indexLocks serialises index writes per (ns, owning-repo) pair so
+	// a burst of concurrent first-writes pays for one OCI round-trip
+	// instead of N. The locks are dropped after the write succeeds —
+	// repeat writers short-circuit on the indexed LRU above.
+	indexLocks sync.Map
+}
+
+// RegistryOption customises a [Registry].
+type RegistryOption func(*Registry)
+
+// WithPackageIndexSuffix overrides [DefaultPackageIndexSuffix].
+// Operators set this when their backend already has a top-level
+// "_packages" repo they want to keep — extremely unlikely, but cheap
+// to make configurable.
+func WithPackageIndexSuffix(s string) RegistryOption {
+	return func(r *Registry) { r.indexSuffix = s }
+}
+
+// WithAuthzFactory overrides the authorizer constructor.
+// Defaults to [NewPolicyAuthorizer].
+func WithAuthzFactory(f AuthzFactory) RegistryOption {
+	return func(r *Registry) { r.factory = f }
+}
+
+// WithPolicyCacheTTL overrides [DefaultPolicyCacheTTL]. A value of
+// zero or negative disables caching — every request pays for a
+// Store.Get + authorizer compile. Operators set ttl=0 in tests that
+// want every Put to take effect immediately without sleeping.
+func WithPolicyCacheTTL(ttl time.Duration) RegistryOption {
+	return func(r *Registry) { r.cacheTTL = ttl }
+}
+
+// NewRegistry wraps inner in a namespace [Registry] backed by store
+// for namespace metadata.
+func NewRegistry(inner RegistryBackend, store *Store, opts ...RegistryOption) *Registry {
+	r := &Registry{
+		inner:       inner,
+		store:       store,
+		indexSuffix: DefaultPackageIndexSuffix,
+		factory:     NewPolicyAuthorizer,
+		cacheTTL:    DefaultPolicyCacheTTL,
+	}
+	for _, o := range opts {
+		o(r)
+	}
+	r.cache = newPolicyCache(DefaultPolicyCacheSize, r.cacheTTL)
+	// Indexed-repos cache exists purely to short-circuit duplicate
+	// AddFile calls into the package index. Its lifetime is the
+	// process — entries should not age out under normal operation
+	// because the underlying OCI tag is also persistent. ttl=0 inside
+	// expirable.NewLRU means "10-year TTL" (effectively no expiry),
+	// which is what we want; bounded size is the only ceiling.
+	r.indexed = expirable.NewLRU[string, struct{}](packageIndexedReposCacheSize, nil, 0)
+	return r
+}
+
+// InvalidatePolicy drops the cached authorizer for name so the next
+// request re-fetches the namespace spec. Admin-side handlers that
+// mutate a namespace call this to make their write visible without
+// waiting out the cache TTL. A name that wasn't cached is a no-op.
+func (r *Registry) InvalidatePolicy(name string) { r.cache.invalidate(name) }
+
+// authorize loads (cached or freshly compiled) the namespace's
+// authorizer and runs op against the [auth.AuthContext] in ctx.
+// Returns:
+//
+//   - nil on allow.
+//   - an error wrapping [ErrNotFound] when the namespace is unknown
+//     (and caches the negative result).
+//   - an error wrapping [auth.ErrUnauthorized] on policy deny.
+//   - any other error from the store / authorizer compile, unwrapped.
+func (r *Registry) authorize(ctx context.Context, namespace string, op auth.Op) error {
+	az, err := r.authorizerFor(ctx, namespace)
+	if err != nil {
+		return err
+	}
+	ac, _ := auth.FromContext(ctx)
+	return az.Authorize(ctx, ac, op)
+}
+
+func (r *Registry) authorizerFor(ctx context.Context, namespace string) (auth.Authorizer, error) {
+	if v, ok := r.cache.get(namespace); ok {
+		if v.notFound {
+			return nil, fmt.Errorf("%w: %s", ErrNotFound, namespace)
+		}
+		return v.authorizer, nil
+	}
+
+	ns, err := r.store.Get(ctx, namespace)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			r.cache.put(namespace, cachedPolicy{notFound: true})
+		}
+		return nil, err
+	}
+
+	az, err := r.factory(ns.Spec.Policy)
+	if err != nil {
+		// Compile errors signal misconfiguration the operator must fix
+		// (e.g. an admin Put that bypassed validation). Don't cache —
+		// repeat requests should keep surfacing the error until the
+		// spec is corrected.
+		return nil, fmt.Errorf("compile authorizer for %q: %w", namespace, err)
+	}
+	r.cache.put(namespace, cachedPolicy{authorizer: az})
+	return az, nil
+}
+
+// repoIn returns the namespace-prefixed OCI repo path for owningRepo.
+// "" stays "" so callers passing an empty owning repo (e.g. a probe)
+// still see a deterministic path under the namespace.
+func (r *Registry) repoIn(namespace, owningRepo string) string {
+	return path.Join(namespace, owningRepo)
+}
+
+func (r *Registry) packageIndexRepo(namespace string) string {
+	return path.Join(namespace, r.indexSuffix)
+}
+
+// AddFile authorizes namespace for write, prefixes f.OwningRepo with
+// the namespace, forwards to the inner registry, and (best-effort)
+// records the owning-repo in the namespace's package index so
+// [ListPackages] can enumerate it later.
+func (r *Registry) AddFile(ctx context.Context, namespace string, f *oci.RepoFile, body io.Reader) (*oci.FileDescriptor, error) {
+	if err := r.authorize(ctx, namespace, auth.OpWrite); err != nil {
+		return nil, err
+	}
+	if f == nil {
+		return nil, errors.New("RepoFile must not be nil")
+	}
+	owningRepo := f.OwningRepo
+	scoped := *f
+	scoped.OwningRepo = r.repoIn(namespace, owningRepo)
+	desc, err := r.inner.AddFile(ctx, &scoped, body)
+	if err != nil {
+		return nil, err
+	}
+	r.recordPackage(ctx, namespace, owningRepo)
+	return desc, nil
+}
+
+// ReadFile authorizes namespace for read and forwards to the inner
+// registry with the owning repo prefixed.
+func (r *Registry) ReadFile(ctx context.Context, namespace string, f *oci.RepoFile) (*oci.FileDescriptor, io.ReadCloser, error) {
+	if err := r.authorize(ctx, namespace, auth.OpRead); err != nil {
+		return nil, nil, err
+	}
+	if f == nil {
+		return nil, nil, errors.New("RepoFile must not be nil")
+	}
+	scoped := *f
+	scoped.OwningRepo = r.repoIn(namespace, f.OwningRepo)
+	return r.inner.ReadFile(ctx, &scoped)
+}
+
+// BlobRedirectURL authorizes namespace for read and forwards to the
+// inner registry with the owning repo prefixed. Returns ("", nil) when
+// the backend serves blobs inline, mirroring [oci.Registry].
+func (r *Registry) BlobRedirectURL(ctx context.Context, namespace string, f *oci.RepoFile) (string, error) {
+	if err := r.authorize(ctx, namespace, auth.OpRead); err != nil {
+		return "", err
+	}
+	if f == nil {
+		return "", errors.New("RepoFile must not be nil")
+	}
+	scoped := *f
+	scoped.OwningRepo = r.repoIn(namespace, f.OwningRepo)
+	return r.inner.BlobRedirectURL(ctx, &scoped)
+}
+
+// ListTags authorizes namespace for read and returns the canonical
+// tags for owningRepo within the namespace.
+func (r *Registry) ListTags(ctx context.Context, namespace, owningRepo string) ([]string, error) {
+	if err := r.authorize(ctx, namespace, auth.OpRead); err != nil {
+		return nil, err
+	}
+	return r.inner.ListTags(ctx, r.repoIn(namespace, owningRepo))
+}
+
+// ListFiles authorizes namespace for read and returns every file
+// across every canonical version of owningRepo within the namespace.
+// The OwningRepo on each returned [oci.RepoFile] is rewritten back to
+// the namespace-relative form so callers don't see the namespace
+// prefix leak through.
+func (r *Registry) ListFiles(ctx context.Context, namespace, owningRepo string) ([]*oci.RepoFile, error) {
+	if err := r.authorize(ctx, namespace, auth.OpRead); err != nil {
+		return nil, err
+	}
+	files, err := r.inner.ListFiles(ctx, r.repoIn(namespace, owningRepo))
+	if err != nil {
+		return nil, err
+	}
+	for _, fl := range files {
+		fl.OwningRepo = stripPrefix(fl.OwningRepo, namespace)
+	}
+	return files, nil
+}
+
+// ListPackages authorizes namespace for read and returns every
+// owning-repo the wrapper has recorded a write for in the namespace's
+// package index. Tags are decoded back to their original "/"-form.
+//
+// An absent index repo is reported as an empty list — a namespace
+// that has never been written to legitimately has no packages.
+func (r *Registry) ListPackages(ctx context.Context, namespace string) ([]string, error) {
+	if err := r.authorize(ctx, namespace, auth.OpRead); err != nil {
+		return nil, err
+	}
+	tags, err := r.inner.ListTags(ctx, r.packageIndexRepo(namespace))
+	if err != nil {
+		if errors.Is(err, errdef.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("list package index for %q: %w", namespace, err)
+	}
+	out := make([]string, 0, len(tags))
+	for _, t := range tags {
+		out = append(out, decodeTag(t))
+	}
+	return out, nil
+}
+
+// AppendRefs authorizes namespace for write and forwards to the inner
+// registry with owningRepo prefixed.
+func (r *Registry) AppendRefs(ctx context.Context, namespace, owningRepo, canonicalTag string, refs ...string) error {
+	if err := r.authorize(ctx, namespace, auth.OpWrite); err != nil {
+		return err
+	}
+	return r.inner.AppendRefs(ctx, r.repoIn(namespace, owningRepo), canonicalTag, refs...)
+}
+
+// DeleteRepoFiles authorizes namespace for write and forwards to the
+// inner registry with owningRepo prefixed. The package index entry
+// for owningRepo is best-effort cleared after the inner delete
+// succeeds; failure is logged at WARN and does not fail the call.
+func (r *Registry) DeleteRepoFiles(ctx context.Context, namespace, owningRepo string) error {
+	if err := r.authorize(ctx, namespace, auth.OpWrite); err != nil {
+		return err
+	}
+	if err := r.inner.DeleteRepoFiles(ctx, r.repoIn(namespace, owningRepo)); err != nil {
+		return err
+	}
+	r.indexed.Remove(indexedKey(namespace, owningRepo))
+	return nil
+}
+
+// recordPackage best-effort marks owningRepo as present in the
+// namespace's package index. Index updates run after the inner write
+// already succeeded so the visible state never includes "indexed but
+// no data". A failed update is logged at WARN — the index is a hint
+// for cascade delete and listing, not a transactional ledger; a stale
+// miss is rectified by the next write or a manual reindex.
+func (r *Registry) recordPackage(ctx context.Context, namespace, owningRepo string) {
+	if owningRepo == "" {
+		return
+	}
+	key := indexedKey(namespace, owningRepo)
+	if _, ok := r.indexed.Get(key); ok {
+		return
+	}
+
+	// Per-key lock so concurrent first-writers pay for one backend
+	// AddFile, not N. Stored value is unused; we only need the
+	// uniqueness of *Mutex per key. LoadOrStore guarantees at most one
+	// goroutine creates a fresh mutex; the rest contend on it.
+	muAny, _ := r.indexLocks.LoadOrStore(key, &sync.Mutex{})
+	mu := muAny.(*sync.Mutex)
+	mu.Lock()
+	defer mu.Unlock()
+	defer r.indexLocks.Delete(key)
+
+	// Re-check after acquiring the lock: an earlier holder may have
+	// just populated the indexed-set, in which case our backend write
+	// is wasted work the LRU would otherwise catch on the next pass.
+	if _, ok := r.indexed.Get(key); ok {
+		return
+	}
+
+	rf := &oci.RepoFile{
+		OwningRepo: r.packageIndexRepo(namespace),
+		OwningTag:  encodeTag(owningRepo),
+		Name:       packageIndexSentinelFile,
+		MediaType:  "text/plain",
+		Size:       int64(len(packageIndexSentinelBody)),
+	}
+	if _, err := r.inner.AddFile(ctx, rf, bytes.NewReader(packageIndexSentinelBody)); err != nil && !errors.Is(err, oci.ErrAlreadyExists) {
+		logging.FromContext(ctx).WarnContext(ctx, "namespace package index update failed",
+			"namespace", namespace,
+			"owning_repo", owningRepo,
+			"error", err,
+		)
+		return
+	}
+	r.indexed.Add(key, struct{}{})
+}
+
+// stripPrefix removes a leading "<namespace>/" from owningRepo. Used
+// by [ListFiles] so callers don't see the namespace prefix leak
+// through in the returned [oci.RepoFile.OwningRepo].
+func stripPrefix(owningRepo, namespace string) string {
+	prefix := namespace + "/"
+	if strings.HasPrefix(owningRepo, prefix) {
+		return owningRepo[len(prefix):]
+	}
+	return owningRepo
+}
+
+// encodeTag escapes '/' characters in an owning-repo name so it can
+// serve as an OCI tag name (which allows [A-Za-z0-9_.-] only). See
+// [tagSlashEscape] for the exact substitution.
+func encodeTag(owningRepo string) string {
+	return strings.ReplaceAll(owningRepo, "/", tagSlashEscape)
+}
+
+// decodeTag reverses [encodeTag]. Owning-repo names produced by
+// callers must not themselves contain the escape sequence; this is a
+// constraint we accept rather than escape recursively because it
+// would push the encoding into territory that operators inspecting
+// the OCI registry can no longer eyeball.
+func decodeTag(tag string) string {
+	return strings.ReplaceAll(tag, tagSlashEscape, "/")
+}
+
+func indexedKey(namespace, owningRepo string) string {
+	return namespace + "\x00" + owningRepo
+}

--- a/pkg/namespace/registry.go
+++ b/pkg/namespace/registry.go
@@ -88,25 +88,22 @@ type RegistryBackend interface {
 	DeleteTagFiles(ctx context.Context, repo string, tag string) error
 }
 
-// Registry is the data-plane wrapper that namespace-scopes every OCI
-// operation. It:
+// Registry is the data-plane wrapper that holds the cross-namespace
+// state — the authorizer cache, the package-index dedupe set, the
+// pluggable authz factory — and hands out per-namespace
+// [ScopedRegistry] views via [Registry.For].
 //
-//   - Reads [oci.RepoFile.Namespace] from the caller-supplied file
-//     and prefixes OwningRepo with it so writes from namespace
-//     "alpha" land under "alpha/<owning-repo>" and cannot be read
-//     from namespace "beta".
-//   - Enforces the namespace's authz policy on every call. The
-//     compiled authorizer is cached behind a TTL+LRU and a
-//     singleflight collapse so the hot path is one map lookup per
-//     request and a cold-start burst pays for one compile, not N.
-//   - Maintains a per-namespace package index at
-//     "<namespace>/_packages" (one tag per owning-repo) so cascade
-//     delete and namespace listing don't depend on the OCI _catalog
-//     endpoint.
+// Handlers don't use *Registry directly; they hold a
+// *ScopedRegistry obtained per request:
 //
-// Handlers consume *Registry instead of *oci.Registry so authz
-// enforcement is a structural guarantee — a future format author
-// cannot forget to call the authorizer.
+//	ns := mux.Vars(req)["namespace"]
+//	scoped := r.For(ns)
+//	desc, err := scoped.AddFile(ctx, f, body)
+//
+// *ScopedRegistry implements the existing [pkg/handler.Registry]
+// interface, so handlers can swap a *pkg/oci.Registry for a
+// *ScopedRegistry without changing any call site — namespace-aware
+// authz and OwningRepo prefixing happen transparently.
 type Registry struct {
 	inner       RegistryBackend
 	store       *Store
@@ -186,6 +183,16 @@ func NewRegistry(inner RegistryBackend, store *Store, opts ...RegistryOption) *R
 	return r
 }
 
+// For returns a [ScopedRegistry] bound to namespace. The returned
+// view is cheap to construct (a small struct, no I/O) so handlers
+// should call it per request rather than caching it. The bound
+// namespace is enforced on every method invocation — there is no
+// way to issue a cross-namespace operation through a single
+// ScopedRegistry.
+func (r *Registry) For(namespace string) *ScopedRegistry {
+	return &ScopedRegistry{parent: r, namespace: namespace}
+}
+
 // InvalidatePolicy drops the cached authorizer for name so the next
 // request re-fetches the namespace spec. The Store calls this
 // automatically after a successful Put or Delete; admin-side code
@@ -230,8 +237,8 @@ func (r *Registry) authorizerFor(ctx context.Context, namespace string) (auth.Au
 
 	// singleflight collapses concurrent misses for the same namespace
 	// onto one Store.Get + factory(...) compile. The closure return
-	// value is the *cachedPolicy we then cache locally; the
-	// follower goroutines all observe the same value via singleflight.
+	// value is the cachedPolicy we then cache locally; the follower
+	// goroutines all observe the same value via singleflight.
 	v, err, _ := r.flight.Do(namespace, func() (any, error) {
 		// Re-check the cache inside the singleflight: another
 		// goroutine may have populated it between our first miss
@@ -291,8 +298,6 @@ func (r *Registry) resolveRepo(namespace, owningRepo string) (string, error) {
 	if cleaned != owningRepo {
 		return "", fmt.Errorf("%w: owning repo %q is not in canonical form (clean: %q)", ErrInvalidOwningRepo, owningRepo, cleaned)
 	}
-	// path.Clean turns "" → "." but we already returned for empty;
-	// any "." or ".." here is a real escape attempt.
 	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") || strings.Contains(cleaned, "/../") || strings.HasSuffix(cleaned, "/..") {
 		return "", fmt.Errorf("%w: owning repo %q escapes namespace", ErrInvalidOwningRepo, owningRepo)
 	}
@@ -308,153 +313,155 @@ func (r *Registry) packageIndexRepo(namespace string) string {
 	return path.Join(namespace, r.indexSuffix)
 }
 
-// requireFile centralises the nil-pointer + namespace-required
-// guards so each public method is one line shorter.
-func requireFile(f *oci.RepoFile) error {
-	if f == nil {
-		return errors.New("RepoFile must not be nil")
-	}
-	if f.Namespace == "" {
-		return errors.New("RepoFile.Namespace must not be empty")
-	}
-	return nil
+// ScopedRegistry is a per-namespace view of a [Registry]. Every
+// method authorizes the bound namespace, prefixes OwningRepo (or the
+// raw repo string for ListTags/ListFiles/etc.) with it, and forwards
+// to the underlying OCI backend.
+//
+// The struct is intentionally cheap to construct — it carries a
+// pointer to the parent and a string. Handlers obtain one per
+// request via [Registry.For] and discard it when the request
+// finishes.
+//
+// *ScopedRegistry implements the existing [pkg/handler.Registry]
+// interface so handler code that previously held a *pkg/oci.Registry
+// can swap to a *ScopedRegistry with no signature changes.
+type ScopedRegistry struct {
+	parent    *Registry
+	namespace string
 }
 
-// AddFile authorizes f.Namespace for write, prefixes f.OwningRepo
-// with the namespace, forwards to the inner registry, and (best-
-// effort) records the owning-repo in the namespace's package index
-// so [ListPackages] can enumerate it later.
-func (r *Registry) AddFile(ctx context.Context, f *oci.RepoFile, body io.Reader) (*oci.FileDescriptor, error) {
-	if err := requireFile(f); err != nil {
+// Namespace returns the bound namespace name.
+func (s *ScopedRegistry) Namespace() string { return s.namespace }
+
+// AddFile authorizes the bound namespace for write, prefixes
+// f.OwningRepo with the namespace, forwards to the inner registry,
+// and (best-effort) records the owning-repo in the namespace's
+// package index.
+func (s *ScopedRegistry) AddFile(ctx context.Context, f *oci.RepoFile, body io.Reader) (*oci.FileDescriptor, error) {
+	if f == nil {
+		return nil, errors.New("RepoFile must not be nil")
+	}
+	if err := s.parent.authorize(ctx, s.namespace, auth.OpWrite); err != nil {
 		return nil, err
 	}
-	if err := r.authorize(ctx, f.Namespace, auth.OpWrite); err != nil {
-		return nil, err
-	}
-	scoped, err := r.scopedFile(f)
+	scoped, err := s.parent.scopedFile(s.namespace, f)
 	if err != nil {
 		return nil, err
 	}
-	desc, err := r.inner.AddFile(ctx, scoped, body)
+	desc, err := s.parent.inner.AddFile(ctx, scoped, body)
 	if err != nil {
 		return nil, err
 	}
-	r.recordPackage(ctx, f.Namespace, f.OwningRepo)
+	s.parent.recordPackage(ctx, s.namespace, f.OwningRepo)
 	return desc, nil
 }
 
-// ReadFile authorizes f.Namespace for read and forwards to the inner
-// registry with OwningRepo prefixed.
-func (r *Registry) ReadFile(ctx context.Context, f *oci.RepoFile) (*oci.FileDescriptor, io.ReadCloser, error) {
-	if err := requireFile(f); err != nil {
+// ReadFile authorizes the bound namespace for read and forwards to
+// the inner registry with OwningRepo prefixed.
+func (s *ScopedRegistry) ReadFile(ctx context.Context, f *oci.RepoFile) (*oci.FileDescriptor, io.ReadCloser, error) {
+	if f == nil {
+		return nil, nil, errors.New("RepoFile must not be nil")
+	}
+	if err := s.parent.authorize(ctx, s.namespace, auth.OpRead); err != nil {
 		return nil, nil, err
 	}
-	if err := r.authorize(ctx, f.Namespace, auth.OpRead); err != nil {
-		return nil, nil, err
-	}
-	scoped, err := r.scopedFile(f)
+	scoped, err := s.parent.scopedFile(s.namespace, f)
 	if err != nil {
 		return nil, nil, err
 	}
-	return r.inner.ReadFile(ctx, scoped)
+	return s.parent.inner.ReadFile(ctx, scoped)
 }
 
-// BlobRedirectURL authorizes f.Namespace for read and forwards to
-// the inner registry with OwningRepo prefixed. Returns ("", nil)
-// when the backend serves blobs inline, mirroring [oci.Registry].
-func (r *Registry) BlobRedirectURL(ctx context.Context, f *oci.RepoFile) (string, error) {
-	if err := requireFile(f); err != nil {
+// BlobRedirectURL authorizes the bound namespace for read and
+// forwards to the inner registry with OwningRepo prefixed. Returns
+// ("", nil) when the backend serves blobs inline, mirroring
+// [oci.Registry].
+func (s *ScopedRegistry) BlobRedirectURL(ctx context.Context, f *oci.RepoFile) (string, error) {
+	if f == nil {
+		return "", errors.New("RepoFile must not be nil")
+	}
+	if err := s.parent.authorize(ctx, s.namespace, auth.OpRead); err != nil {
 		return "", err
 	}
-	if err := r.authorize(ctx, f.Namespace, auth.OpRead); err != nil {
-		return "", err
-	}
-	scoped, err := r.scopedFile(f)
+	scoped, err := s.parent.scopedFile(s.namespace, f)
 	if err != nil {
 		return "", err
 	}
-	return r.inner.BlobRedirectURL(ctx, scoped)
+	return s.parent.inner.BlobRedirectURL(ctx, scoped)
 }
 
-// ListTags authorizes f.Namespace for read and returns the canonical
-// tags for f.OwningRepo within the namespace. f need only carry
-// Namespace and OwningRepo; other fields are ignored.
-func (r *Registry) ListTags(ctx context.Context, f *oci.RepoFile) ([]string, error) {
-	if err := requireFile(f); err != nil {
+// ListTags authorizes the bound namespace for read and returns the
+// canonical tags for repo within the namespace.
+func (s *ScopedRegistry) ListTags(ctx context.Context, repo string) ([]string, error) {
+	if err := s.parent.authorize(ctx, s.namespace, auth.OpRead); err != nil {
 		return nil, err
 	}
-	if err := r.authorize(ctx, f.Namespace, auth.OpRead); err != nil {
-		return nil, err
-	}
-	scoped, err := r.resolveRepo(f.Namespace, f.OwningRepo)
+	scoped, err := s.parent.resolveRepo(s.namespace, repo)
 	if err != nil {
 		return nil, err
 	}
-	return r.inner.ListTags(ctx, scoped)
+	return s.parent.inner.ListTags(ctx, scoped)
 }
 
-// ListFiles authorizes f.Namespace for read and returns every file
-// across every canonical version of f.OwningRepo within the
+// ListFiles authorizes the bound namespace for read and returns
+// every file across every canonical version of repo within the
 // namespace. The OwningRepo on each returned [oci.RepoFile] is
-// rewritten back to the namespace-relative form and the Namespace
-// field is set, so callers don't see the raw backend prefix leak
-// through. Returned slices and pointers are freshly allocated by the
-// inner registry; the wrapper makes a defensive copy of each
-// element before mutating to keep any future inner-side caching
-// safe.
-func (r *Registry) ListFiles(ctx context.Context, f *oci.RepoFile) ([]*oci.RepoFile, error) {
-	if err := requireFile(f); err != nil {
+// rewritten back to the namespace-relative form so callers don't see
+// the raw backend prefix leak through. Each returned *RepoFile is
+// freshly allocated by the wrapper so a future inner-side cache of
+// descriptors stays safe.
+func (s *ScopedRegistry) ListFiles(ctx context.Context, repo string) ([]*oci.RepoFile, error) {
+	if err := s.parent.authorize(ctx, s.namespace, auth.OpRead); err != nil {
 		return nil, err
 	}
-	if err := r.authorize(ctx, f.Namespace, auth.OpRead); err != nil {
-		return nil, err
-	}
-	scoped, err := r.resolveRepo(f.Namespace, f.OwningRepo)
+	scoped, err := s.parent.resolveRepo(s.namespace, repo)
 	if err != nil {
 		return nil, err
 	}
-	files, err := r.inner.ListFiles(ctx, scoped)
+	files, err := s.parent.inner.ListFiles(ctx, scoped)
 	if err != nil {
 		return nil, err
 	}
 	out := make([]*oci.RepoFile, len(files))
 	for i, src := range files {
 		copyF := *src
-		copyF.Namespace = f.Namespace
-		copyF.OwningRepo = stripPrefix(copyF.OwningRepo, f.Namespace)
+		copyF.OwningRepo = stripPrefix(copyF.OwningRepo, s.namespace)
 		out[i] = &copyF
 	}
 	return out, nil
 }
 
-// ListPackages authorizes namespace for read and returns every
-// owning-repo the wrapper has recorded a write for in the namespace's
-// package index. Tags are decoded back to their original "/"-form.
+// ListPackages authorizes the bound namespace for read and returns
+// every owning-repo the wrapper has recorded a write for in the
+// namespace's package index. Tags are decoded back to their original
+// "/"-form.
 //
 // An absent index repo is reported as an empty list — a namespace
 // that has never been written to legitimately has no packages.
-func (r *Registry) ListPackages(ctx context.Context, namespace string) ([]string, error) {
-	if err := r.authorize(ctx, namespace, auth.OpRead); err != nil {
+func (s *ScopedRegistry) ListPackages(ctx context.Context) ([]string, error) {
+	if err := s.parent.authorize(ctx, s.namespace, auth.OpRead); err != nil {
 		return nil, err
 	}
-	tags, err := r.inner.ListTags(ctx, r.packageIndexRepo(namespace))
+	tags, err := s.parent.inner.ListTags(ctx, s.parent.packageIndexRepo(s.namespace))
 	if err != nil {
 		if errors.Is(err, errdef.ErrNotFound) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("list package index for %q: %w", namespace, err)
+		return nil, fmt.Errorf("list package index for %q: %w", s.namespace, err)
 	}
 	out := make([]string, 0, len(tags))
 	for _, t := range tags {
 		decoded, derr := decodeTag(t)
 		if derr != nil {
-			// A tag that doesn't decode means an admin or a previous
-			// ocifactory version wrote a non-encoded tag. Skip it
-			// rather than failing the whole listing — the contract
-			// is "best-effort enumeration" and a stray tag is no
-			// reason to deny callers their other packages.
+			// A tag that doesn't decode means an admin or a
+			// previous ocifactory version wrote a non-encoded tag.
+			// Skip it rather than failing the whole listing — the
+			// contract is "best-effort enumeration" and a stray
+			// tag is no reason to deny callers their other
+			// packages.
 			logging.FromContext(ctx).WarnContext(ctx, "namespace package index: skipping undecodable tag",
-				"namespace", namespace, "tag", t, "error", derr,
+				"namespace", s.namespace, "tag", t, "error", derr,
 			)
 			continue
 		}
@@ -463,73 +470,63 @@ func (r *Registry) ListPackages(ctx context.Context, namespace string) ([]string
 	return out, nil
 }
 
-// AppendRefs authorizes f.Namespace for write and forwards to the
-// inner registry with OwningRepo prefixed. f need only carry
-// Namespace, OwningRepo, and OwningTag (treated as the canonical
-// tag); other fields are ignored.
-func (r *Registry) AppendRefs(ctx context.Context, f *oci.RepoFile, refs ...string) error {
-	if err := requireFile(f); err != nil {
+// AppendRefs authorizes the bound namespace for write and forwards
+// to the inner registry with repo prefixed.
+func (s *ScopedRegistry) AppendRefs(ctx context.Context, repo string, canonicalTag string, refs ...string) error {
+	if err := s.parent.authorize(ctx, s.namespace, auth.OpWrite); err != nil {
 		return err
 	}
-	if f.OwningTag == "" {
-		return errors.New("RepoFile.OwningTag must be set for AppendRefs")
+	if canonicalTag == "" {
+		return errors.New("canonicalTag must not be empty")
 	}
-	if err := r.authorize(ctx, f.Namespace, auth.OpWrite); err != nil {
-		return err
-	}
-	scoped, err := r.resolveRepo(f.Namespace, f.OwningRepo)
+	scoped, err := s.parent.resolveRepo(s.namespace, repo)
 	if err != nil {
 		return err
 	}
-	return r.inner.AppendRefs(ctx, scoped, f.OwningTag, refs...)
+	return s.parent.inner.AppendRefs(ctx, scoped, canonicalTag, refs...)
 }
 
-// DeleteRepoFiles authorizes f.Namespace for write and forwards to
-// the inner registry with OwningRepo prefixed. The package index
-// entry for f.OwningRepo is cleared after the inner delete succeeds
-// — both the in-process indexed marker AND the backend index tag —
-// so [ListPackages] no longer reports the now-empty repo. Index
-// cleanup failures are logged at WARN and do not fail the call.
-func (r *Registry) DeleteRepoFiles(ctx context.Context, f *oci.RepoFile) error {
-	if err := requireFile(f); err != nil {
+// DeleteRepoFiles authorizes the bound namespace for write and
+// forwards to the inner registry with repo prefixed. The package
+// index entry for repo is cleared after the inner delete succeeds —
+// both the in-process indexed marker AND the backend index tag — so
+// [ListPackages] no longer reports the now-empty repo. Index cleanup
+// failures are logged at WARN and do not fail the call.
+func (s *ScopedRegistry) DeleteRepoFiles(ctx context.Context, repo string) error {
+	if err := s.parent.authorize(ctx, s.namespace, auth.OpWrite); err != nil {
 		return err
 	}
-	if err := r.authorize(ctx, f.Namespace, auth.OpWrite); err != nil {
-		return err
-	}
-	scoped, err := r.resolveRepo(f.Namespace, f.OwningRepo)
+	scoped, err := s.parent.resolveRepo(s.namespace, repo)
 	if err != nil {
 		return err
 	}
-	if err := r.inner.DeleteRepoFiles(ctx, scoped); err != nil {
+	if err := s.parent.inner.DeleteRepoFiles(ctx, scoped); err != nil {
 		return err
 	}
-	r.indexed.Remove(indexedKey(f.Namespace, f.OwningRepo))
-	encoded, encErr := encodeTag(f.OwningRepo)
+	s.parent.indexed.Remove(indexedKey(s.namespace, repo))
+	encoded, encErr := encodeTag(repo)
 	if encErr != nil {
-		// The owning-repo passed authorize() and resolveRepo() so
-		// this should never fail; treat as bug-not-vuln and log.
+		// The repo passed authorize() and resolveRepo() so this
+		// should never fail; treat as bug-not-vuln and log.
 		logging.FromContext(ctx).WarnContext(ctx, "namespace package index: encode failed on delete",
-			"namespace", f.Namespace, "owning_repo", f.OwningRepo, "error", encErr,
+			"namespace", s.namespace, "owning_repo", repo, "error", encErr,
 		)
 		return nil
 	}
-	if err := r.inner.DeleteTagFiles(ctx, r.packageIndexRepo(f.Namespace), encoded); err != nil && !errors.Is(err, errdef.ErrNotFound) {
+	if err := s.parent.inner.DeleteTagFiles(ctx, s.parent.packageIndexRepo(s.namespace), encoded); err != nil && !errors.Is(err, errdef.ErrNotFound) {
 		logging.FromContext(ctx).WarnContext(ctx, "namespace package index sweep failed",
-			"namespace", f.Namespace, "owning_repo", f.OwningRepo, "error", err,
+			"namespace", s.namespace, "owning_repo", repo, "error", err,
 		)
 	}
 	return nil
 }
 
 // scopedFile returns a copy of f with OwningRepo rewritten to the
-// namespace-prefixed backend form and Namespace cleared (the inner
-// OCI registry doesn't know about namespaces). Returns
-// [ErrInvalidOwningRepo] when the input would escape the namespace.
-func (r *Registry) scopedFile(f *oci.RepoFile) (*oci.RepoFile, error) {
+// namespace-prefixed backend form. Returns [ErrInvalidOwningRepo]
+// when the input would escape the namespace.
+func (r *Registry) scopedFile(namespace string, f *oci.RepoFile) (*oci.RepoFile, error) {
 	scoped := *f
-	scoped.Namespace = ""
-	resolved, err := r.resolveRepo(f.Namespace, f.OwningRepo)
+	resolved, err := r.resolveRepo(namespace, f.OwningRepo)
 	if err != nil {
 		return nil, err
 	}
@@ -549,8 +546,7 @@ func (r *Registry) scopedFile(f *oci.RepoFile) (*oci.RepoFile, error) {
 // deleting while another goroutine still references the same
 // *sync.Mutex would let an arriving third goroutine LoadOrStore a
 // fresh mutex for the same key, "guarding" with two unrelated
-// mutexes. The map is bounded by the indexed-LRU's eviction (entries
-// never used again age out as the LRU evicts).
+// mutexes. The map is bounded by the indexed-LRU's eviction.
 func (r *Registry) recordPackage(ctx context.Context, namespace, owningRepo string) {
 	if owningRepo == "" {
 		return
@@ -568,11 +564,7 @@ func (r *Registry) recordPackage(ctx context.Context, namespace, owningRepo stri
 	// Re-check after acquiring the lock: an earlier holder may have
 	// just populated the indexed-set, in which case our backend write
 	// is wasted work the LRU re-check catches here. This re-check is
-	// the load-bearing dedupe — without it, a later concurrent
-	// arriver under a different mutex (impossible today thanks to
-	// the no-delete invariant on indexLocks, but enforced by belt-
-	// and-braces here) would race a redundant AddFile to the
-	// backend.
+	// the load-bearing dedupe.
 	if _, ok := r.indexed.Get(key); ok {
 		return
 	}

--- a/pkg/namespace/registry_test.go
+++ b/pkg/namespace/registry_test.go
@@ -15,9 +15,16 @@ import (
 	"oras.land/oras-go/v2/errdef"
 
 	"github.com/yolocs/ocifactory/pkg/auth"
+	"github.com/yolocs/ocifactory/pkg/handler"
 	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
 )
+
+// Compile-time assertion: *ScopedRegistry satisfies handler.Registry
+// so existing python/maven handlers can swap a *pkg/oci.Registry for
+// a *ScopedRegistry without any signature changes. Lives in the
+// _test package to avoid pkg/namespace importing pkg/handler.
+var _ handler.Registry = (*namespace.ScopedRegistry)(nil)
 
 const (
 	googleIss   = "https://accounts.google.com"
@@ -29,9 +36,9 @@ const (
 	defaultBody = "hello world"
 )
 
-// allowAllSpec is a Spec whose policy admits any oidc subject for both
-// read and write. Tests that aren't exercising authz mechanics use it
-// to keep noise out of the assertions.
+// allowAllSpec is a Spec whose policy admits any oidc subject for
+// both read and write. Tests that aren't exercising authz mechanics
+// use it to keep noise out of the assertions.
 func allowAllSpec() namespace.Spec {
 	return namespace.Spec{
 		Policy: namespace.Policy{
@@ -69,13 +76,9 @@ func putNamespace(t *testing.T, store *namespace.Store, name string, spec namesp
 	}
 }
 
-// nsRepoFile builds a RepoFile with Namespace populated. Tests use
-// this consistently so a future change to the file struct doesn't
-// require a global sed.
-func nsRepoFile(ns, repo, tag, name string) *oci.RepoFile {
+func newRepoFile(repo, tag, name string) *oci.RepoFile {
 	body := []byte(defaultBody)
 	return &oci.RepoFile{
-		Namespace:  ns,
 		OwningRepo: repo,
 		OwningTag:  tag,
 		Name:       name,
@@ -84,15 +87,20 @@ func nsRepoFile(ns, repo, tag, name string) *oci.RepoFile {
 	}
 }
 
-func TestRegistry_AddRead_HappyPath(t *testing.T) {
+func TestScopedRegistry_AddRead_HappyPath(t *testing.T) {
 	t.Parallel()
 
 	fake, reg, store := setup(t)
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
+	scoped := reg.For("alpha")
+
+	if scoped.Namespace() != "alpha" {
+		t.Errorf("Namespace() = %q, want %q", scoped.Namespace(), "alpha")
+	}
 
 	body := strings.NewReader(defaultBody)
-	if _, err := reg.AddFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "foo.txt"), body); err != nil {
+	if _, err := scoped.AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"), body); err != nil {
 		t.Fatalf("AddFile: %v", err)
 	}
 
@@ -101,7 +109,7 @@ func TestRegistry_AddRead_HappyPath(t *testing.T) {
 			repoFoo, slicesSortedKeys(fake.Files))
 	}
 
-	_, rc, err := reg.ReadFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "foo.txt"))
+	_, rc, err := scoped.ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"))
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
 	}
@@ -115,12 +123,12 @@ func TestRegistry_AddRead_HappyPath(t *testing.T) {
 	}
 }
 
-// TestRegistry_NamespaceIsolation pins the load-bearing security
-// guarantee: namespace beta cannot read a file written through
-// namespace alpha, AND alpha can still read its own file (so a
-// regression that 5xx'd on every read wouldn't pass for the wrong
-// reason).
-func TestRegistry_NamespaceIsolation(t *testing.T) {
+// TestScopedRegistry_NamespaceIsolation pins the load-bearing
+// security guarantee: the beta scoped view cannot read a file
+// written through the alpha scoped view, AND alpha can still read
+// its own file (so a regression that 5xx'd on every read wouldn't
+// pass for the wrong reason).
+func TestScopedRegistry_NamespaceIsolation(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
@@ -128,20 +136,20 @@ func TestRegistry_NamespaceIsolation(t *testing.T) {
 	putNamespace(t, store, "beta", allowAllSpec())
 	ctx := aliceCtx(t)
 
-	if _, err := reg.AddFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "foo.txt"), strings.NewReader(defaultBody)); err != nil {
+	if _, err := reg.For("alpha").AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"), strings.NewReader(defaultBody)); err != nil {
 		t.Fatalf("AddFile alpha: %v", err)
 	}
 
-	// Alpha must still see its own file (rules out a generic-error regression).
-	if _, rc, err := reg.ReadFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "foo.txt")); err != nil {
+	// Alpha must still see its own file (rules out a generic-error
+	// regression).
+	if _, rc, err := reg.For("alpha").ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt")); err != nil {
 		t.Errorf("ReadFile alpha (own file): %v, want success", err)
 	} else {
 		rc.Close()
 	}
 
-	// Beta must not — and the failure mode must be ErrNotFound, not
-	// some generic 5xx.
-	_, _, err := reg.ReadFile(ctx, nsRepoFile("beta", repoFoo, "1.0.0", "foo.txt"))
+	// Beta must not — and the failure mode must be ErrNotFound.
+	_, _, err := reg.For("beta").ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"))
 	if err == nil {
 		t.Fatal("ReadFile beta = nil, want not-found error (namespaces must isolate)")
 	}
@@ -150,11 +158,10 @@ func TestRegistry_NamespaceIsolation(t *testing.T) {
 	}
 }
 
-// TestRegistry_NamespaceEscape is the explicit anti-vuln test: a
-// caller authorised for alpha cannot reach beta by passing
-// OwningRepo="../beta/foo" etc. The wrapper rejects with
-// ErrInvalidOwningRepo BEFORE any backend call.
-func TestRegistry_NamespaceEscape(t *testing.T) {
+// TestScopedRegistry_NamespaceEscape is the explicit anti-vuln
+// test: the alpha scoped view cannot reach beta by passing
+// OwningRepo="../beta/foo" etc.
+func TestScopedRegistry_NamespaceEscape(t *testing.T) {
 	t.Parallel()
 
 	fake, reg, store := setup(t)
@@ -184,7 +191,7 @@ func TestRegistry_NamespaceEscape(t *testing.T) {
 	for _, esc := range escapes {
 		t.Run("escape="+esc, func(t *testing.T) {
 			t.Parallel()
-			_, _, err := reg.ReadFile(ctx, nsRepoFile("alpha", esc, "1.0.0", "secret.txt"))
+			_, _, err := reg.For("alpha").ReadFile(ctx, newRepoFile(esc, "1.0.0", "secret.txt"))
 			if err == nil {
 				t.Fatalf("ReadFile owningRepo=%q = nil, want ErrInvalidOwningRepo (namespace escape!)", esc)
 			}
@@ -195,11 +202,12 @@ func TestRegistry_NamespaceEscape(t *testing.T) {
 	}
 }
 
-func TestRegistry_NamespaceNotFound(t *testing.T) {
+func TestScopedRegistry_NamespaceNotFound(t *testing.T) {
 	t.Parallel()
 
 	_, reg, _ := setup(t)
 	ctx := aliceCtx(t)
+	scoped := reg.For("ghost")
 
 	tests := []struct {
 		name string
@@ -208,55 +216,55 @@ func TestRegistry_NamespaceNotFound(t *testing.T) {
 		{
 			name: "AddFile",
 			call: func() error {
-				_, err := reg.AddFile(ctx, nsRepoFile("ghost", repoFoo, "1.0.0", "foo.txt"), strings.NewReader(defaultBody))
+				_, err := scoped.AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"), strings.NewReader(defaultBody))
 				return err
 			},
 		},
 		{
 			name: "ReadFile",
 			call: func() error {
-				_, _, err := reg.ReadFile(ctx, nsRepoFile("ghost", repoFoo, "1.0.0", "foo.txt"))
+				_, _, err := scoped.ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"))
 				return err
 			},
 		},
 		{
 			name: "BlobRedirectURL",
 			call: func() error {
-				_, err := reg.BlobRedirectURL(ctx, nsRepoFile("ghost", repoFoo, "1.0.0", "foo.txt"))
+				_, err := scoped.BlobRedirectURL(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"))
 				return err
 			},
 		},
 		{
 			name: "ListTags",
 			call: func() error {
-				_, err := reg.ListTags(ctx, nsRepoFile("ghost", repoFoo, "", ""))
+				_, err := scoped.ListTags(ctx, repoFoo)
 				return err
 			},
 		},
 		{
 			name: "ListFiles",
 			call: func() error {
-				_, err := reg.ListFiles(ctx, nsRepoFile("ghost", repoFoo, "", ""))
+				_, err := scoped.ListFiles(ctx, repoFoo)
 				return err
 			},
 		},
 		{
 			name: "ListPackages",
 			call: func() error {
-				_, err := reg.ListPackages(ctx, "ghost")
+				_, err := scoped.ListPackages(ctx)
 				return err
 			},
 		},
 		{
 			name: "AppendRefs",
 			call: func() error {
-				return reg.AppendRefs(ctx, nsRepoFile("ghost", repoFoo, "1.0.0", ""), "latest")
+				return scoped.AppendRefs(ctx, repoFoo, "1.0.0", "latest")
 			},
 		},
 		{
 			name: "DeleteRepoFiles",
 			call: func() error {
-				return reg.DeleteRepoFiles(ctx, nsRepoFile("ghost", repoFoo, "", ""))
+				return scoped.DeleteRepoFiles(ctx, repoFoo)
 			},
 		},
 	}
@@ -275,46 +283,26 @@ func TestRegistry_NamespaceNotFound(t *testing.T) {
 	}
 }
 
-func TestRegistry_NilFile(t *testing.T) {
+func TestScopedRegistry_NilFile(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
+	scoped := reg.For("alpha")
 
-	if _, err := reg.AddFile(ctx, nil, strings.NewReader("")); err == nil {
+	if _, err := scoped.AddFile(ctx, nil, strings.NewReader("")); err == nil {
 		t.Error("AddFile(nil) = nil, want error")
 	}
-	if _, _, err := reg.ReadFile(ctx, nil); err == nil {
+	if _, _, err := scoped.ReadFile(ctx, nil); err == nil {
 		t.Error("ReadFile(nil) = nil, want error")
 	}
-	if _, err := reg.BlobRedirectURL(ctx, nil); err == nil {
+	if _, err := scoped.BlobRedirectURL(ctx, nil); err == nil {
 		t.Error("BlobRedirectURL(nil) = nil, want error")
 	}
 }
 
-func TestRegistry_EmptyNamespace(t *testing.T) {
-	t.Parallel()
-
-	_, reg, store := setup(t)
-	putNamespace(t, store, "alpha", allowAllSpec())
-	ctx := aliceCtx(t)
-
-	// Empty Namespace on the file — the wrapper must refuse before
-	// authz; otherwise an empty namespace would resolve to a "" auth
-	// lookup which could behave unpredictably depending on the
-	// authorizer plugin.
-	bad := &oci.RepoFile{
-		OwningRepo: repoFoo,
-		OwningTag:  "1.0.0",
-		Name:       "foo.txt",
-	}
-	if _, err := reg.AddFile(ctx, bad, strings.NewReader("")); err == nil {
-		t.Error("AddFile(empty Namespace) = nil, want error")
-	}
-}
-
-func TestRegistry_Authz(t *testing.T) {
+func TestScopedRegistry_Authz(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -334,8 +322,6 @@ func TestRegistry_Authz(t *testing.T) {
 		{
 			name: "read-denied-empty-readers",
 			spec: namespace.Spec{Policy: namespace.Policy{
-				// Readers list is nil — empty list is the explicit
-				// "no one can read" case the issue test plan calls out.
 				Writers: []namespace.SubjectMatcher{{Email: aliceEmail}},
 			}},
 			ac:        &auth.AuthContext{Issuer: googleIss, ID: aliceID, Email: aliceEmail},
@@ -392,21 +378,19 @@ func TestRegistry_Authz(t *testing.T) {
 			fake, reg, store := setup(t)
 			putNamespace(t, store, "alpha", tc.spec)
 
-			// Seed the file directly through the fake so the read
-			// path always has something to find: any error must come
-			// from authz, not file-not-found.
 			if tc.op == auth.OpRead {
 				seedDirect(t, fake, "alpha")
 			}
 
 			ctx := auth.WithAuthContext(t.Context(), tc.ac)
+			scoped := reg.For("alpha")
 
 			var got error
 			switch tc.op {
 			case auth.OpWrite:
-				_, got = reg.AddFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "foo.txt"), strings.NewReader(defaultBody))
+				_, got = scoped.AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"), strings.NewReader(defaultBody))
 			case auth.OpRead:
-				_, _, got = reg.ReadFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "foo.txt"))
+				_, _, got = scoped.ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"))
 			}
 
 			if tc.wantAllow {
@@ -425,9 +409,6 @@ func TestRegistry_Authz(t *testing.T) {
 	}
 }
 
-// seedDirect plants a file under namespace ns via the fake directly,
-// bypassing the wrapper's authz so read tests can isolate the deny
-// paths from "file not found" noise.
 func seedDirect(t *testing.T, fake *oci.FakeRegistry, ns string) {
 	t.Helper()
 	rf := &oci.RepoFile{
@@ -442,17 +423,13 @@ func seedDirect(t *testing.T, fake *oci.FakeRegistry, ns string) {
 	}
 }
 
-func TestRegistry_NoAuthContextDenied(t *testing.T) {
+func TestScopedRegistry_NoAuthContextDenied(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
 	putNamespace(t, store, "alpha", allowAllSpec())
 
-	// Defense in depth: the wrapper itself rejects nil AuthContext,
-	// not just the plugin authorizer. A faulty third-party
-	// AuthzFactory that forgets the nil check must not turn into an
-	// auth bypass.
-	_, _, err := reg.ReadFile(t.Context(), nsRepoFile("alpha", repoFoo, "1.0.0", "foo.txt"))
+	_, _, err := reg.For("alpha").ReadFile(t.Context(), newRepoFile(repoFoo, "1.0.0", "foo.txt"))
 	if err == nil {
 		t.Fatal("ReadFile with no AuthContext = nil, want error wrapping auth.ErrUnauthorized")
 	}
@@ -461,32 +438,30 @@ func TestRegistry_NoAuthContextDenied(t *testing.T) {
 	}
 }
 
-// TestRegistry_NoAuthContextDeniedAtWrapper proves the wrapper
+// TestScopedRegistry_NoAuthContextDeniedAtWrapper proves the wrapper
 // itself denies nil even when the AuthzFactory would have allowed.
-func TestRegistry_NoAuthContextDeniedAtWrapper(t *testing.T) {
+func TestScopedRegistry_NoAuthContextDeniedAtWrapper(t *testing.T) {
 	t.Parallel()
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	// Use AllowAll authorizer — if the wrapper delegated nil-handling
-	// to the authorizer, this test would falsely pass.
 	reg := namespace.NewRegistry(fake, store,
 		namespace.WithAuthzFactory(func(_ namespace.Policy) (auth.Authorizer, error) { return auth.AllowAll, nil }),
 		namespace.WithPolicyCacheTTL(0),
 	)
 	putNamespace(t, store, "alpha", allowAllSpec())
 
-	_, _, err := reg.ReadFile(t.Context(), nsRepoFile("alpha", repoFoo, "1.0.0", "foo.txt"))
+	_, _, err := reg.For("alpha").ReadFile(t.Context(), newRepoFile(repoFoo, "1.0.0", "foo.txt"))
 	if !errors.Is(err, auth.ErrUnauthorized) {
 		t.Errorf("ReadFile (AllowAll factory + nil ctx) err = %v, want errors.Is(auth.ErrUnauthorized)", err)
 	}
 }
 
-// TestRegistry_PackageIndex_PopulatedExactlyOnce uses a counting
-// backend to prove the wrapper makes exactly one index-repo AddFile
-// call across N data writes to the same (ns, owning-repo). Without
-// the indexed-LRU dedupe, this would be N.
-func TestRegistry_PackageIndex_PopulatedExactlyOnce(t *testing.T) {
+// TestScopedRegistry_PackageIndex_PopulatedExactlyOnce uses a
+// counting backend to prove the wrapper makes exactly one
+// index-repo AddFile call across N data writes to the same
+// (ns, owning-repo).
+func TestScopedRegistry_PackageIndex_PopulatedExactlyOnce(t *testing.T) {
 	t.Parallel()
 
 	counted := newCountingBackend()
@@ -494,10 +469,11 @@ func TestRegistry_PackageIndex_PopulatedExactlyOnce(t *testing.T) {
 	reg := namespace.NewRegistry(counted, store, namespace.WithPolicyCacheTTL(0))
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
+	scoped := reg.For("alpha")
 
 	for i := 0; i < 5; i++ {
 		tag := fmt.Sprintf("1.0.%d", i)
-		if _, err := reg.AddFile(ctx, nsRepoFile("alpha", repoFoo, tag, "f.txt"), strings.NewReader(defaultBody)); err != nil {
+		if _, err := scoped.AddFile(ctx, newRepoFile(repoFoo, tag, "f.txt"), strings.NewReader(defaultBody)); err != nil {
 			t.Fatalf("AddFile %s: %v", tag, err)
 		}
 	}
@@ -507,20 +483,21 @@ func TestRegistry_PackageIndex_PopulatedExactlyOnce(t *testing.T) {
 	}
 }
 
-func TestRegistry_PackageIndex_MultipleRepos(t *testing.T) {
+func TestScopedRegistry_PackageIndex_MultipleRepos(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
+	scoped := reg.For("alpha")
 
 	for _, repo := range []string{repoFoo, repoBar, "tools/cli"} {
-		if _, err := reg.AddFile(ctx, nsRepoFile("alpha", repo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+		if _, err := scoped.AddFile(ctx, newRepoFile(repo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
 			t.Fatalf("AddFile %s: %v", repo, err)
 		}
 	}
 
-	got, err := reg.ListPackages(ctx, "alpha")
+	got, err := scoped.ListPackages(ctx)
 	if err != nil {
 		t.Fatalf("ListPackages: %v", err)
 	}
@@ -531,14 +508,10 @@ func TestRegistry_PackageIndex_MultipleRepos(t *testing.T) {
 	}
 }
 
-// TestRegistry_PackageIndex_ConcurrentExactlyOneAddFile is the
-// concurrency stress: N goroutines hammering the same (ns, owning-
-// repo) must result in exactly ONE index-repo AddFile call. Without
-// the per-key sync.Mutex + LRU re-check, every losing goroutine
-// would issue an idempotent AddFile that the fake swallows via
-// ErrAlreadyExists — invisible to the end-state assertion but
-// proportional in backend round-trips.
-func TestRegistry_PackageIndex_ConcurrentExactlyOneAddFile(t *testing.T) {
+// TestScopedRegistry_PackageIndex_ConcurrentExactlyOneAddFile is
+// the concurrency stress: N goroutines hammering the same
+// (ns, owning-repo) must result in exactly ONE index-repo AddFile.
+func TestScopedRegistry_PackageIndex_ConcurrentExactlyOneAddFile(t *testing.T) {
 	t.Parallel()
 
 	counted := newCountingBackend()
@@ -546,6 +519,7 @@ func TestRegistry_PackageIndex_ConcurrentExactlyOneAddFile(t *testing.T) {
 	reg := namespace.NewRegistry(counted, store, namespace.WithPolicyCacheTTL(0))
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
+	scoped := reg.For("alpha")
 
 	const n = 16
 	var wg sync.WaitGroup
@@ -555,7 +529,7 @@ func TestRegistry_PackageIndex_ConcurrentExactlyOneAddFile(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			tag := fmt.Sprintf("v%d", i)
-			if _, err := reg.AddFile(ctx, nsRepoFile("alpha", repoFoo, tag, "f.txt"), strings.NewReader(defaultBody)); err != nil {
+			if _, err := scoped.AddFile(ctx, newRepoFile(repoFoo, tag, "f.txt"), strings.NewReader(defaultBody)); err != nil {
 				errs <- err
 			}
 		}(i)
@@ -569,7 +543,7 @@ func TestRegistry_PackageIndex_ConcurrentExactlyOneAddFile(t *testing.T) {
 	if got := counted.indexAddCount("alpha"); got != 1 {
 		t.Errorf("index AddFile count = %d across %d concurrent writes, want 1", got, n)
 	}
-	pkgs, err := reg.ListPackages(ctx, "alpha")
+	pkgs, err := scoped.ListPackages(ctx)
 	if err != nil {
 		t.Fatalf("ListPackages: %v", err)
 	}
@@ -578,7 +552,7 @@ func TestRegistry_PackageIndex_ConcurrentExactlyOneAddFile(t *testing.T) {
 	}
 }
 
-func TestRegistry_PackageIndex_Isolated(t *testing.T) {
+func TestScopedRegistry_PackageIndex_Isolated(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
@@ -586,11 +560,11 @@ func TestRegistry_PackageIndex_Isolated(t *testing.T) {
 	putNamespace(t, store, "beta", allowAllSpec())
 	ctx := aliceCtx(t)
 
-	if _, err := reg.AddFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+	if _, err := reg.For("alpha").AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
 		t.Fatalf("AddFile alpha: %v", err)
 	}
 
-	betaPkgs, err := reg.ListPackages(ctx, "beta")
+	betaPkgs, err := reg.For("beta").ListPackages(ctx)
 	if err != nil {
 		t.Fatalf("ListPackages beta: %v", err)
 	}
@@ -599,31 +573,32 @@ func TestRegistry_PackageIndex_Isolated(t *testing.T) {
 	}
 }
 
-// TestRegistry_TagEncoding_RoundTrip pins the encoding properties
-// the security review flagged: collision-free between names that
-// differ only in '/' vs '_' (the old encoding silently merged them).
-func TestRegistry_TagEncoding_RoundTrip(t *testing.T) {
+// TestScopedRegistry_TagEncoding_RoundTrip pins the encoding
+// properties: collision-free between names that differ only in '/'
+// vs '_'.
+func TestScopedRegistry_TagEncoding_RoundTrip(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
+	scoped := reg.For("alpha")
 
 	repos := []string{
 		"packages/requests",
 		"com/example/foo-bar",
 		"toplevel",
-		"a__b",  // would collide with "a/b" under the old "/__" encoding
-		"a_b_c", // bare underscores must round-trip
+		"a__b",
+		"a_b_c",
 		"x.y.z",
 	}
 	for _, r := range repos {
-		if _, err := reg.AddFile(ctx, nsRepoFile("alpha", r, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+		if _, err := scoped.AddFile(ctx, newRepoFile(r, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
 			t.Fatalf("AddFile %s: %v", r, err)
 		}
 	}
 
-	got, err := reg.ListPackages(ctx, "alpha")
+	got, err := scoped.ListPackages(ctx)
 	if err != nil {
 		t.Fatalf("ListPackages: %v", err)
 	}
@@ -635,14 +610,14 @@ func TestRegistry_TagEncoding_RoundTrip(t *testing.T) {
 	}
 }
 
-func TestRegistry_ListPackages_EmptyOnUntouchedNamespace(t *testing.T) {
+func TestScopedRegistry_ListPackages_EmptyOnUntouchedNamespace(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
 
-	got, err := reg.ListPackages(ctx, "alpha")
+	got, err := reg.For("alpha").ListPackages(ctx)
 	if err != nil {
 		t.Fatalf("ListPackages: %v", err)
 	}
@@ -651,20 +626,21 @@ func TestRegistry_ListPackages_EmptyOnUntouchedNamespace(t *testing.T) {
 	}
 }
 
-func TestRegistry_ListTags_AndListFiles(t *testing.T) {
+func TestScopedRegistry_ListTags_AndListFiles(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
+	scoped := reg.For("alpha")
 
 	for _, tag := range []string{"1.0.0", "2.0.0"} {
-		if _, err := reg.AddFile(ctx, nsRepoFile("alpha", repoFoo, tag, "f.txt"), strings.NewReader(defaultBody)); err != nil {
+		if _, err := scoped.AddFile(ctx, newRepoFile(repoFoo, tag, "f.txt"), strings.NewReader(defaultBody)); err != nil {
 			t.Fatalf("AddFile %s: %v", tag, err)
 		}
 	}
 
-	tags, err := reg.ListTags(ctx, nsRepoFile("alpha", repoFoo, "", ""))
+	tags, err := scoped.ListTags(ctx, repoFoo)
 	if err != nil {
 		t.Fatalf("ListTags: %v", err)
 	}
@@ -673,7 +649,7 @@ func TestRegistry_ListTags_AndListFiles(t *testing.T) {
 		t.Errorf("ListTags mismatch (-want +got):\n%s", diff)
 	}
 
-	files, err := reg.ListFiles(ctx, nsRepoFile("alpha", repoFoo, "", ""))
+	files, err := scoped.ListFiles(ctx, repoFoo)
 	if err != nil {
 		t.Fatalf("ListFiles: %v", err)
 	}
@@ -681,29 +657,25 @@ func TestRegistry_ListTags_AndListFiles(t *testing.T) {
 		if f.OwningRepo != repoFoo {
 			t.Errorf("ListFiles OwningRepo = %q, want %q (namespace prefix must not leak)", f.OwningRepo, repoFoo)
 		}
-		if f.Namespace != "alpha" {
-			t.Errorf("ListFiles Namespace = %q, want %q", f.Namespace, "alpha")
-		}
 	}
 	if len(files) != 2 {
 		t.Errorf("ListFiles len = %d, want 2", len(files))
 	}
 }
 
-// TestRegistry_ListFiles_MultiSegmentRepo guards against a buggy
-// stripPrefix that would only chop the first path segment.
-func TestRegistry_ListFiles_MultiSegmentRepo(t *testing.T) {
+func TestScopedRegistry_ListFiles_MultiSegmentRepo(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
+	scoped := reg.For("alpha")
 
 	repo := "com/example/foo-bar"
-	if _, err := reg.AddFile(ctx, nsRepoFile("alpha", repo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+	if _, err := scoped.AddFile(ctx, newRepoFile(repo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
 		t.Fatalf("AddFile: %v", err)
 	}
-	files, err := reg.ListFiles(ctx, nsRepoFile("alpha", repo, "", ""))
+	files, err := scoped.ListFiles(ctx, repo)
 	if err != nil {
 		t.Fatalf("ListFiles: %v", err)
 	}
@@ -712,18 +684,15 @@ func TestRegistry_ListFiles_MultiSegmentRepo(t *testing.T) {
 	}
 }
 
-// TestRegistry_ListFiles_PrefixOfAnotherNamespace pins that "alpha"
-// doesn't accidentally strip from "alpha-foo" repos.
-func TestRegistry_ListFiles_PrefixOfAnotherNamespace(t *testing.T) {
+// TestScopedRegistry_ListFiles_PrefixOfAnotherNamespace pins that
+// "alpha" doesn't accidentally strip from "alpha-foo" repos.
+func TestScopedRegistry_ListFiles_PrefixOfAnotherNamespace(t *testing.T) {
 	t.Parallel()
 
 	fake, reg, store := setup(t)
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
 
-	// Plant a file under a backend repo that LOOKS LIKE it shares a
-	// prefix with "alpha" but is actually a sibling — exercising the
-	// trailing-slash check.
 	if _, err := fake.AddFile(ctx, &oci.RepoFile{
 		OwningRepo: "alpha/" + repoFoo,
 		OwningTag:  "1.0.0",
@@ -733,7 +702,7 @@ func TestRegistry_ListFiles_PrefixOfAnotherNamespace(t *testing.T) {
 		t.Fatalf("seed: %v", err)
 	}
 
-	files, err := reg.ListFiles(ctx, nsRepoFile("alpha", repoFoo, "", ""))
+	files, err := reg.For("alpha").ListFiles(ctx, repoFoo)
 	if err != nil {
 		t.Fatalf("ListFiles: %v", err)
 	}
@@ -742,17 +711,18 @@ func TestRegistry_ListFiles_PrefixOfAnotherNamespace(t *testing.T) {
 	}
 }
 
-func TestRegistry_AppendRefs_Forwards(t *testing.T) {
+func TestScopedRegistry_AppendRefs_Forwards(t *testing.T) {
 	t.Parallel()
 
 	fake, reg, store := setup(t)
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
+	scoped := reg.For("alpha")
 
-	if _, err := reg.AddFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+	if _, err := scoped.AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
 		t.Fatalf("AddFile: %v", err)
 	}
-	if err := reg.AppendRefs(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", ""), "latest"); err != nil {
+	if err := scoped.AppendRefs(ctx, repoFoo, "1.0.0", "latest"); err != nil {
 		t.Fatalf("AppendRefs: %v", err)
 	}
 	if got, ok := fake.Aliases["alpha/"+repoFoo+"/latest"]; !ok || got != "1.0.0" {
@@ -760,22 +730,21 @@ func TestRegistry_AppendRefs_Forwards(t *testing.T) {
 	}
 }
 
-// TestRegistry_DeleteRepoFiles_SweepsBackendIndex verifies BOTH the
-// in-process indexed marker AND the backend _packages tag are
-// cleared. Without the backend sweep, ListPackages would lie about
-// deleted repos until the namespace itself is purged.
-func TestRegistry_DeleteRepoFiles_SweepsBackendIndex(t *testing.T) {
+// TestScopedRegistry_DeleteRepoFiles_SweepsBackendIndex verifies
+// BOTH the in-process indexed marker AND the backend _packages tag
+// are cleared.
+func TestScopedRegistry_DeleteRepoFiles_SweepsBackendIndex(t *testing.T) {
 	t.Parallel()
 
 	fake, reg, store := setup(t)
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
+	scoped := reg.For("alpha")
 
-	if _, err := reg.AddFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+	if _, err := scoped.AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
 		t.Fatalf("AddFile: %v", err)
 	}
-	// Pre-flight: index has an entry.
-	pkgs, err := reg.ListPackages(ctx, "alpha")
+	pkgs, err := scoped.ListPackages(ctx)
 	if err != nil {
 		t.Fatalf("ListPackages pre: %v", err)
 	}
@@ -783,7 +752,7 @@ func TestRegistry_DeleteRepoFiles_SweepsBackendIndex(t *testing.T) {
 		t.Fatalf("ListPackages pre = %v, want to contain %q", pkgs, repoFoo)
 	}
 
-	if err := reg.DeleteRepoFiles(ctx, nsRepoFile("alpha", repoFoo, "", "")); err != nil {
+	if err := scoped.DeleteRepoFiles(ctx, repoFoo); err != nil {
 		t.Fatalf("DeleteRepoFiles: %v", err)
 	}
 	for k := range fake.Files {
@@ -791,9 +760,7 @@ func TestRegistry_DeleteRepoFiles_SweepsBackendIndex(t *testing.T) {
 			t.Errorf("file %q remained after DeleteRepoFiles", k)
 		}
 	}
-	// ListPackages must no longer report the deleted repo even
-	// without a re-add.
-	pkgs, err = reg.ListPackages(ctx, "alpha")
+	pkgs, err = scoped.ListPackages(ctx)
 	if err != nil {
 		t.Fatalf("ListPackages post: %v", err)
 	}
@@ -801,11 +768,10 @@ func TestRegistry_DeleteRepoFiles_SweepsBackendIndex(t *testing.T) {
 		t.Errorf("ListPackages post = %v, want NOT to contain %q (backend index must be swept)", pkgs, repoFoo)
 	}
 
-	// Re-AddFile must repopulate the package index.
-	if _, err := reg.AddFile(ctx, nsRepoFile("alpha", repoFoo, "2.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+	if _, err := scoped.AddFile(ctx, newRepoFile(repoFoo, "2.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
 		t.Fatalf("AddFile after delete: %v", err)
 	}
-	pkgs, err = reg.ListPackages(ctx, "alpha")
+	pkgs, err = scoped.ListPackages(ctx)
 	if err != nil {
 		t.Fatalf("ListPackages re-add: %v", err)
 	}
@@ -815,11 +781,9 @@ func TestRegistry_DeleteRepoFiles_SweepsBackendIndex(t *testing.T) {
 }
 
 // TestRegistry_PolicyCache_HotPathSkipsStore counts spec.json reads
-// the metadata Store performs and asserts the cache absorbs all but
-// the first lookup across N data-plane requests. The before-snapshot
-// is taken AFTER the seed write so the cache is known to be
-// populated; if the before count were 0 this test could pass
-// vacuously.
+// and asserts the cache absorbs all but the first lookup. The
+// before-snapshot is taken AFTER the seed so the cache is known to
+// be populated.
 func TestRegistry_PolicyCache_HotPathSkipsStore(t *testing.T) {
 	t.Parallel()
 
@@ -829,10 +793,9 @@ func TestRegistry_PolicyCache_HotPathSkipsStore(t *testing.T) {
 
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
+	scoped := reg.For("alpha")
 
-	// Seed AND ensure the cache is populated by issuing a single
-	// pre-call.
-	if _, err := reg.AddFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+	if _, err := scoped.AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
 		t.Fatalf("AddFile: %v", err)
 	}
 	priming := counted.specReads("alpha")
@@ -842,7 +805,7 @@ func TestRegistry_PolicyCache_HotPathSkipsStore(t *testing.T) {
 
 	const iters = 50
 	for i := 0; i < iters; i++ {
-		_, _, err := reg.ReadFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "f.txt"))
+		_, _, err := scoped.ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"))
 		if err != nil {
 			t.Fatalf("ReadFile %d: %v", i, err)
 		}
@@ -853,8 +816,6 @@ func TestRegistry_PolicyCache_HotPathSkipsStore(t *testing.T) {
 	}
 }
 
-// TestRegistry_PolicyCache_TTLZero_DisablesCache: with caching
-// disabled, every request must re-fetch the spec.
 func TestRegistry_PolicyCache_TTLZero_DisablesCache(t *testing.T) {
 	t.Parallel()
 
@@ -864,15 +825,16 @@ func TestRegistry_PolicyCache_TTLZero_DisablesCache(t *testing.T) {
 
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
+	scoped := reg.For("alpha")
 
-	if _, err := reg.AddFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+	if _, err := scoped.AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
 		t.Fatalf("AddFile: %v", err)
 	}
 
 	before := counted.specReads("alpha")
 	const iters = 5
 	for i := 0; i < iters; i++ {
-		_, _, err := reg.ReadFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "f.txt"))
+		_, _, err := scoped.ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"))
 		if err != nil {
 			t.Fatalf("ReadFile: %v", err)
 		}
@@ -884,9 +846,6 @@ func TestRegistry_PolicyCache_TTLZero_DisablesCache(t *testing.T) {
 	}
 }
 
-// TestRegistry_PolicyCache_NegativeCaching pins that ErrNotFound
-// from Store.Get is cached. A counterpart check after Invalidate
-// proves the cache was load-bearing.
 func TestRegistry_PolicyCache_NegativeCaching(t *testing.T) {
 	t.Parallel()
 
@@ -897,7 +856,7 @@ func TestRegistry_PolicyCache_NegativeCaching(t *testing.T) {
 
 	const iters = 10
 	for i := 0; i < iters; i++ {
-		_, _, err := reg.ReadFile(ctx, nsRepoFile("ghost", repoFoo, "1.0.0", "f.txt"))
+		_, _, err := reg.For("ghost").ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"))
 		if !errors.Is(err, namespace.ErrNotFound) {
 			t.Fatalf("ReadFile(ghost) %d err = %v, want errors.Is(ErrNotFound)", i, err)
 		}
@@ -906,9 +865,8 @@ func TestRegistry_PolicyCache_NegativeCaching(t *testing.T) {
 		t.Errorf("spec reads for missing namespace = %d after %d requests, want 1 (negative cache must absorb)", got, iters)
 	}
 
-	// Invalidate-then-call must repopulate (cache was load-bearing).
 	reg.InvalidatePolicy("ghost")
-	if _, _, err := reg.ReadFile(ctx, nsRepoFile("ghost", repoFoo, "1.0.0", "f.txt")); !errors.Is(err, namespace.ErrNotFound) {
+	if _, _, err := reg.For("ghost").ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt")); !errors.Is(err, namespace.ErrNotFound) {
 		t.Fatalf("post-invalidate ReadFile = %v, want errors.Is(ErrNotFound)", err)
 	}
 	if got := counted.specReads("ghost"); got != 2 {
@@ -925,22 +883,18 @@ func TestRegistry_StorePut_InvalidatesCache(t *testing.T) {
 	counted := newCountingBackend()
 	store := namespace.NewStore(counted)
 	reg := namespace.NewRegistry(counted, store, namespace.WithPolicyCacheTTL(time.Hour))
-	_ = reg
 	ctx := aliceCtx(t)
 
-	// First spec denies alice via Email mismatch.
 	putNamespace(t, store, "alpha", namespace.Spec{Policy: namespace.Policy{
 		Readers: []namespace.SubjectMatcher{{Email: otherEmail}},
 	}})
 	seedDirect(t, counted.FakeRegistry, "alpha")
-	if _, _, err := reg.ReadFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "foo.txt")); !errors.Is(err, auth.ErrUnauthorized) {
+	if _, _, err := reg.For("alpha").ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt")); !errors.Is(err, auth.ErrUnauthorized) {
 		t.Fatalf("pre-update ReadFile = %v, want errors.Is(auth.ErrUnauthorized)", err)
 	}
 
-	// Update spec to allow alice. Without the mutation hook the
-	// cached deny would survive for an hour and this would still 403.
 	putNamespace(t, store, "alpha", allowAllSpec())
-	if _, _, err := reg.ReadFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "foo.txt")); err != nil {
+	if _, _, err := reg.For("alpha").ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt")); err != nil {
 		t.Errorf("post-update ReadFile = %v, want success (Store.Put must invalidate cache)", err)
 	}
 }
@@ -955,12 +909,10 @@ func TestRegistry_PolicyCache_Singleflight(t *testing.T) {
 	reg := namespace.NewRegistry(counted, store, namespace.WithPolicyCacheTTL(time.Hour))
 	putNamespace(t, store, "alpha", allowAllSpec())
 	seedDirect(t, counted.FakeRegistry, "alpha")
-	// Reset the counter so the seed's Put doesn't pollute the
-	// assertion.
 	counted.resetSpecReads("alpha")
 	ctx := aliceCtx(t)
 
-	// Serialize the spec read so concurrent goroutines all queue up
+	// Block the spec read so concurrent goroutines all queue up
 	// behind a slow first miss — this is what makes singleflight
 	// observable.
 	counted.blockSpecRead = make(chan struct{})
@@ -972,12 +924,10 @@ func TestRegistry_PolicyCache_Singleflight(t *testing.T) {
 	for i := 0; i < n; i++ {
 		go func() {
 			defer wg.Done()
-			_, _, _ = reg.ReadFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "foo.txt"))
+			_, _, _ = reg.For("alpha").ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"))
 		}()
 	}
-	// Give all N goroutines a moment to enter the singleflight.
 	time.Sleep(50 * time.Millisecond)
-	// Release the spec read.
 	counted.blockSpecRead <- struct{}{}
 	wg.Wait()
 
@@ -988,15 +938,14 @@ func TestRegistry_PolicyCache_Singleflight(t *testing.T) {
 
 // countingBackend wraps an [oci.FakeRegistry] and counts how many
 // times the namespace metadata spec.json is read for each namespace,
-// and how many times the per-namespace _packages index repo receives
-// an AddFile. The two counters separate "metadata-store traffic"
-// from "package-index dedupe" assertions in the tests above.
+// and how many times the per-namespace _packages index repo
+// receives an AddFile.
 type countingBackend struct {
 	*oci.FakeRegistry
 	mu            sync.Mutex
 	specReads_    map[string]int
 	indexAdds_    map[string]int
-	blockSpecRead chan struct{} // when non-nil, ReadFile blocks waiting on a value
+	blockSpecRead chan struct{}
 }
 
 func newCountingBackend() *countingBackend {
@@ -1059,8 +1008,6 @@ func indexRepoNamespace(owningRepo string) (string, bool) {
 	return "", false
 }
 
-// slicesSortedKeys returns the keys of m sorted; lifted out so
-// failure messages are stable across runs.
 func slicesSortedKeys(m map[string][]byte) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {

--- a/pkg/namespace/registry_test.go
+++ b/pkg/namespace/registry_test.go
@@ -1,0 +1,806 @@
+package namespace_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/yolocs/ocifactory/pkg/auth"
+	"github.com/yolocs/ocifactory/pkg/namespace"
+	"github.com/yolocs/ocifactory/pkg/oci"
+)
+
+const (
+	googleIss   = "https://accounts.google.com"
+	aliceID     = "alice"
+	aliceEmail  = "alice@example.com"
+	otherEmail  = "bob@example.com"
+	repoFoo     = "packages/foo"
+	repoBar     = "packages/bar"
+	defaultBody = "hello world"
+)
+
+// allowAllSpec is a Spec whose policy admits any oidc subject for both
+// read and write. Tests that aren't exercising authz mechanics use it
+// to keep noise out of the assertions.
+func allowAllSpec() namespace.Spec {
+	return namespace.Spec{
+		Policy: namespace.Policy{
+			Readers: []namespace.SubjectMatcher{{Issuer: googleIss}},
+			Writers: []namespace.SubjectMatcher{{Issuer: googleIss}},
+		},
+	}
+}
+
+func aliceCtx(t *testing.T) context.Context {
+	t.Helper()
+	return auth.WithAuthContext(t.Context(), &auth.AuthContext{
+		Issuer: googleIss,
+		ID:     aliceID,
+		Email:  aliceEmail,
+	})
+}
+
+func setup(t *testing.T, opts ...namespace.RegistryOption) (*oci.FakeRegistry, *namespace.Registry, *namespace.Store) {
+	t.Helper()
+	fake := oci.NewFakeRegistry()
+	store := namespace.NewStore(fake)
+	// Disable the policy cache by default in tests so a Put then call
+	// in the same test sees the new spec without sleeping. The cache
+	// itself is exercised explicitly in TestRegistry_PolicyCache_*.
+	allOpts := append([]namespace.RegistryOption{namespace.WithPolicyCacheTTL(0)}, opts...)
+	reg := namespace.NewRegistry(fake, store, allOpts...)
+	return fake, reg, store
+}
+
+func putNamespace(t *testing.T, store *namespace.Store, name string, spec namespace.Spec) {
+	t.Helper()
+	if err := store.Put(t.Context(), &namespace.Namespace{Name: name, Spec: spec}); err != nil {
+		t.Fatalf("Put namespace %q: %v", name, err)
+	}
+}
+
+func newRepoFile(repo, tag, name string) *oci.RepoFile {
+	body := []byte(defaultBody)
+	return &oci.RepoFile{
+		OwningRepo: repo,
+		OwningTag:  tag,
+		Name:       name,
+		MediaType:  "application/octet-stream",
+		Size:       int64(len(body)),
+	}
+}
+
+func TestRegistry_AddRead_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	fake, reg, store := setup(t)
+	putNamespace(t, store, "alpha", allowAllSpec())
+	ctx := aliceCtx(t)
+
+	body := strings.NewReader(defaultBody)
+	if _, err := reg.AddFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "foo.txt"), body); err != nil {
+		t.Fatalf("AddFile: %v", err)
+	}
+
+	if _, ok := fake.Files["alpha/"+repoFoo+"/1.0.0/foo.txt"]; !ok {
+		t.Errorf("expected backend file under alpha/%s/1.0.0/foo.txt; got %v",
+			repoFoo, slicesSortedKeys(fake.Files))
+	}
+
+	_, rc, err := reg.ReadFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "foo.txt"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	defer rc.Close()
+	gotBody, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(gotBody) != defaultBody {
+		t.Errorf("ReadFile body = %q, want %q", gotBody, defaultBody)
+	}
+}
+
+// TestRegistry_NamespaceIsolation pins the load-bearing security
+// guarantee: namespace beta cannot read a file written through
+// namespace alpha, even when both have permissive policies. The
+// prefix is the only thing isolating them — if it ever regresses,
+// every authz test below is moot.
+func TestRegistry_NamespaceIsolation(t *testing.T) {
+	t.Parallel()
+
+	_, reg, store := setup(t)
+	putNamespace(t, store, "alpha", allowAllSpec())
+	putNamespace(t, store, "beta", allowAllSpec())
+	ctx := aliceCtx(t)
+
+	if _, err := reg.AddFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "foo.txt"), strings.NewReader(defaultBody)); err != nil {
+		t.Fatalf("AddFile alpha: %v", err)
+	}
+
+	_, _, err := reg.ReadFile(ctx, "beta", newRepoFile(repoFoo, "1.0.0", "foo.txt"))
+	if err == nil {
+		t.Fatal("ReadFile beta = nil, want not-found error (namespaces must isolate)")
+	}
+}
+
+func TestRegistry_NamespaceNotFound(t *testing.T) {
+	t.Parallel()
+
+	_, reg, _ := setup(t)
+	ctx := aliceCtx(t)
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "AddFile",
+			call: func() error {
+				_, err := reg.AddFile(ctx, "ghost", newRepoFile(repoFoo, "1.0.0", "foo.txt"), strings.NewReader(defaultBody))
+				return err
+			},
+		},
+		{
+			name: "ReadFile",
+			call: func() error {
+				_, _, err := reg.ReadFile(ctx, "ghost", newRepoFile(repoFoo, "1.0.0", "foo.txt"))
+				return err
+			},
+		},
+		{
+			name: "BlobRedirectURL",
+			call: func() error {
+				_, err := reg.BlobRedirectURL(ctx, "ghost", newRepoFile(repoFoo, "1.0.0", "foo.txt"))
+				return err
+			},
+		},
+		{
+			name: "ListTags",
+			call: func() error {
+				_, err := reg.ListTags(ctx, "ghost", repoFoo)
+				return err
+			},
+		},
+		{
+			name: "ListFiles",
+			call: func() error {
+				_, err := reg.ListFiles(ctx, "ghost", repoFoo)
+				return err
+			},
+		},
+		{
+			name: "ListPackages",
+			call: func() error {
+				_, err := reg.ListPackages(ctx, "ghost")
+				return err
+			},
+		},
+		{
+			name: "AppendRefs",
+			call: func() error {
+				return reg.AppendRefs(ctx, "ghost", repoFoo, "1.0.0", "latest")
+			},
+		},
+		{
+			name: "DeleteRepoFiles",
+			call: func() error {
+				return reg.DeleteRepoFiles(ctx, "ghost", repoFoo)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.call()
+			if err == nil {
+				t.Fatalf("%s = nil, want error wrapping ErrNotFound", tc.name)
+			}
+			if !errors.Is(err, namespace.ErrNotFound) {
+				t.Errorf("%s err = %v, want errors.Is(ErrNotFound)", tc.name, err)
+			}
+		})
+	}
+}
+
+func TestRegistry_Authz(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		spec      namespace.Spec
+		ac        *auth.AuthContext
+		op        string // "read" or "write"
+		wantAllow bool
+	}{
+		{
+			name:      "read-allowed",
+			spec:      namespace.Spec{Policy: namespace.Policy{Readers: []namespace.SubjectMatcher{{Email: aliceEmail}}}},
+			ac:        &auth.AuthContext{Issuer: googleIss, ID: aliceID, Email: aliceEmail},
+			op:        "read",
+			wantAllow: true,
+		},
+		{
+			name: "read-denied-when-only-writers-set",
+			spec: namespace.Spec{Policy: namespace.Policy{
+				Writers: []namespace.SubjectMatcher{{Email: aliceEmail}},
+			}},
+			ac:        &auth.AuthContext{Issuer: googleIss, ID: aliceID, Email: aliceEmail},
+			op:        "read",
+			wantAllow: false,
+		},
+		{
+			name: "write-allowed",
+			spec: namespace.Spec{Policy: namespace.Policy{
+				Writers: []namespace.SubjectMatcher{{Email: aliceEmail}},
+			}},
+			ac:        &auth.AuthContext{Issuer: googleIss, ID: aliceID, Email: aliceEmail},
+			op:        "write",
+			wantAllow: true,
+		},
+		{
+			name: "write-denied-when-only-readers-set",
+			spec: namespace.Spec{Policy: namespace.Policy{
+				Readers: []namespace.SubjectMatcher{{Email: aliceEmail}},
+			}},
+			ac:        &auth.AuthContext{Issuer: googleIss, ID: aliceID, Email: aliceEmail},
+			op:        "write",
+			wantAllow: false,
+		},
+		{
+			name:      "empty-policy-denies-read",
+			spec:      namespace.Spec{},
+			ac:        &auth.AuthContext{Issuer: googleIss, ID: aliceID, Email: aliceEmail},
+			op:        "read",
+			wantAllow: false,
+		},
+		{
+			name:      "empty-policy-denies-write",
+			spec:      namespace.Spec{},
+			ac:        &auth.AuthContext{Issuer: googleIss, ID: aliceID, Email: aliceEmail},
+			op:        "write",
+			wantAllow: false,
+		},
+		{
+			name: "subject-mismatch-denied",
+			spec: namespace.Spec{Policy: namespace.Policy{
+				Readers: []namespace.SubjectMatcher{{Email: aliceEmail}},
+			}},
+			ac:        &auth.AuthContext{Issuer: googleIss, ID: "stranger", Email: otherEmail},
+			op:        "read",
+			wantAllow: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fake, reg, store := setup(t)
+			putNamespace(t, store, "alpha", tc.spec)
+
+			// Seed the file directly through the fake so the read
+			// path always has something to find: any error must come
+			// from authz, not file-not-found.
+			if tc.op == "read" {
+				seedDirect(t, fake, "alpha")
+			}
+
+			ctx := auth.WithAuthContext(t.Context(), tc.ac)
+
+			var got error
+			switch tc.op {
+			case "write":
+				_, got = reg.AddFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "foo.txt"), strings.NewReader(defaultBody))
+			case "read":
+				_, _, got = reg.ReadFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "foo.txt"))
+			}
+
+			if tc.wantAllow {
+				if got != nil {
+					t.Errorf("op=%s allowed but err=%v", tc.op, got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("op=%s = nil, want error wrapping auth.ErrUnauthorized", tc.op)
+			}
+			if !errors.Is(got, auth.ErrUnauthorized) {
+				t.Errorf("op=%s err = %v, want errors.Is(auth.ErrUnauthorized)", tc.op, got)
+			}
+		})
+	}
+}
+
+// seedDirect plants a file under namespace ns via the fake directly,
+// bypassing the wrapper's authz so read tests can isolate the deny
+// paths from "file not found" noise.
+func seedDirect(t *testing.T, fake *oci.FakeRegistry, ns string) {
+	t.Helper()
+	rf := &oci.RepoFile{
+		OwningRepo: ns + "/" + repoFoo,
+		OwningTag:  "1.0.0",
+		Name:       "foo.txt",
+		MediaType:  "application/octet-stream",
+		Size:       int64(len(defaultBody)),
+	}
+	if _, err := fake.AddFile(t.Context(), rf, strings.NewReader(defaultBody)); err != nil {
+		t.Fatalf("seedDirect AddFile: %v", err)
+	}
+}
+
+func TestRegistry_NoAuthContextDenied(t *testing.T) {
+	t.Parallel()
+
+	_, reg, store := setup(t)
+	putNamespace(t, store, "alpha", allowAllSpec())
+
+	// No AuthContext on ctx — policyAuthorizer denies a nil subject.
+	_, _, err := reg.ReadFile(t.Context(), "alpha", newRepoFile(repoFoo, "1.0.0", "foo.txt"))
+	if err == nil {
+		t.Fatal("ReadFile with no AuthContext = nil, want error wrapping auth.ErrUnauthorized")
+	}
+	if !errors.Is(err, auth.ErrUnauthorized) {
+		t.Errorf("ReadFile err = %v, want errors.Is(auth.ErrUnauthorized)", err)
+	}
+}
+
+// TestRegistry_PackageIndex_PopulatedOnce verifies the index is
+// populated by AddFile and that re-writing the same owning-repo does
+// not stack duplicate entries.
+func TestRegistry_PackageIndex_PopulatedOnce(t *testing.T) {
+	t.Parallel()
+
+	_, reg, store := setup(t)
+	putNamespace(t, store, "alpha", allowAllSpec())
+	ctx := aliceCtx(t)
+
+	for i := 0; i < 3; i++ {
+		tag := fmt.Sprintf("1.0.%d", i)
+		if _, err := reg.AddFile(ctx, "alpha", newRepoFile(repoFoo, tag, "foo.txt"), strings.NewReader(defaultBody)); err != nil {
+			t.Fatalf("AddFile %s: %v", tag, err)
+		}
+	}
+
+	got, err := reg.ListPackages(ctx, "alpha")
+	if err != nil {
+		t.Fatalf("ListPackages: %v", err)
+	}
+	if diff := cmp.Diff([]string{repoFoo}, got); diff != "" {
+		t.Errorf("ListPackages mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestRegistry_PackageIndex_MultipleRepos(t *testing.T) {
+	t.Parallel()
+
+	_, reg, store := setup(t)
+	putNamespace(t, store, "alpha", allowAllSpec())
+	ctx := aliceCtx(t)
+
+	for _, repo := range []string{repoFoo, repoBar, "tools/cli"} {
+		if _, err := reg.AddFile(ctx, "alpha", newRepoFile(repo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+			t.Fatalf("AddFile %s: %v", repo, err)
+		}
+	}
+
+	got, err := reg.ListPackages(ctx, "alpha")
+	if err != nil {
+		t.Fatalf("ListPackages: %v", err)
+	}
+	slices.Sort(got)
+	want := []string{repoBar, repoFoo, "tools/cli"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("ListPackages mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestRegistry_PackageIndex_ConcurrentSameRepo races N goroutines
+// publishing to the same (ns, owning-repo) and asserts the index ends
+// up with exactly one entry and no errors leak out.
+func TestRegistry_PackageIndex_ConcurrentSameRepo(t *testing.T) {
+	t.Parallel()
+
+	_, reg, store := setup(t)
+	putNamespace(t, store, "alpha", allowAllSpec())
+	ctx := aliceCtx(t)
+
+	const n = 16
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			tag := fmt.Sprintf("v%d", i)
+			if _, err := reg.AddFile(ctx, "alpha", newRepoFile(repoFoo, tag, "f.txt"), strings.NewReader(defaultBody)); err != nil {
+				errs <- err
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("concurrent AddFile: %v", err)
+	}
+
+	pkgs, err := reg.ListPackages(ctx, "alpha")
+	if err != nil {
+		t.Fatalf("ListPackages: %v", err)
+	}
+	if diff := cmp.Diff([]string{repoFoo}, pkgs); diff != "" {
+		t.Errorf("ListPackages mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestRegistry_PackageIndex_Isolated pins that the package index is
+// per-namespace: a write into alpha doesn't show up in beta's index.
+func TestRegistry_PackageIndex_Isolated(t *testing.T) {
+	t.Parallel()
+
+	_, reg, store := setup(t)
+	putNamespace(t, store, "alpha", allowAllSpec())
+	putNamespace(t, store, "beta", allowAllSpec())
+	ctx := aliceCtx(t)
+
+	if _, err := reg.AddFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+		t.Fatalf("AddFile alpha: %v", err)
+	}
+
+	betaPkgs, err := reg.ListPackages(ctx, "beta")
+	if err != nil {
+		t.Fatalf("ListPackages beta: %v", err)
+	}
+	if len(betaPkgs) != 0 {
+		t.Errorf("ListPackages beta = %v, want empty", betaPkgs)
+	}
+}
+
+// TestRegistry_PackageIndex_TagEncoding pins that owning-repo names
+// containing '/' round-trip through the index correctly.
+func TestRegistry_PackageIndex_TagEncoding(t *testing.T) {
+	t.Parallel()
+
+	fake, reg, store := setup(t)
+	putNamespace(t, store, "alpha", allowAllSpec())
+	ctx := aliceCtx(t)
+
+	repos := []string{
+		"packages/requests",
+		"com/example/foo-bar",
+		"toplevel",
+	}
+	for _, r := range repos {
+		if _, err := reg.AddFile(ctx, "alpha", newRepoFile(r, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+			t.Fatalf("AddFile %s: %v", r, err)
+		}
+	}
+
+	// Verify the on-backend tag form is escaped (for inspectability
+	// the test pins the encoding the wrapper uses).
+	indexTags, err := fake.ListTags(ctx, "alpha/_packages")
+	if err != nil {
+		t.Fatalf("ListTags index: %v", err)
+	}
+	wantBackend := []string{
+		"packages__requests",
+		"com__example__foo-bar",
+		"toplevel",
+	}
+	slices.Sort(indexTags)
+	slices.Sort(wantBackend)
+	if diff := cmp.Diff(wantBackend, indexTags); diff != "" {
+		t.Errorf("backend index tags mismatch (-want +got):\n%s", diff)
+	}
+
+	got, err := reg.ListPackages(ctx, "alpha")
+	if err != nil {
+		t.Fatalf("ListPackages: %v", err)
+	}
+	slices.Sort(got)
+	wantDecoded := []string{
+		"com/example/foo-bar",
+		"packages/requests",
+		"toplevel",
+	}
+	if diff := cmp.Diff(wantDecoded, got); diff != "" {
+		t.Errorf("ListPackages mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestRegistry_ListPackages_EmptyOnUntouchedNamespace(t *testing.T) {
+	t.Parallel()
+
+	_, reg, store := setup(t)
+	putNamespace(t, store, "alpha", allowAllSpec())
+	ctx := aliceCtx(t)
+
+	got, err := reg.ListPackages(ctx, "alpha")
+	if err != nil {
+		t.Fatalf("ListPackages: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("ListPackages = %v, want empty", got)
+	}
+}
+
+func TestRegistry_ListTags_AndListFiles(t *testing.T) {
+	t.Parallel()
+
+	_, reg, store := setup(t)
+	putNamespace(t, store, "alpha", allowAllSpec())
+	ctx := aliceCtx(t)
+
+	for _, tag := range []string{"1.0.0", "2.0.0"} {
+		if _, err := reg.AddFile(ctx, "alpha", newRepoFile(repoFoo, tag, "f.txt"), strings.NewReader(defaultBody)); err != nil {
+			t.Fatalf("AddFile %s: %v", tag, err)
+		}
+	}
+
+	tags, err := reg.ListTags(ctx, "alpha", repoFoo)
+	if err != nil {
+		t.Fatalf("ListTags: %v", err)
+	}
+	slices.Sort(tags)
+	if diff := cmp.Diff([]string{"1.0.0", "2.0.0"}, tags); diff != "" {
+		t.Errorf("ListTags mismatch (-want +got):\n%s", diff)
+	}
+
+	files, err := reg.ListFiles(ctx, "alpha", repoFoo)
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	// OwningRepo must come back without the namespace prefix —
+	// callers should not see the namespace leak through.
+	for _, f := range files {
+		if f.OwningRepo != repoFoo {
+			t.Errorf("ListFiles OwningRepo = %q, want %q (namespace prefix must not leak)", f.OwningRepo, repoFoo)
+		}
+	}
+	if len(files) != 2 {
+		t.Errorf("ListFiles len = %d, want 2", len(files))
+	}
+}
+
+func TestRegistry_AppendRefs_Forwards(t *testing.T) {
+	t.Parallel()
+
+	fake, reg, store := setup(t)
+	putNamespace(t, store, "alpha", allowAllSpec())
+	ctx := aliceCtx(t)
+
+	if _, err := reg.AddFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+		t.Fatalf("AddFile: %v", err)
+	}
+	if err := reg.AppendRefs(ctx, "alpha", repoFoo, "1.0.0", "latest"); err != nil {
+		t.Fatalf("AppendRefs: %v", err)
+	}
+	// Assert the alias landed under the namespace-scoped repo.
+	if got, ok := fake.Aliases["alpha/"+repoFoo+"/latest"]; !ok || got != "1.0.0" {
+		t.Errorf("alias under alpha/%s/latest = %q (ok=%v), want 1.0.0", repoFoo, got, ok)
+	}
+}
+
+func TestRegistry_DeleteRepoFiles_ClearsBackendAndIndex(t *testing.T) {
+	t.Parallel()
+
+	fake, reg, store := setup(t)
+	putNamespace(t, store, "alpha", allowAllSpec())
+	ctx := aliceCtx(t)
+
+	if _, err := reg.AddFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+		t.Fatalf("AddFile: %v", err)
+	}
+	if err := reg.DeleteRepoFiles(ctx, "alpha", repoFoo); err != nil {
+		t.Fatalf("DeleteRepoFiles: %v", err)
+	}
+	for k := range fake.Files {
+		if strings.HasPrefix(k, "alpha/"+repoFoo+"/") {
+			t.Errorf("file %q remained after DeleteRepoFiles", k)
+		}
+	}
+	// Re-AddFile must repopulate the package index — DeleteRepoFiles
+	// drops the in-process indexed marker.
+	if _, err := reg.AddFile(ctx, "alpha", newRepoFile(repoFoo, "2.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+		t.Fatalf("AddFile after delete: %v", err)
+	}
+	pkgs, err := reg.ListPackages(ctx, "alpha")
+	if err != nil {
+		t.Fatalf("ListPackages: %v", err)
+	}
+	if diff := cmp.Diff([]string{repoFoo}, pkgs); diff != "" {
+		t.Errorf("ListPackages mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestRegistry_PolicyCache_HotPathSkipsStore counts the spec.json
+// reads the metadata Store performs and asserts the cache absorbs all
+// but the first lookup across N data-plane requests. The
+// countingBackend below double-duties as the data plane's backend AND
+// the metadata store's backend, so we can isolate spec-file reads by
+// path matching.
+func TestRegistry_PolicyCache_HotPathSkipsStore(t *testing.T) {
+	t.Parallel()
+
+	counted := newCountingBackend()
+	store := namespace.NewStore(counted)
+	reg := namespace.NewRegistry(counted, store, namespace.WithPolicyCacheTTL(time.Hour))
+
+	if err := store.Put(t.Context(), &namespace.Namespace{Name: "alpha", Spec: allowAllSpec()}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	ctx := aliceCtx(t)
+
+	// Seed one write so subsequent reads have something to fetch.
+	if _, err := reg.AddFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+		t.Fatalf("AddFile: %v", err)
+	}
+
+	before := counted.specReads("alpha")
+	const iters = 50
+	for i := 0; i < iters; i++ {
+		_, _, err := reg.ReadFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "f.txt"))
+		if err != nil {
+			t.Fatalf("ReadFile %d: %v", i, err)
+		}
+	}
+	after := counted.specReads("alpha")
+	if after-before != 0 {
+		t.Errorf("spec re-fetched %d times across %d requests, want 0 (cache must absorb)",
+			after-before, iters)
+	}
+}
+
+// TestRegistry_PolicyCache_TTLZero_DisablesCache is the inverse of the
+// above: with caching disabled, every request must re-fetch the spec.
+func TestRegistry_PolicyCache_TTLZero_DisablesCache(t *testing.T) {
+	t.Parallel()
+
+	counted := newCountingBackend()
+	store := namespace.NewStore(counted)
+	reg := namespace.NewRegistry(counted, store, namespace.WithPolicyCacheTTL(0))
+
+	if err := store.Put(t.Context(), &namespace.Namespace{Name: "alpha", Spec: allowAllSpec()}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	ctx := aliceCtx(t)
+
+	if _, err := reg.AddFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+		t.Fatalf("AddFile: %v", err)
+	}
+
+	before := counted.specReads("alpha")
+	const iters = 5
+	for i := 0; i < iters; i++ {
+		_, _, err := reg.ReadFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "f.txt"))
+		if err != nil {
+			t.Fatalf("ReadFile: %v", err)
+		}
+	}
+	after := counted.specReads("alpha")
+	if after-before < iters {
+		t.Errorf("spec re-fetches = %d across %d disabled-cache requests, want >= %d",
+			after-before, iters, iters)
+	}
+}
+
+// TestRegistry_PolicyCache_NegativeCaching pins that a 404 from
+// Store.Get is cached too — a hot loop hammering an unknown
+// namespace must not turn into N store reads.
+func TestRegistry_PolicyCache_NegativeCaching(t *testing.T) {
+	t.Parallel()
+
+	counted := newCountingBackend()
+	store := namespace.NewStore(counted)
+	reg := namespace.NewRegistry(counted, store, namespace.WithPolicyCacheTTL(time.Hour))
+	ctx := aliceCtx(t)
+
+	const iters = 10
+	for i := 0; i < iters; i++ {
+		_, _, err := reg.ReadFile(ctx, "ghost", newRepoFile(repoFoo, "1.0.0", "f.txt"))
+		if !errors.Is(err, namespace.ErrNotFound) {
+			t.Fatalf("ReadFile(ghost) %d err = %v, want errors.Is(ErrNotFound)", i, err)
+		}
+	}
+	// The first miss should pay one spec read; the rest are absorbed
+	// by the negative cache. >= 2 here would be a regression.
+	if got := counted.specReads("ghost"); got > 1 {
+		t.Errorf("spec reads for missing namespace = %d, want <= 1 (negative cache must absorb)", got)
+	}
+}
+
+// TestRegistry_InvalidatePolicy_PicksUpNewSpec exercises the
+// admin-side invalidation path: a Put followed by Invalidate must
+// take effect on the very next call.
+func TestRegistry_InvalidatePolicy_PicksUpNewSpec(t *testing.T) {
+	t.Parallel()
+
+	counted := newCountingBackend()
+	store := namespace.NewStore(counted)
+	reg := namespace.NewRegistry(counted, store, namespace.WithPolicyCacheTTL(time.Hour))
+	ctx := aliceCtx(t)
+
+	// Initial spec denies alice.
+	putNamespace(t, store, "alpha", namespace.Spec{Policy: namespace.Policy{
+		Readers: []namespace.SubjectMatcher{{Email: otherEmail}},
+	}})
+	if _, _, err := reg.ReadFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "f.txt")); !errors.Is(err, auth.ErrUnauthorized) {
+		t.Fatalf("ReadFile pre-update err = %v, want errors.Is(auth.ErrUnauthorized)", err)
+	}
+
+	// Update the spec to allow alice — without invalidation the cache
+	// would still deny.
+	putNamespace(t, store, "alpha", allowAllSpec())
+	reg.InvalidatePolicy("alpha")
+
+	// Seed via AddFile (now permitted) so the subsequent ReadFile
+	// tests authz, not file presence.
+	if _, err := reg.AddFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+		t.Fatalf("AddFile post-invalidate: %v", err)
+	}
+	if _, _, err := reg.ReadFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "f.txt")); err != nil {
+		t.Errorf("ReadFile post-update err = %v, want nil", err)
+	}
+}
+
+// countingBackend wraps an [oci.FakeRegistry] and counts how many
+// times the namespace metadata spec.json file has been read for each
+// namespace. We use the counter to prove the policy cache absorbs
+// repeated lookups: every wrapper call goes through ReadFile, but
+// only spec-file reads — those whose path matches "<ns>/_metadata/spec.json"
+// — represent uncached metadata-store traffic.
+type countingBackend struct {
+	*oci.FakeRegistry
+	mu         sync.Mutex
+	specReads_ map[string]int
+}
+
+func newCountingBackend() *countingBackend {
+	return &countingBackend{
+		FakeRegistry: oci.NewFakeRegistry(),
+		specReads_:   map[string]int{},
+	}
+}
+
+func (c *countingBackend) ReadFile(ctx context.Context, f *oci.RepoFile) (*oci.FileDescriptor, io.ReadCloser, error) {
+	if isSpecRead(f) {
+		c.mu.Lock()
+		c.specReads_[f.OwningRepo]++
+		c.mu.Unlock()
+	}
+	return c.FakeRegistry.ReadFile(ctx, f)
+}
+
+func (c *countingBackend) specReads(name string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.specReads_[name]
+}
+
+func isSpecRead(f *oci.RepoFile) bool {
+	// The Store stores the spec at "<name>/_metadata/spec.json" with
+	// the default empty prefix. Anything matching that pattern is
+	// metadata traffic.
+	return f.OwningTag == "_metadata" && f.Name == "spec.json"
+}
+
+// slicesSortedKeys returns the keys of m sorted; lifted out so
+// failure messages are stable across runs.
+func slicesSortedKeys(m map[string][]byte) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	slices.Sort(out)
+	return out
+}

--- a/pkg/namespace/registry_test.go
+++ b/pkg/namespace/registry_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"oras.land/oras-go/v2/errdef"
 
 	"github.com/yolocs/ocifactory/pkg/auth"
 	"github.com/yolocs/ocifactory/pkg/namespace"
@@ -68,9 +69,13 @@ func putNamespace(t *testing.T, store *namespace.Store, name string, spec namesp
 	}
 }
 
-func newRepoFile(repo, tag, name string) *oci.RepoFile {
+// nsRepoFile builds a RepoFile with Namespace populated. Tests use
+// this consistently so a future change to the file struct doesn't
+// require a global sed.
+func nsRepoFile(ns, repo, tag, name string) *oci.RepoFile {
 	body := []byte(defaultBody)
 	return &oci.RepoFile{
+		Namespace:  ns,
 		OwningRepo: repo,
 		OwningTag:  tag,
 		Name:       name,
@@ -87,7 +92,7 @@ func TestRegistry_AddRead_HappyPath(t *testing.T) {
 	ctx := aliceCtx(t)
 
 	body := strings.NewReader(defaultBody)
-	if _, err := reg.AddFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "foo.txt"), body); err != nil {
+	if _, err := reg.AddFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "foo.txt"), body); err != nil {
 		t.Fatalf("AddFile: %v", err)
 	}
 
@@ -96,7 +101,7 @@ func TestRegistry_AddRead_HappyPath(t *testing.T) {
 			repoFoo, slicesSortedKeys(fake.Files))
 	}
 
-	_, rc, err := reg.ReadFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "foo.txt"))
+	_, rc, err := reg.ReadFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "foo.txt"))
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
 	}
@@ -112,9 +117,9 @@ func TestRegistry_AddRead_HappyPath(t *testing.T) {
 
 // TestRegistry_NamespaceIsolation pins the load-bearing security
 // guarantee: namespace beta cannot read a file written through
-// namespace alpha, even when both have permissive policies. The
-// prefix is the only thing isolating them — if it ever regresses,
-// every authz test below is moot.
+// namespace alpha, AND alpha can still read its own file (so a
+// regression that 5xx'd on every read wouldn't pass for the wrong
+// reason).
 func TestRegistry_NamespaceIsolation(t *testing.T) {
 	t.Parallel()
 
@@ -123,13 +128,70 @@ func TestRegistry_NamespaceIsolation(t *testing.T) {
 	putNamespace(t, store, "beta", allowAllSpec())
 	ctx := aliceCtx(t)
 
-	if _, err := reg.AddFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "foo.txt"), strings.NewReader(defaultBody)); err != nil {
+	if _, err := reg.AddFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "foo.txt"), strings.NewReader(defaultBody)); err != nil {
 		t.Fatalf("AddFile alpha: %v", err)
 	}
 
-	_, _, err := reg.ReadFile(ctx, "beta", newRepoFile(repoFoo, "1.0.0", "foo.txt"))
+	// Alpha must still see its own file (rules out a generic-error regression).
+	if _, rc, err := reg.ReadFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "foo.txt")); err != nil {
+		t.Errorf("ReadFile alpha (own file): %v, want success", err)
+	} else {
+		rc.Close()
+	}
+
+	// Beta must not — and the failure mode must be ErrNotFound, not
+	// some generic 5xx.
+	_, _, err := reg.ReadFile(ctx, nsRepoFile("beta", repoFoo, "1.0.0", "foo.txt"))
 	if err == nil {
 		t.Fatal("ReadFile beta = nil, want not-found error (namespaces must isolate)")
+	}
+	if !errors.Is(err, errdef.ErrNotFound) {
+		t.Errorf("ReadFile beta err = %v, want errors.Is(errdef.ErrNotFound)", err)
+	}
+}
+
+// TestRegistry_NamespaceEscape is the explicit anti-vuln test: a
+// caller authorised for alpha cannot reach beta by passing
+// OwningRepo="../beta/foo" etc. The wrapper rejects with
+// ErrInvalidOwningRepo BEFORE any backend call.
+func TestRegistry_NamespaceEscape(t *testing.T) {
+	t.Parallel()
+
+	fake, reg, store := setup(t)
+	putNamespace(t, store, "alpha", allowAllSpec())
+	putNamespace(t, store, "beta", allowAllSpec())
+	ctx := aliceCtx(t)
+
+	// Plant a beta file directly so a successful escape would have
+	// something to find.
+	if _, err := fake.AddFile(ctx, &oci.RepoFile{
+		OwningRepo: "beta/" + repoFoo,
+		OwningTag:  "1.0.0",
+		Name:       "secret.txt",
+		Size:       int64(len("secret")),
+	}, strings.NewReader("secret")); err != nil {
+		t.Fatalf("seed beta: %v", err)
+	}
+
+	escapes := []string{
+		"../beta/" + repoFoo,
+		"..",
+		"foo/../../beta",
+		"/beta/" + repoFoo, // absolute
+		"./" + repoFoo,     // non-canonical
+		repoFoo + "/",      // trailing slash, non-canonical
+	}
+	for _, esc := range escapes {
+		t.Run("escape="+esc, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := reg.ReadFile(ctx, nsRepoFile("alpha", esc, "1.0.0", "secret.txt"))
+			if err == nil {
+				t.Fatalf("ReadFile owningRepo=%q = nil, want ErrInvalidOwningRepo (namespace escape!)", esc)
+			}
+			if !errors.Is(err, namespace.ErrInvalidOwningRepo) {
+				t.Errorf("ReadFile owningRepo=%q err = %v, want errors.Is(ErrInvalidOwningRepo)", esc, err)
+			}
+		})
 	}
 }
 
@@ -146,35 +208,35 @@ func TestRegistry_NamespaceNotFound(t *testing.T) {
 		{
 			name: "AddFile",
 			call: func() error {
-				_, err := reg.AddFile(ctx, "ghost", newRepoFile(repoFoo, "1.0.0", "foo.txt"), strings.NewReader(defaultBody))
+				_, err := reg.AddFile(ctx, nsRepoFile("ghost", repoFoo, "1.0.0", "foo.txt"), strings.NewReader(defaultBody))
 				return err
 			},
 		},
 		{
 			name: "ReadFile",
 			call: func() error {
-				_, _, err := reg.ReadFile(ctx, "ghost", newRepoFile(repoFoo, "1.0.0", "foo.txt"))
+				_, _, err := reg.ReadFile(ctx, nsRepoFile("ghost", repoFoo, "1.0.0", "foo.txt"))
 				return err
 			},
 		},
 		{
 			name: "BlobRedirectURL",
 			call: func() error {
-				_, err := reg.BlobRedirectURL(ctx, "ghost", newRepoFile(repoFoo, "1.0.0", "foo.txt"))
+				_, err := reg.BlobRedirectURL(ctx, nsRepoFile("ghost", repoFoo, "1.0.0", "foo.txt"))
 				return err
 			},
 		},
 		{
 			name: "ListTags",
 			call: func() error {
-				_, err := reg.ListTags(ctx, "ghost", repoFoo)
+				_, err := reg.ListTags(ctx, nsRepoFile("ghost", repoFoo, "", ""))
 				return err
 			},
 		},
 		{
 			name: "ListFiles",
 			call: func() error {
-				_, err := reg.ListFiles(ctx, "ghost", repoFoo)
+				_, err := reg.ListFiles(ctx, nsRepoFile("ghost", repoFoo, "", ""))
 				return err
 			},
 		},
@@ -188,13 +250,13 @@ func TestRegistry_NamespaceNotFound(t *testing.T) {
 		{
 			name: "AppendRefs",
 			call: func() error {
-				return reg.AppendRefs(ctx, "ghost", repoFoo, "1.0.0", "latest")
+				return reg.AppendRefs(ctx, nsRepoFile("ghost", repoFoo, "1.0.0", ""), "latest")
 			},
 		},
 		{
 			name: "DeleteRepoFiles",
 			call: func() error {
-				return reg.DeleteRepoFiles(ctx, "ghost", repoFoo)
+				return reg.DeleteRepoFiles(ctx, nsRepoFile("ghost", repoFoo, "", ""))
 			},
 		},
 	}
@@ -213,6 +275,45 @@ func TestRegistry_NamespaceNotFound(t *testing.T) {
 	}
 }
 
+func TestRegistry_NilFile(t *testing.T) {
+	t.Parallel()
+
+	_, reg, store := setup(t)
+	putNamespace(t, store, "alpha", allowAllSpec())
+	ctx := aliceCtx(t)
+
+	if _, err := reg.AddFile(ctx, nil, strings.NewReader("")); err == nil {
+		t.Error("AddFile(nil) = nil, want error")
+	}
+	if _, _, err := reg.ReadFile(ctx, nil); err == nil {
+		t.Error("ReadFile(nil) = nil, want error")
+	}
+	if _, err := reg.BlobRedirectURL(ctx, nil); err == nil {
+		t.Error("BlobRedirectURL(nil) = nil, want error")
+	}
+}
+
+func TestRegistry_EmptyNamespace(t *testing.T) {
+	t.Parallel()
+
+	_, reg, store := setup(t)
+	putNamespace(t, store, "alpha", allowAllSpec())
+	ctx := aliceCtx(t)
+
+	// Empty Namespace on the file — the wrapper must refuse before
+	// authz; otherwise an empty namespace would resolve to a "" auth
+	// lookup which could behave unpredictably depending on the
+	// authorizer plugin.
+	bad := &oci.RepoFile{
+		OwningRepo: repoFoo,
+		OwningTag:  "1.0.0",
+		Name:       "foo.txt",
+	}
+	if _, err := reg.AddFile(ctx, bad, strings.NewReader("")); err == nil {
+		t.Error("AddFile(empty Namespace) = nil, want error")
+	}
+}
+
 func TestRegistry_Authz(t *testing.T) {
 	t.Parallel()
 
@@ -220,23 +321,25 @@ func TestRegistry_Authz(t *testing.T) {
 		name      string
 		spec      namespace.Spec
 		ac        *auth.AuthContext
-		op        string // "read" or "write"
+		op        auth.Op
 		wantAllow bool
 	}{
 		{
 			name:      "read-allowed",
 			spec:      namespace.Spec{Policy: namespace.Policy{Readers: []namespace.SubjectMatcher{{Email: aliceEmail}}}},
 			ac:        &auth.AuthContext{Issuer: googleIss, ID: aliceID, Email: aliceEmail},
-			op:        "read",
+			op:        auth.OpRead,
 			wantAllow: true,
 		},
 		{
-			name: "read-denied-when-only-writers-set",
+			name: "read-denied-empty-readers",
 			spec: namespace.Spec{Policy: namespace.Policy{
+				// Readers list is nil — empty list is the explicit
+				// "no one can read" case the issue test plan calls out.
 				Writers: []namespace.SubjectMatcher{{Email: aliceEmail}},
 			}},
 			ac:        &auth.AuthContext{Issuer: googleIss, ID: aliceID, Email: aliceEmail},
-			op:        "read",
+			op:        auth.OpRead,
 			wantAllow: false,
 		},
 		{
@@ -245,30 +348,30 @@ func TestRegistry_Authz(t *testing.T) {
 				Writers: []namespace.SubjectMatcher{{Email: aliceEmail}},
 			}},
 			ac:        &auth.AuthContext{Issuer: googleIss, ID: aliceID, Email: aliceEmail},
-			op:        "write",
+			op:        auth.OpWrite,
 			wantAllow: true,
 		},
 		{
-			name: "write-denied-when-only-readers-set",
+			name: "write-denied-empty-writers",
 			spec: namespace.Spec{Policy: namespace.Policy{
 				Readers: []namespace.SubjectMatcher{{Email: aliceEmail}},
 			}},
 			ac:        &auth.AuthContext{Issuer: googleIss, ID: aliceID, Email: aliceEmail},
-			op:        "write",
+			op:        auth.OpWrite,
 			wantAllow: false,
 		},
 		{
 			name:      "empty-policy-denies-read",
 			spec:      namespace.Spec{},
 			ac:        &auth.AuthContext{Issuer: googleIss, ID: aliceID, Email: aliceEmail},
-			op:        "read",
+			op:        auth.OpRead,
 			wantAllow: false,
 		},
 		{
 			name:      "empty-policy-denies-write",
 			spec:      namespace.Spec{},
 			ac:        &auth.AuthContext{Issuer: googleIss, ID: aliceID, Email: aliceEmail},
-			op:        "write",
+			op:        auth.OpWrite,
 			wantAllow: false,
 		},
 		{
@@ -277,7 +380,7 @@ func TestRegistry_Authz(t *testing.T) {
 				Readers: []namespace.SubjectMatcher{{Email: aliceEmail}},
 			}},
 			ac:        &auth.AuthContext{Issuer: googleIss, ID: "stranger", Email: otherEmail},
-			op:        "read",
+			op:        auth.OpRead,
 			wantAllow: false,
 		},
 	}
@@ -292,7 +395,7 @@ func TestRegistry_Authz(t *testing.T) {
 			// Seed the file directly through the fake so the read
 			// path always has something to find: any error must come
 			// from authz, not file-not-found.
-			if tc.op == "read" {
+			if tc.op == auth.OpRead {
 				seedDirect(t, fake, "alpha")
 			}
 
@@ -300,10 +403,10 @@ func TestRegistry_Authz(t *testing.T) {
 
 			var got error
 			switch tc.op {
-			case "write":
-				_, got = reg.AddFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "foo.txt"), strings.NewReader(defaultBody))
-			case "read":
-				_, _, got = reg.ReadFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "foo.txt"))
+			case auth.OpWrite:
+				_, got = reg.AddFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "foo.txt"), strings.NewReader(defaultBody))
+			case auth.OpRead:
+				_, _, got = reg.ReadFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "foo.txt"))
 			}
 
 			if tc.wantAllow {
@@ -345,8 +448,11 @@ func TestRegistry_NoAuthContextDenied(t *testing.T) {
 	_, reg, store := setup(t)
 	putNamespace(t, store, "alpha", allowAllSpec())
 
-	// No AuthContext on ctx — policyAuthorizer denies a nil subject.
-	_, _, err := reg.ReadFile(t.Context(), "alpha", newRepoFile(repoFoo, "1.0.0", "foo.txt"))
+	// Defense in depth: the wrapper itself rejects nil AuthContext,
+	// not just the plugin authorizer. A faulty third-party
+	// AuthzFactory that forgets the nil check must not turn into an
+	// auth bypass.
+	_, _, err := reg.ReadFile(t.Context(), nsRepoFile("alpha", repoFoo, "1.0.0", "foo.txt"))
 	if err == nil {
 		t.Fatal("ReadFile with no AuthContext = nil, want error wrapping auth.ErrUnauthorized")
 	}
@@ -355,29 +461,49 @@ func TestRegistry_NoAuthContextDenied(t *testing.T) {
 	}
 }
 
-// TestRegistry_PackageIndex_PopulatedOnce verifies the index is
-// populated by AddFile and that re-writing the same owning-repo does
-// not stack duplicate entries.
-func TestRegistry_PackageIndex_PopulatedOnce(t *testing.T) {
+// TestRegistry_NoAuthContextDeniedAtWrapper proves the wrapper
+// itself denies nil even when the AuthzFactory would have allowed.
+func TestRegistry_NoAuthContextDeniedAtWrapper(t *testing.T) {
 	t.Parallel()
 
-	_, reg, store := setup(t)
+	fake := oci.NewFakeRegistry()
+	store := namespace.NewStore(fake)
+	// Use AllowAll authorizer — if the wrapper delegated nil-handling
+	// to the authorizer, this test would falsely pass.
+	reg := namespace.NewRegistry(fake, store,
+		namespace.WithAuthzFactory(func(_ namespace.Policy) (auth.Authorizer, error) { return auth.AllowAll, nil }),
+		namespace.WithPolicyCacheTTL(0),
+	)
+	putNamespace(t, store, "alpha", allowAllSpec())
+
+	_, _, err := reg.ReadFile(t.Context(), nsRepoFile("alpha", repoFoo, "1.0.0", "foo.txt"))
+	if !errors.Is(err, auth.ErrUnauthorized) {
+		t.Errorf("ReadFile (AllowAll factory + nil ctx) err = %v, want errors.Is(auth.ErrUnauthorized)", err)
+	}
+}
+
+// TestRegistry_PackageIndex_PopulatedExactlyOnce uses a counting
+// backend to prove the wrapper makes exactly one index-repo AddFile
+// call across N data writes to the same (ns, owning-repo). Without
+// the indexed-LRU dedupe, this would be N.
+func TestRegistry_PackageIndex_PopulatedExactlyOnce(t *testing.T) {
+	t.Parallel()
+
+	counted := newCountingBackend()
+	store := namespace.NewStore(counted)
+	reg := namespace.NewRegistry(counted, store, namespace.WithPolicyCacheTTL(0))
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
 
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 5; i++ {
 		tag := fmt.Sprintf("1.0.%d", i)
-		if _, err := reg.AddFile(ctx, "alpha", newRepoFile(repoFoo, tag, "foo.txt"), strings.NewReader(defaultBody)); err != nil {
+		if _, err := reg.AddFile(ctx, nsRepoFile("alpha", repoFoo, tag, "f.txt"), strings.NewReader(defaultBody)); err != nil {
 			t.Fatalf("AddFile %s: %v", tag, err)
 		}
 	}
 
-	got, err := reg.ListPackages(ctx, "alpha")
-	if err != nil {
-		t.Fatalf("ListPackages: %v", err)
-	}
-	if diff := cmp.Diff([]string{repoFoo}, got); diff != "" {
-		t.Errorf("ListPackages mismatch (-want +got):\n%s", diff)
+	if got := counted.indexAddCount("alpha"); got != 1 {
+		t.Errorf("index AddFile count = %d, want 1 (LRU must dedupe)", got)
 	}
 }
 
@@ -389,7 +515,7 @@ func TestRegistry_PackageIndex_MultipleRepos(t *testing.T) {
 	ctx := aliceCtx(t)
 
 	for _, repo := range []string{repoFoo, repoBar, "tools/cli"} {
-		if _, err := reg.AddFile(ctx, "alpha", newRepoFile(repo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+		if _, err := reg.AddFile(ctx, nsRepoFile("alpha", repo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
 			t.Fatalf("AddFile %s: %v", repo, err)
 		}
 	}
@@ -405,13 +531,19 @@ func TestRegistry_PackageIndex_MultipleRepos(t *testing.T) {
 	}
 }
 
-// TestRegistry_PackageIndex_ConcurrentSameRepo races N goroutines
-// publishing to the same (ns, owning-repo) and asserts the index ends
-// up with exactly one entry and no errors leak out.
-func TestRegistry_PackageIndex_ConcurrentSameRepo(t *testing.T) {
+// TestRegistry_PackageIndex_ConcurrentExactlyOneAddFile is the
+// concurrency stress: N goroutines hammering the same (ns, owning-
+// repo) must result in exactly ONE index-repo AddFile call. Without
+// the per-key sync.Mutex + LRU re-check, every losing goroutine
+// would issue an idempotent AddFile that the fake swallows via
+// ErrAlreadyExists — invisible to the end-state assertion but
+// proportional in backend round-trips.
+func TestRegistry_PackageIndex_ConcurrentExactlyOneAddFile(t *testing.T) {
 	t.Parallel()
 
-	_, reg, store := setup(t)
+	counted := newCountingBackend()
+	store := namespace.NewStore(counted)
+	reg := namespace.NewRegistry(counted, store, namespace.WithPolicyCacheTTL(0))
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
 
@@ -423,7 +555,7 @@ func TestRegistry_PackageIndex_ConcurrentSameRepo(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			tag := fmt.Sprintf("v%d", i)
-			if _, err := reg.AddFile(ctx, "alpha", newRepoFile(repoFoo, tag, "f.txt"), strings.NewReader(defaultBody)); err != nil {
+			if _, err := reg.AddFile(ctx, nsRepoFile("alpha", repoFoo, tag, "f.txt"), strings.NewReader(defaultBody)); err != nil {
 				errs <- err
 			}
 		}(i)
@@ -434,6 +566,9 @@ func TestRegistry_PackageIndex_ConcurrentSameRepo(t *testing.T) {
 		t.Errorf("concurrent AddFile: %v", err)
 	}
 
+	if got := counted.indexAddCount("alpha"); got != 1 {
+		t.Errorf("index AddFile count = %d across %d concurrent writes, want 1", got, n)
+	}
 	pkgs, err := reg.ListPackages(ctx, "alpha")
 	if err != nil {
 		t.Fatalf("ListPackages: %v", err)
@@ -443,8 +578,6 @@ func TestRegistry_PackageIndex_ConcurrentSameRepo(t *testing.T) {
 	}
 }
 
-// TestRegistry_PackageIndex_Isolated pins that the package index is
-// per-namespace: a write into alpha doesn't show up in beta's index.
 func TestRegistry_PackageIndex_Isolated(t *testing.T) {
 	t.Parallel()
 
@@ -453,7 +586,7 @@ func TestRegistry_PackageIndex_Isolated(t *testing.T) {
 	putNamespace(t, store, "beta", allowAllSpec())
 	ctx := aliceCtx(t)
 
-	if _, err := reg.AddFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+	if _, err := reg.AddFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
 		t.Fatalf("AddFile alpha: %v", err)
 	}
 
@@ -466,12 +599,13 @@ func TestRegistry_PackageIndex_Isolated(t *testing.T) {
 	}
 }
 
-// TestRegistry_PackageIndex_TagEncoding pins that owning-repo names
-// containing '/' round-trip through the index correctly.
-func TestRegistry_PackageIndex_TagEncoding(t *testing.T) {
+// TestRegistry_TagEncoding_RoundTrip pins the encoding properties
+// the security review flagged: collision-free between names that
+// differ only in '/' vs '_' (the old encoding silently merged them).
+func TestRegistry_TagEncoding_RoundTrip(t *testing.T) {
 	t.Parallel()
 
-	fake, reg, store := setup(t)
+	_, reg, store := setup(t)
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
 
@@ -479,28 +613,14 @@ func TestRegistry_PackageIndex_TagEncoding(t *testing.T) {
 		"packages/requests",
 		"com/example/foo-bar",
 		"toplevel",
+		"a__b",  // would collide with "a/b" under the old "/__" encoding
+		"a_b_c", // bare underscores must round-trip
+		"x.y.z",
 	}
 	for _, r := range repos {
-		if _, err := reg.AddFile(ctx, "alpha", newRepoFile(r, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+		if _, err := reg.AddFile(ctx, nsRepoFile("alpha", r, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
 			t.Fatalf("AddFile %s: %v", r, err)
 		}
-	}
-
-	// Verify the on-backend tag form is escaped (for inspectability
-	// the test pins the encoding the wrapper uses).
-	indexTags, err := fake.ListTags(ctx, "alpha/_packages")
-	if err != nil {
-		t.Fatalf("ListTags index: %v", err)
-	}
-	wantBackend := []string{
-		"packages__requests",
-		"com__example__foo-bar",
-		"toplevel",
-	}
-	slices.Sort(indexTags)
-	slices.Sort(wantBackend)
-	if diff := cmp.Diff(wantBackend, indexTags); diff != "" {
-		t.Errorf("backend index tags mismatch (-want +got):\n%s", diff)
 	}
 
 	got, err := reg.ListPackages(ctx, "alpha")
@@ -508,12 +628,9 @@ func TestRegistry_PackageIndex_TagEncoding(t *testing.T) {
 		t.Fatalf("ListPackages: %v", err)
 	}
 	slices.Sort(got)
-	wantDecoded := []string{
-		"com/example/foo-bar",
-		"packages/requests",
-		"toplevel",
-	}
-	if diff := cmp.Diff(wantDecoded, got); diff != "" {
+	want := append([]string(nil), repos...)
+	slices.Sort(want)
+	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("ListPackages mismatch (-want +got):\n%s", diff)
 	}
 }
@@ -542,12 +659,12 @@ func TestRegistry_ListTags_AndListFiles(t *testing.T) {
 	ctx := aliceCtx(t)
 
 	for _, tag := range []string{"1.0.0", "2.0.0"} {
-		if _, err := reg.AddFile(ctx, "alpha", newRepoFile(repoFoo, tag, "f.txt"), strings.NewReader(defaultBody)); err != nil {
+		if _, err := reg.AddFile(ctx, nsRepoFile("alpha", repoFoo, tag, "f.txt"), strings.NewReader(defaultBody)); err != nil {
 			t.Fatalf("AddFile %s: %v", tag, err)
 		}
 	}
 
-	tags, err := reg.ListTags(ctx, "alpha", repoFoo)
+	tags, err := reg.ListTags(ctx, nsRepoFile("alpha", repoFoo, "", ""))
 	if err != nil {
 		t.Fatalf("ListTags: %v", err)
 	}
@@ -556,19 +673,72 @@ func TestRegistry_ListTags_AndListFiles(t *testing.T) {
 		t.Errorf("ListTags mismatch (-want +got):\n%s", diff)
 	}
 
-	files, err := reg.ListFiles(ctx, "alpha", repoFoo)
+	files, err := reg.ListFiles(ctx, nsRepoFile("alpha", repoFoo, "", ""))
 	if err != nil {
 		t.Fatalf("ListFiles: %v", err)
 	}
-	// OwningRepo must come back without the namespace prefix —
-	// callers should not see the namespace leak through.
 	for _, f := range files {
 		if f.OwningRepo != repoFoo {
 			t.Errorf("ListFiles OwningRepo = %q, want %q (namespace prefix must not leak)", f.OwningRepo, repoFoo)
 		}
+		if f.Namespace != "alpha" {
+			t.Errorf("ListFiles Namespace = %q, want %q", f.Namespace, "alpha")
+		}
 	}
 	if len(files) != 2 {
 		t.Errorf("ListFiles len = %d, want 2", len(files))
+	}
+}
+
+// TestRegistry_ListFiles_MultiSegmentRepo guards against a buggy
+// stripPrefix that would only chop the first path segment.
+func TestRegistry_ListFiles_MultiSegmentRepo(t *testing.T) {
+	t.Parallel()
+
+	_, reg, store := setup(t)
+	putNamespace(t, store, "alpha", allowAllSpec())
+	ctx := aliceCtx(t)
+
+	repo := "com/example/foo-bar"
+	if _, err := reg.AddFile(ctx, nsRepoFile("alpha", repo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+		t.Fatalf("AddFile: %v", err)
+	}
+	files, err := reg.ListFiles(ctx, nsRepoFile("alpha", repo, "", ""))
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	if len(files) != 1 || files[0].OwningRepo != repo {
+		t.Errorf("ListFiles[0].OwningRepo = %v, want %q (full multi-segment path)", files, repo)
+	}
+}
+
+// TestRegistry_ListFiles_PrefixOfAnotherNamespace pins that "alpha"
+// doesn't accidentally strip from "alpha-foo" repos.
+func TestRegistry_ListFiles_PrefixOfAnotherNamespace(t *testing.T) {
+	t.Parallel()
+
+	fake, reg, store := setup(t)
+	putNamespace(t, store, "alpha", allowAllSpec())
+	ctx := aliceCtx(t)
+
+	// Plant a file under a backend repo that LOOKS LIKE it shares a
+	// prefix with "alpha" but is actually a sibling — exercising the
+	// trailing-slash check.
+	if _, err := fake.AddFile(ctx, &oci.RepoFile{
+		OwningRepo: "alpha/" + repoFoo,
+		OwningTag:  "1.0.0",
+		Name:       "f.txt",
+		Size:       int64(len(defaultBody)),
+	}, strings.NewReader(defaultBody)); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	files, err := reg.ListFiles(ctx, nsRepoFile("alpha", repoFoo, "", ""))
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	if len(files) != 1 || files[0].OwningRepo != repoFoo {
+		t.Errorf("ListFiles = %v, want one entry with OwningRepo=%q", files, repoFoo)
 	}
 }
 
@@ -579,29 +749,41 @@ func TestRegistry_AppendRefs_Forwards(t *testing.T) {
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
 
-	if _, err := reg.AddFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+	if _, err := reg.AddFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
 		t.Fatalf("AddFile: %v", err)
 	}
-	if err := reg.AppendRefs(ctx, "alpha", repoFoo, "1.0.0", "latest"); err != nil {
+	if err := reg.AppendRefs(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", ""), "latest"); err != nil {
 		t.Fatalf("AppendRefs: %v", err)
 	}
-	// Assert the alias landed under the namespace-scoped repo.
 	if got, ok := fake.Aliases["alpha/"+repoFoo+"/latest"]; !ok || got != "1.0.0" {
 		t.Errorf("alias under alpha/%s/latest = %q (ok=%v), want 1.0.0", repoFoo, got, ok)
 	}
 }
 
-func TestRegistry_DeleteRepoFiles_ClearsBackendAndIndex(t *testing.T) {
+// TestRegistry_DeleteRepoFiles_SweepsBackendIndex verifies BOTH the
+// in-process indexed marker AND the backend _packages tag are
+// cleared. Without the backend sweep, ListPackages would lie about
+// deleted repos until the namespace itself is purged.
+func TestRegistry_DeleteRepoFiles_SweepsBackendIndex(t *testing.T) {
 	t.Parallel()
 
 	fake, reg, store := setup(t)
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
 
-	if _, err := reg.AddFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+	if _, err := reg.AddFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
 		t.Fatalf("AddFile: %v", err)
 	}
-	if err := reg.DeleteRepoFiles(ctx, "alpha", repoFoo); err != nil {
+	// Pre-flight: index has an entry.
+	pkgs, err := reg.ListPackages(ctx, "alpha")
+	if err != nil {
+		t.Fatalf("ListPackages pre: %v", err)
+	}
+	if !slices.Contains(pkgs, repoFoo) {
+		t.Fatalf("ListPackages pre = %v, want to contain %q", pkgs, repoFoo)
+	}
+
+	if err := reg.DeleteRepoFiles(ctx, nsRepoFile("alpha", repoFoo, "", "")); err != nil {
 		t.Fatalf("DeleteRepoFiles: %v", err)
 	}
 	for k := range fake.Files {
@@ -609,26 +791,35 @@ func TestRegistry_DeleteRepoFiles_ClearsBackendAndIndex(t *testing.T) {
 			t.Errorf("file %q remained after DeleteRepoFiles", k)
 		}
 	}
-	// Re-AddFile must repopulate the package index — DeleteRepoFiles
-	// drops the in-process indexed marker.
-	if _, err := reg.AddFile(ctx, "alpha", newRepoFile(repoFoo, "2.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+	// ListPackages must no longer report the deleted repo even
+	// without a re-add.
+	pkgs, err = reg.ListPackages(ctx, "alpha")
+	if err != nil {
+		t.Fatalf("ListPackages post: %v", err)
+	}
+	if slices.Contains(pkgs, repoFoo) {
+		t.Errorf("ListPackages post = %v, want NOT to contain %q (backend index must be swept)", pkgs, repoFoo)
+	}
+
+	// Re-AddFile must repopulate the package index.
+	if _, err := reg.AddFile(ctx, nsRepoFile("alpha", repoFoo, "2.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
 		t.Fatalf("AddFile after delete: %v", err)
 	}
-	pkgs, err := reg.ListPackages(ctx, "alpha")
+	pkgs, err = reg.ListPackages(ctx, "alpha")
 	if err != nil {
-		t.Fatalf("ListPackages: %v", err)
+		t.Fatalf("ListPackages re-add: %v", err)
 	}
-	if diff := cmp.Diff([]string{repoFoo}, pkgs); diff != "" {
-		t.Errorf("ListPackages mismatch (-want +got):\n%s", diff)
+	if !slices.Contains(pkgs, repoFoo) {
+		t.Errorf("ListPackages re-add = %v, want to contain %q", pkgs, repoFoo)
 	}
 }
 
-// TestRegistry_PolicyCache_HotPathSkipsStore counts the spec.json
-// reads the metadata Store performs and asserts the cache absorbs all
-// but the first lookup across N data-plane requests. The
-// countingBackend below double-duties as the data plane's backend AND
-// the metadata store's backend, so we can isolate spec-file reads by
-// path matching.
+// TestRegistry_PolicyCache_HotPathSkipsStore counts spec.json reads
+// the metadata Store performs and asserts the cache absorbs all but
+// the first lookup across N data-plane requests. The before-snapshot
+// is taken AFTER the seed write so the cache is known to be
+// populated; if the before count were 0 this test could pass
+// vacuously.
 func TestRegistry_PolicyCache_HotPathSkipsStore(t *testing.T) {
 	t.Parallel()
 
@@ -636,33 +827,34 @@ func TestRegistry_PolicyCache_HotPathSkipsStore(t *testing.T) {
 	store := namespace.NewStore(counted)
 	reg := namespace.NewRegistry(counted, store, namespace.WithPolicyCacheTTL(time.Hour))
 
-	if err := store.Put(t.Context(), &namespace.Namespace{Name: "alpha", Spec: allowAllSpec()}); err != nil {
-		t.Fatalf("Put: %v", err)
-	}
+	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
 
-	// Seed one write so subsequent reads have something to fetch.
-	if _, err := reg.AddFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+	// Seed AND ensure the cache is populated by issuing a single
+	// pre-call.
+	if _, err := reg.AddFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
 		t.Fatalf("AddFile: %v", err)
 	}
+	priming := counted.specReads("alpha")
+	if priming == 0 {
+		t.Fatal("priming spec reads = 0, test is vacuous (the wrapper should have polled the store at least once)")
+	}
 
-	before := counted.specReads("alpha")
 	const iters = 50
 	for i := 0; i < iters; i++ {
-		_, _, err := reg.ReadFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "f.txt"))
+		_, _, err := reg.ReadFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "f.txt"))
 		if err != nil {
 			t.Fatalf("ReadFile %d: %v", i, err)
 		}
 	}
 	after := counted.specReads("alpha")
-	if after-before != 0 {
-		t.Errorf("spec re-fetched %d times across %d requests, want 0 (cache must absorb)",
-			after-before, iters)
+	if after != priming {
+		t.Errorf("spec re-fetched %d times across %d cached requests, want 0", after-priming, iters)
 	}
 }
 
-// TestRegistry_PolicyCache_TTLZero_DisablesCache is the inverse of the
-// above: with caching disabled, every request must re-fetch the spec.
+// TestRegistry_PolicyCache_TTLZero_DisablesCache: with caching
+// disabled, every request must re-fetch the spec.
 func TestRegistry_PolicyCache_TTLZero_DisablesCache(t *testing.T) {
 	t.Parallel()
 
@@ -670,19 +862,17 @@ func TestRegistry_PolicyCache_TTLZero_DisablesCache(t *testing.T) {
 	store := namespace.NewStore(counted)
 	reg := namespace.NewRegistry(counted, store, namespace.WithPolicyCacheTTL(0))
 
-	if err := store.Put(t.Context(), &namespace.Namespace{Name: "alpha", Spec: allowAllSpec()}); err != nil {
-		t.Fatalf("Put: %v", err)
-	}
+	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
 
-	if _, err := reg.AddFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+	if _, err := reg.AddFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
 		t.Fatalf("AddFile: %v", err)
 	}
 
 	before := counted.specReads("alpha")
 	const iters = 5
 	for i := 0; i < iters; i++ {
-		_, _, err := reg.ReadFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "f.txt"))
+		_, _, err := reg.ReadFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "f.txt"))
 		if err != nil {
 			t.Fatalf("ReadFile: %v", err)
 		}
@@ -694,9 +884,9 @@ func TestRegistry_PolicyCache_TTLZero_DisablesCache(t *testing.T) {
 	}
 }
 
-// TestRegistry_PolicyCache_NegativeCaching pins that a 404 from
-// Store.Get is cached too — a hot loop hammering an unknown
-// namespace must not turn into N store reads.
+// TestRegistry_PolicyCache_NegativeCaching pins that ErrNotFound
+// from Store.Get is cached. A counterpart check after Invalidate
+// proves the cache was load-bearing.
 func TestRegistry_PolicyCache_NegativeCaching(t *testing.T) {
 	t.Parallel()
 
@@ -707,68 +897,113 @@ func TestRegistry_PolicyCache_NegativeCaching(t *testing.T) {
 
 	const iters = 10
 	for i := 0; i < iters; i++ {
-		_, _, err := reg.ReadFile(ctx, "ghost", newRepoFile(repoFoo, "1.0.0", "f.txt"))
+		_, _, err := reg.ReadFile(ctx, nsRepoFile("ghost", repoFoo, "1.0.0", "f.txt"))
 		if !errors.Is(err, namespace.ErrNotFound) {
 			t.Fatalf("ReadFile(ghost) %d err = %v, want errors.Is(ErrNotFound)", i, err)
 		}
 	}
-	// The first miss should pay one spec read; the rest are absorbed
-	// by the negative cache. >= 2 here would be a regression.
 	if got := counted.specReads("ghost"); got > 1 {
-		t.Errorf("spec reads for missing namespace = %d, want <= 1 (negative cache must absorb)", got)
+		t.Errorf("spec reads for missing namespace = %d after %d requests, want 1 (negative cache must absorb)", got, iters)
+	}
+
+	// Invalidate-then-call must repopulate (cache was load-bearing).
+	reg.InvalidatePolicy("ghost")
+	if _, _, err := reg.ReadFile(ctx, nsRepoFile("ghost", repoFoo, "1.0.0", "f.txt")); !errors.Is(err, namespace.ErrNotFound) {
+		t.Fatalf("post-invalidate ReadFile = %v, want errors.Is(ErrNotFound)", err)
+	}
+	if got := counted.specReads("ghost"); got != 2 {
+		t.Errorf("spec reads after invalidate = %d, want 2 (one before, one after)", got)
 	}
 }
 
-// TestRegistry_InvalidatePolicy_PicksUpNewSpec exercises the
-// admin-side invalidation path: a Put followed by Invalidate must
-// take effect on the very next call.
-func TestRegistry_InvalidatePolicy_PicksUpNewSpec(t *testing.T) {
+// TestRegistry_StorePut_InvalidatesCache verifies the mutation hook
+// wired by NewRegistry: an admin Put takes effect on the very next
+// data-plane call without waiting for the cache TTL.
+func TestRegistry_StorePut_InvalidatesCache(t *testing.T) {
 	t.Parallel()
 
 	counted := newCountingBackend()
 	store := namespace.NewStore(counted)
 	reg := namespace.NewRegistry(counted, store, namespace.WithPolicyCacheTTL(time.Hour))
+	_ = reg
 	ctx := aliceCtx(t)
 
-	// Initial spec denies alice.
+	// First spec denies alice via Email mismatch.
 	putNamespace(t, store, "alpha", namespace.Spec{Policy: namespace.Policy{
 		Readers: []namespace.SubjectMatcher{{Email: otherEmail}},
 	}})
-	if _, _, err := reg.ReadFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "f.txt")); !errors.Is(err, auth.ErrUnauthorized) {
-		t.Fatalf("ReadFile pre-update err = %v, want errors.Is(auth.ErrUnauthorized)", err)
+	seedDirect(t, counted.FakeRegistry, "alpha")
+	if _, _, err := reg.ReadFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "foo.txt")); !errors.Is(err, auth.ErrUnauthorized) {
+		t.Fatalf("pre-update ReadFile = %v, want errors.Is(auth.ErrUnauthorized)", err)
 	}
 
-	// Update the spec to allow alice — without invalidation the cache
-	// would still deny.
+	// Update spec to allow alice. Without the mutation hook the
+	// cached deny would survive for an hour and this would still 403.
 	putNamespace(t, store, "alpha", allowAllSpec())
-	reg.InvalidatePolicy("alpha")
-
-	// Seed via AddFile (now permitted) so the subsequent ReadFile
-	// tests authz, not file presence.
-	if _, err := reg.AddFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
-		t.Fatalf("AddFile post-invalidate: %v", err)
+	if _, _, err := reg.ReadFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "foo.txt")); err != nil {
+		t.Errorf("post-update ReadFile = %v, want success (Store.Put must invalidate cache)", err)
 	}
-	if _, _, err := reg.ReadFile(ctx, "alpha", newRepoFile(repoFoo, "1.0.0", "f.txt")); err != nil {
-		t.Errorf("ReadFile post-update err = %v, want nil", err)
+}
+
+// TestRegistry_PolicyCache_Singleflight: N concurrent first-misses
+// for the same namespace must collapse into a single Store.Get.
+func TestRegistry_PolicyCache_Singleflight(t *testing.T) {
+	t.Parallel()
+
+	counted := newCountingBackend()
+	store := namespace.NewStore(counted)
+	reg := namespace.NewRegistry(counted, store, namespace.WithPolicyCacheTTL(time.Hour))
+	putNamespace(t, store, "alpha", allowAllSpec())
+	seedDirect(t, counted.FakeRegistry, "alpha")
+	// Reset the counter so the seed's Put doesn't pollute the
+	// assertion.
+	counted.resetSpecReads("alpha")
+	ctx := aliceCtx(t)
+
+	// Serialize the spec read so concurrent goroutines all queue up
+	// behind a slow first miss — this is what makes singleflight
+	// observable.
+	counted.blockSpecRead = make(chan struct{})
+	defer close(counted.blockSpecRead)
+
+	const n = 10
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			_, _, _ = reg.ReadFile(ctx, nsRepoFile("alpha", repoFoo, "1.0.0", "foo.txt"))
+		}()
+	}
+	// Give all N goroutines a moment to enter the singleflight.
+	time.Sleep(50 * time.Millisecond)
+	// Release the spec read.
+	counted.blockSpecRead <- struct{}{}
+	wg.Wait()
+
+	if got := counted.specReads("alpha"); got != 1 {
+		t.Errorf("spec reads under singleflight = %d across %d concurrent misses, want 1", got, n)
 	}
 }
 
 // countingBackend wraps an [oci.FakeRegistry] and counts how many
-// times the namespace metadata spec.json file has been read for each
-// namespace. We use the counter to prove the policy cache absorbs
-// repeated lookups: every wrapper call goes through ReadFile, but
-// only spec-file reads — those whose path matches "<ns>/_metadata/spec.json"
-// — represent uncached metadata-store traffic.
+// times the namespace metadata spec.json is read for each namespace,
+// and how many times the per-namespace _packages index repo receives
+// an AddFile. The two counters separate "metadata-store traffic"
+// from "package-index dedupe" assertions in the tests above.
 type countingBackend struct {
 	*oci.FakeRegistry
-	mu         sync.Mutex
-	specReads_ map[string]int
+	mu            sync.Mutex
+	specReads_    map[string]int
+	indexAdds_    map[string]int
+	blockSpecRead chan struct{} // when non-nil, ReadFile blocks waiting on a value
 }
 
 func newCountingBackend() *countingBackend {
 	return &countingBackend{
 		FakeRegistry: oci.NewFakeRegistry(),
 		specReads_:   map[string]int{},
+		indexAdds_:   map[string]int{},
 	}
 }
 
@@ -776,9 +1011,22 @@ func (c *countingBackend) ReadFile(ctx context.Context, f *oci.RepoFile) (*oci.F
 	if isSpecRead(f) {
 		c.mu.Lock()
 		c.specReads_[f.OwningRepo]++
+		blocker := c.blockSpecRead
 		c.mu.Unlock()
+		if blocker != nil {
+			<-blocker
+		}
 	}
 	return c.FakeRegistry.ReadFile(ctx, f)
+}
+
+func (c *countingBackend) AddFile(ctx context.Context, f *oci.RepoFile, ro io.Reader) (*oci.FileDescriptor, error) {
+	if ns, ok := indexRepoNamespace(f.OwningRepo); ok {
+		c.mu.Lock()
+		c.indexAdds_[ns]++
+		c.mu.Unlock()
+	}
+	return c.FakeRegistry.AddFile(ctx, f, ro)
 }
 
 func (c *countingBackend) specReads(name string) int {
@@ -787,11 +1035,28 @@ func (c *countingBackend) specReads(name string) int {
 	return c.specReads_[name]
 }
 
+func (c *countingBackend) resetSpecReads(name string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.specReads_, name)
+}
+
+func (c *countingBackend) indexAddCount(name string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.indexAdds_[name]
+}
+
 func isSpecRead(f *oci.RepoFile) bool {
-	// The Store stores the spec at "<name>/_metadata/spec.json" with
-	// the default empty prefix. Anything matching that pattern is
-	// metadata traffic.
 	return f.OwningTag == "_metadata" && f.Name == "spec.json"
+}
+
+func indexRepoNamespace(owningRepo string) (string, bool) {
+	const suffix = "/_packages"
+	if strings.HasSuffix(owningRepo, suffix) {
+		return owningRepo[:len(owningRepo)-len(suffix)], true
+	}
+	return "", false
 }
 
 // slicesSortedKeys returns the keys of m sorted; lifted out so

--- a/pkg/namespace/store.go
+++ b/pkg/namespace/store.go
@@ -50,8 +50,9 @@ type Backend interface {
 // _catalog endpoint is optional and inconsistently implemented across
 // registries, so we maintain the index ourselves.
 type Store struct {
-	backend Backend
-	prefix  string
+	backend   Backend
+	prefix    string
+	onMutated func(name string)
 }
 
 type Option func(*Store)
@@ -59,6 +60,15 @@ type Option func(*Store)
 // WithPrefix overrides [DefaultPrefix].
 func WithPrefix(prefix string) Option {
 	return func(s *Store) { s.prefix = prefix }
+}
+
+// WithMutationHook registers a callback the Store invokes after a
+// successful Put or Delete with the affected namespace name. The
+// data-plane wrapper uses this to invalidate its cached authorizer
+// so an admin Put takes effect on the very next request without
+// waiting for the cache TTL to expire. nil clears any previous hook.
+func WithMutationHook(hook func(name string)) Option {
+	return func(s *Store) { s.onMutated = hook }
 }
 
 // NewStore wraps backend in a namespace [Store]. In production
@@ -70,6 +80,20 @@ func NewStore(backend Backend, opts ...Option) *Store {
 		opt(s)
 	}
 	return s
+}
+
+// SetMutationHook installs a mutation callback after construction.
+// Used by [Registry] to plug itself in for cache invalidation
+// without forcing the caller to construct the wrapper before the
+// store. Passing nil clears the hook.
+func (s *Store) SetMutationHook(hook func(name string)) {
+	s.onMutated = hook
+}
+
+func (s *Store) notifyMutated(name string) {
+	if s.onMutated != nil {
+		s.onMutated(name)
+	}
 }
 
 func (s *Store) repoFor(name string) string {
@@ -169,6 +193,7 @@ func (s *Store) Put(ctx context.Context, ns *Namespace) error {
 	if _, err := s.backend.AddFile(ctx, indexRF, bytes.NewReader(indexSentinelBody)); err != nil && !errors.Is(err, oci.ErrAlreadyExists) {
 		return fmt.Errorf("write namespace %q index entry: %w", ns.Name, err)
 	}
+	s.notifyMutated(ns.Name)
 	return nil
 }
 
@@ -191,6 +216,7 @@ func (s *Store) Delete(ctx context.Context, name string) error {
 	if err := swallowNotFound(s.backend.DeleteTagFiles(ctx, s.indexRepo(), name)); err != nil {
 		return fmt.Errorf("delete namespace %q index entry: %w", name, err)
 	}
+	s.notifyMutated(name)
 	return nil
 }
 

--- a/pkg/oci/errors_test.go
+++ b/pkg/oci/errors_test.go
@@ -86,10 +86,10 @@ func TestNormalizeNotFound(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		err         error
-		wantNotFnd  bool // errors.Is(err, errdef.ErrNotFound) after normalize
-		wantHas404  bool // HasCode(err, 404) after normalize
+		name       string
+		err        error
+		wantNotFnd bool // errors.Is(err, errdef.ErrNotFound) after normalize
+		wantHas404 bool // HasCode(err, 404) after normalize
 	}{
 		{
 			name:       "nil",

--- a/pkg/oci/fake.go
+++ b/pkg/oci/fake.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"slices"
 	"strings"
+	"sync"
 
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -28,6 +29,13 @@ import (
 // need those should use the inMemoryRepo wrapper around oras-go's
 // content/memory.Store instead (see registry_test.go).
 type FakeRegistry struct {
+	// mu guards Files, Tags, and Aliases against concurrent
+	// mutation. Single-threaded handler tests don't need it; the
+	// lock exists for tests that exercise wrappers concurrently
+	// (e.g. pkg/namespace's package-index race test). Public field
+	// access from tests still works — callers reading the maps
+	// outside of test goroutines see a consistent snapshot.
+	mu      sync.Mutex
 	Files   map[string][]byte
 	Tags    map[string][]string
 	Aliases map[string]string
@@ -53,6 +61,12 @@ func NewFakeRegistry() *FakeRegistry {
 // helper because handler tests (notably python) seed canonical tags
 // directly to set up package-list expectations.
 func (r *FakeRegistry) AddTag(repo, tag string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.addTagLocked(repo, tag)
+}
+
+func (r *FakeRegistry) addTagLocked(repo, tag string) {
 	if slices.Contains(r.Tags[repo], tag) {
 		return
 	}
@@ -63,6 +77,10 @@ func (r *FakeRegistry) AddFile(ctx context.Context, f *RepoFile, ro io.Reader) (
 	if f.OwningTag == "" {
 		return nil, fmt.Errorf("OwningTag must be set")
 	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	// Refuse to clobber an alias tag with a canonical version push — the
 	// real registry does the same via the artifactType HEAD probe.
 	if _, ok := r.Aliases[aliasKey(f.OwningRepo, f.OwningTag)]; ok {
@@ -83,7 +101,7 @@ func (r *FakeRegistry) AddFile(ctx context.Context, f *RepoFile, ro io.Reader) (
 	}
 
 	r.Files[key] = content
-	r.AddTag(f.OwningRepo, f.OwningTag)
+	r.addTagLocked(f.OwningRepo, f.OwningTag)
 
 	desc := generateDescriptor(content, f)
 	return &FileDescriptor{File: desc}, nil
@@ -109,6 +127,9 @@ func (r *FakeRegistry) ReadFile(ctx context.Context, f *RepoFile) (*FileDescript
 		return nil, nil, fmt.Errorf("either OwningTag or RefTag must be set")
 	}
 
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	tag := f.OwningTag
 	if tag == "" {
 		canonical, ok := r.Aliases[aliasKey(f.OwningRepo, f.RefTag)]
@@ -133,6 +154,8 @@ func (r *FakeRegistry) ReadFile(ctx context.Context, f *RepoFile) (*FileDescript
 // re-point of an existing alias is allowed and replaces the previous
 // target.
 func (r *FakeRegistry) AppendRefs(ctx context.Context, repo string, canonicalTag string, refs ...string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	if !slices.Contains(r.Tags[repo], canonicalTag) {
 		return fmt.Errorf("canonical tag %q not found in repo %q: %w", canonicalTag, repo, errdef.ErrNotFound)
 	}
@@ -153,6 +176,8 @@ func (r *FakeRegistry) AppendRefs(ctx context.Context, repo string, canonicalTag
 // check (not modelled here — tests that need it use the inMemoryRepo
 // wrapper).
 func (r *FakeRegistry) ListTags(ctx context.Context, repo string) ([]string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	tags := append([]string{}, r.Tags[repo]...)
 	prefix := repo + "/"
 	for k := range r.Aliases {
@@ -169,6 +194,8 @@ func (r *FakeRegistry) ListTags(ctx context.Context, repo string) ([]string, err
 // to mirror the real Registry's behaviour, where the digest comes from
 // the file manifest's FileDigestAnnotation.
 func (r *FakeRegistry) ListFiles(ctx context.Context, repo string) ([]*RepoFile, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	var filesList []*RepoFile
 	for key, content := range r.Files {
 		parts := strings.Split(key, "/")
@@ -205,6 +232,8 @@ func (r *FakeRegistry) BlobRedirectURL(ctx context.Context, f *RepoFile) (string
 // callers can use errors.Is to distinguish "already gone" from a
 // genuine error.
 func (r *FakeRegistry) DeleteTagFiles(ctx context.Context, repo string, tag string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	aliasK := aliasKey(repo, tag)
 	if _, ok := r.Aliases[aliasK]; ok {
 		delete(r.Aliases, aliasK)
@@ -222,6 +251,29 @@ func (r *FakeRegistry) DeleteTagFiles(ctx context.Context, repo string, tag stri
 	r.Tags[repo] = slices.DeleteFunc(r.Tags[repo], func(t string) bool { return t == tag })
 	if len(r.Tags[repo]) == 0 {
 		delete(r.Tags, repo)
+	}
+	return nil
+}
+
+// DeleteRepoFiles mirrors *Registry.DeleteRepoFiles for the in-memory
+// fake. Every canonical version (and its files) under repo is removed,
+// then aliases anchored to repo are unbound. A repo with no canonical
+// versions and no aliases is a no-op — matches the real Registry's
+// best-effort cleanup contract.
+func (r *FakeRegistry) DeleteRepoFiles(ctx context.Context, repo string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	prefix := repo + "/"
+	for k := range r.Files {
+		if strings.HasPrefix(k, prefix) {
+			delete(r.Files, k)
+		}
+	}
+	delete(r.Tags, repo)
+	for k := range r.Aliases {
+		if strings.HasPrefix(k, prefix) {
+			delete(r.Aliases, k)
+		}
 	}
 	return nil
 }

--- a/pkg/oci/fake.go
+++ b/pkg/oci/fake.go
@@ -78,28 +78,36 @@ func (r *FakeRegistry) AddFile(ctx context.Context, f *RepoFile, ro io.Reader) (
 		return nil, fmt.Errorf("OwningTag must be set")
 	}
 
+	// Pre-flight checks under the lock so we can refuse the upload
+	// without consuming the body — matches the real Registry's
+	// pre-upload rejection contract that handler tests rely on for
+	// twine-retry simulation.
+	key := f.OwningRepo + "/" + f.OwningTag + "/" + f.Name
 	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	// Refuse to clobber an alias tag with a canonical version push — the
-	// real registry does the same via the artifactType HEAD probe.
 	if _, ok := r.Aliases[aliasKey(f.OwningRepo, f.OwningTag)]; ok {
+		r.mu.Unlock()
 		return nil, fmt.Errorf("%w: tag %q in repo %q is an alias", ErrAliasCollision, f.OwningTag, f.OwningRepo)
 	}
-
-	key := f.OwningRepo + "/" + f.OwningTag + "/" + f.Name
 	if _, exists := r.Files[key]; exists && !r.AllowOverwrite {
-		// Match the real Registry's pre-upload rejection: the body
-		// is not consumed, so handler tests that simulate a twine
-		// retry can re-use the same reader.
+		r.mu.Unlock()
 		return nil, fmt.Errorf("%w: %s", ErrAlreadyExists, key)
 	}
+	r.mu.Unlock()
 
+	// Read the body without holding the lock — a slow reader (e.g.
+	// one blocked on a channel) would otherwise stall every
+	// concurrent fake op. The race window is benign: a colliding
+	// concurrent upload that wins between the pre-check and the
+	// store below either gets ErrAlreadyExists itself or, with
+	// AllowOverwrite, is overwritten in turn — same outcome as a
+	// real backend racing two PUTs.
 	content, err := io.ReadAll(ro)
 	if err != nil {
 		return nil, err
 	}
 
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.Files[key] = content
 	r.addTagLocked(f.OwningRepo, f.OwningTag)
 

--- a/pkg/oci/registry.go
+++ b/pkg/oci/registry.go
@@ -267,16 +267,6 @@ func WithBlobRedirectDisabled(disabled bool) RegistryOption {
 
 // RepoFile represents a file in an OCI repository.
 type RepoFile struct {
-	// Namespace is the logical registry tenant the file belongs to.
-	// pkg/oci itself ignores this field — it is consumed by upstream
-	// wrappers (notably pkg/namespace.Registry) that prefix
-	// OwningRepo with the namespace before forwarding to oci.Registry.
-	// Carrying it on the file struct rather than as a separate
-	// argument lets handlers keep using the existing
-	// (*RepoFile)-shaped Registry methods regardless of whether
-	// they're talking to a wrapper or the raw OCI layer.
-	Namespace string
-
 	OwningRepo string // Repository the owns the file. Usually what's right after the registy host.
 	OwningTag  string // Usually the package version that owns the file.
 	RefTag     string // Tag that points to the file. Could be empty.

--- a/pkg/oci/registry.go
+++ b/pkg/oci/registry.go
@@ -267,6 +267,16 @@ func WithBlobRedirectDisabled(disabled bool) RegistryOption {
 
 // RepoFile represents a file in an OCI repository.
 type RepoFile struct {
+	// Namespace is the logical registry tenant the file belongs to.
+	// pkg/oci itself ignores this field — it is consumed by upstream
+	// wrappers (notably pkg/namespace.Registry) that prefix
+	// OwningRepo with the namespace before forwarding to oci.Registry.
+	// Carrying it on the file struct rather than as a separate
+	// argument lets handlers keep using the existing
+	// (*RepoFile)-shaped Registry methods regardless of whether
+	// they're talking to a wrapper or the raw OCI layer.
+	Namespace string
+
 	OwningRepo string // Repository the owns the file. Usually what's right after the registy host.
 	OwningTag  string // Usually the package version that owns the file.
 	RefTag     string // Tag that points to the file. Could be empty.


### PR DESCRIPTION
Wraps *pkg/oci.Registry to namespace-scope every data-plane operation:
prefixes OwningRepo with the namespace name, enforces the namespace's
authz policy on every call, and maintains a per-namespace package index
at <ns>/_packages so cascade delete and listing don't depend on the
optional OCI _catalog endpoint.

The compiled per-namespace Authorizer is cached behind a TTL+LRU
(default 60s, 1024 entries) so the hot path is one map lookup per
request — without this, every artifact fetch would pay for a Store.Get
plus a full Policy compile. Negative results from Store.Get are cached
too so a hot loop hammering an unknown namespace doesn't turn into N
metadata round-trips. InvalidatePolicy lets the admin server drop a
cached entry when it mutates the spec.

A bounded in-process LRU short-circuits duplicate writes into the
package index, with a per-key sync.Mutex serialising concurrent
first-writers so a burst of N goroutines pays for one backend AddFile
instead of N idempotent retries. Index updates are best-effort and run
after the inner write succeeds — a failed update logs WARN and does
not fail the call, matching the issue's "hint, not a transactional
ledger" framing.

Also makes oci.FakeRegistry concurrency-safe via an internal mutex so
the wrapper's race test can exercise the package-index lock paths.

Closes #70

https://claude.ai/code/session_01TBM9RXVMumz89ptLnatWHG
Signed-off-by: Claude <noreply@anthropic.com>