### PR TITLE
Plumb namespace registry into Python and Maven handlers

### DIFF
--- a/pkg/commands/serve.go
+++ b/pkg/commands/serve.go
@@ -22,6 +22,7 @@ import (
 	"github.com/yolocs/ocifactory/pkg/handler/python"
 	"github.com/yolocs/ocifactory/pkg/logging"
 	"github.com/yolocs/ocifactory/pkg/metrics"
+	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
 )
 
@@ -74,6 +75,7 @@ const (
 	flagAuthnKind                       = "authn-kind"
 	flagAuthnOIDCIssuers                = "authn-oidc-issuers"
 	flagAuthnOIDCAudience               = "authn-oidc-audience"
+	flagDefaultNamespaceAllowAll        = "default-namespace-allow-all"
 	flagBackendAuthKind                 = "backend-auth-kind"
 	flagBackendAuthGCPADCScopes         = "backend-auth-gcpadc-scopes"
 	flagBackendAuthStaticEnvUserEnv     = "backend-auth-staticenv-user-env"
@@ -97,6 +99,8 @@ type serveConfig struct {
 	PythonMaxUploadBytes int64         `mapstructure:"python-max-upload-bytes"`
 	EnableMetrics        bool          `mapstructure:"enable-metrics"`
 	MetricsPath          string        `mapstructure:"metrics-path"`
+
+	DefaultNamespaceAllowAll bool `mapstructure:"default-namespace-allow-all"`
 
 	DisableAuthn      bool     `mapstructure:"disable-authn"`
 	AuthnKind         string   `mapstructure:"authn-kind"`
@@ -274,6 +278,10 @@ func registerServeFlags(flags *pflag.FlagSet) {
 		"Path on the main listener that serves Prometheus exposition. "+
 			"Operators wanting authn / network ACLs on metrics should "+
 			"front this with their own reverse proxy.")
+	flags.Bool(flagDefaultNamespaceAllowAll, false,
+		"Synthesize a dev-only default namespace with allow-all policy when "+
+			"no persisted default namespace exists. Intended for tests and local "+
+			"development only; never use in production.")
 
 	// Frontend authentication.
 	flags.Bool(flagDisableAuthn, false,
@@ -321,6 +329,10 @@ func runServe(ctx context.Context, cfg *serveConfig) error {
 	}
 	authMW := auth.Middleware(authn)
 
+	if cfg.DefaultNamespaceAllowAll {
+		logging.NewFromEnv("OCIFACTORY_").WarnContext(ctx, "--default-namespace-allow-all set; the 'default' namespace allows all requests; do not use in production")
+	}
+
 	bp, err := buildBackendAuth(ctx, cfg)
 	if err != nil {
 		return fmt.Errorf("failed to build backend credentials: %w", err)
@@ -348,7 +360,8 @@ func runServe(ctx context.Context, cfg *serveConfig) error {
 		if err != nil {
 			return fmt.Errorf("failed to create registry: %w", err)
 		}
-		mh, err := maven.NewHandler(r, maven.WithAuthMiddleware(authMW))
+		nr := namespace.NewRegistry(r, namespace.NewStore(r), namespace.WithDefaultNamespaceAllowAll(cfg.DefaultNamespaceAllowAll))
+		mh, err := maven.NewHandler(nr, maven.WithAuthMiddleware(authMW))
 		if err != nil {
 			return fmt.Errorf("failed to create maven handler: %w", err)
 		}
@@ -361,7 +374,8 @@ func runServe(ctx context.Context, cfg *serveConfig) error {
 		if err != nil {
 			return fmt.Errorf("failed to create registry: %w", err)
 		}
-		ph, err := python.NewHandler(r,
+		nr := namespace.NewRegistry(r, namespace.NewStore(r), namespace.WithDefaultNamespaceAllowAll(cfg.DefaultNamespaceAllowAll))
+		ph, err := python.NewHandler(nr,
 			python.WithSimpleIndexCacheTTL(cfg.SimpleIndexCacheTTL),
 			python.WithMaxUploadBytes(cfg.PythonMaxUploadBytes),
 			python.WithAuthMiddleware(authMW),

--- a/pkg/commands/serve.go
+++ b/pkg/commands/serve.go
@@ -361,7 +361,10 @@ func runServe(ctx context.Context, cfg *serveConfig) error {
 			return fmt.Errorf("failed to create registry: %w", err)
 		}
 		nr := namespace.NewRegistry(r, namespace.NewStore(r), namespace.WithDefaultNamespaceAllowAll(cfg.DefaultNamespaceAllowAll))
-		mh, err := maven.NewHandler(nr, maven.WithAuthMiddleware(authMW))
+		mh, err := maven.NewHandler(r,
+			maven.WithNamespaceRegistry(func(ns string) handler.Registry { return nr.For(ns) }),
+			maven.WithAuthMiddleware(authMW),
+		)
 		if err != nil {
 			return fmt.Errorf("failed to create maven handler: %w", err)
 		}
@@ -375,7 +378,8 @@ func runServe(ctx context.Context, cfg *serveConfig) error {
 			return fmt.Errorf("failed to create registry: %w", err)
 		}
 		nr := namespace.NewRegistry(r, namespace.NewStore(r), namespace.WithDefaultNamespaceAllowAll(cfg.DefaultNamespaceAllowAll))
-		ph, err := python.NewHandler(nr,
+		ph, err := python.NewHandler(r,
+			python.WithNamespaceRegistry(func(ns string) handler.Registry { return nr.For(ns) }),
 			python.WithSimpleIndexCacheTTL(cfg.SimpleIndexCacheTTL),
 			python.WithMaxUploadBytes(cfg.PythonMaxUploadBytes),
 			python.WithAuthMiddleware(authMW),

--- a/pkg/handler/integrationtest/harness.go
+++ b/pkg/handler/integrationtest/harness.go
@@ -103,6 +103,7 @@ func Start(t *testing.T, repoType string, extraArgs ...string) *Harness {
 		fmt.Sprintf("--backend-registry=%s://%s/%s", zotURL.Scheme, zotURL.Host, backendRepo),
 		fmt.Sprintf("--port=%d", port),
 		"--disable-authn",
+		"--default-namespace-allow-all",
 		// zot served over HTTP without auth needs no backend creds;
 		// "anonymous" is the default but pin it explicitly so the
 		// test isn't sensitive to default changes.

--- a/pkg/handler/maven/handler.go
+++ b/pkg/handler/maven/handler.go
@@ -2,6 +2,7 @@ package maven
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -10,8 +11,10 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
+	"github.com/yolocs/ocifactory/pkg/auth"
 	"github.com/yolocs/ocifactory/pkg/handler"
 	"github.com/yolocs/ocifactory/pkg/logging"
+	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
 	"oras.land/oras-go/v2/errdef"
 )
@@ -47,7 +50,7 @@ var (
 )
 
 type Handler struct {
-	registry handler.Registry
+	registry any
 	authMW   func(http.Handler) http.Handler
 }
 
@@ -67,10 +70,13 @@ func WithAuthMiddleware(mw func(http.Handler) http.Handler) Option {
 	}
 }
 
-func NewHandler(registry handler.Registry, opts ...Option) (*Handler, error) {
+func NewHandler(registry any, opts ...Option) (*Handler, error) {
 	cfg := handlerConfig{}
 	for _, opt := range opts {
 		opt(&cfg)
+	}
+	if registry == nil {
+		return nil, fmt.Errorf("registry must not be nil")
 	}
 	return &Handler{registry: registry, authMW: cfg.authMW}, nil
 }
@@ -83,24 +89,36 @@ func (h *Handler) Mux() http.Handler {
 		router.Use(mux.MiddlewareFunc(h.authMW))
 	}
 
+	nsRouter := router.PathPrefix("/{namespace}/maven2").Subrouter()
+
 	// 1. Archetype Catalog
-	// Handles GET, HEAD, PUT, POST for /archetype-catalog.xml
-	router.HandleFunc("/archetype-catalog.xml", h.handleArchetypeCatalog).Methods(http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPost)
+	// Handles GET, HEAD, PUT, POST for /{namespace}/maven2/archetype-catalog.xml
+	nsRouter.HandleFunc("/archetype-catalog.xml", h.handleArchetypeCatalog).Methods(http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPost)
 
 	// 2. Snapshot Metadata (e.g., group/artifact/1.0-SNAPSHOT/maven-metadata.xml)
 	// Handles GET, HEAD, PUT, POST for snapshot metadata files.
 	// Example: /{groupId}/{artifactId}/{version}-SNAPSHOT/maven-metadata.xml
-	router.HandleFunc("/{repoParts:.+}/{versionSnapshot:.+-SNAPSHOT}/maven-metadata.xml", h.handleSnapshotMetadata).Methods(http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPost)
+	nsRouter.HandleFunc("/{repoParts:.+}/{versionSnapshot:.+-SNAPSHOT}/maven-metadata.xml", h.handleSnapshotMetadata).Methods(http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPost)
 
 	// 3. Artifact Metadata (e.g., group/artifact/maven-metadata.xml or group/artifact/version/maven-metadata.xml for releases)
 	// Handles GET, HEAD, PUT, POST for non-snapshot metadata files. This must be after snapshot metadata.
 	// Example: /{groupId}/{artifactId}/maven-metadata.xml
-	router.HandleFunc("/{repoParts:.+}/maven-metadata.xml", h.handleArtifactMetadata).Methods(http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPost)
+	nsRouter.HandleFunc("/{repoParts:.+}/maven-metadata.xml", h.handleArtifactMetadata).Methods(http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPost)
 
 	// 4. Regular Artifact Files (e.g., group/artifact/version/file.jar)
 	// Handles GET, HEAD, PUT, POST for general artifact files. This is the most general route and must be last.
 	// Example: /{groupId}/{artifactId}/{version}/{filename.ext}
-	router.HandleFunc("/{repoParts:.+}/{version:.+}/{filename:.+}", h.handleRegularArtifact).Methods(http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPost)
+	nsRouter.HandleFunc("/{repoParts:.+}/{version:.+}/{filename:.+}", h.handleRegularArtifact).Methods(http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPost)
+
+	if !h.usesNamespaceRegistry() {
+		// Legacy root routes keep unit tests that pass a raw handler.Registry focused
+		// on handler semantics; production serve always passes a namespace registry
+		// and clients should use /{namespace}/maven2 routes above.
+		router.HandleFunc("/archetype-catalog.xml", h.handleArchetypeCatalog).Methods(http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPost)
+		router.HandleFunc("/{repoParts:.+}/{versionSnapshot:.+-SNAPSHOT}/maven-metadata.xml", h.handleSnapshotMetadata).Methods(http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPost)
+		router.HandleFunc("/{repoParts:.+}/maven-metadata.xml", h.handleArtifactMetadata).Methods(http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPost)
+		router.HandleFunc("/{repoParts:.+}/{version:.+}/{filename:.+}", h.handleRegularArtifact).Methods(http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPost)
+	}
 
 	return router
 }
@@ -114,9 +132,9 @@ func (h *Handler) handleArchetypeCatalog(w http.ResponseWriter, req *http.Reques
 		MediaType:  "text/xml",
 	}
 	if req.Method == http.MethodPut || req.Method == http.MethodPost {
-		h.handlePut(w, req, f)
+		h.handlePut(w, req, h.scopedRegistry(req), f)
 	} else { // GET, HEAD
-		h.handleGet(w, req, f)
+		h.handleGet(w, req, h.scopedRegistry(req), f)
 	}
 }
 
@@ -138,9 +156,9 @@ func (h *Handler) handleSnapshotMetadata(w http.ResponseWriter, req *http.Reques
 		MediaType:  "text/xml",
 	}
 	if req.Method == http.MethodPut || req.Method == http.MethodPost {
-		h.handlePut(w, req, f)
+		h.handlePut(w, req, h.scopedRegistry(req), f)
 	} else { // GET, HEAD
-		h.handleGet(w, req, f)
+		h.handleGet(w, req, h.scopedRegistry(req), f)
 	}
 }
 
@@ -161,9 +179,9 @@ func (h *Handler) handleArtifactMetadata(w http.ResponseWriter, req *http.Reques
 		MediaType:  "text/xml",
 	}
 	if req.Method == http.MethodPut || req.Method == http.MethodPost {
-		h.handlePut(w, req, f)
+		h.handlePut(w, req, h.scopedRegistry(req), f)
 	} else { // GET, HEAD
-		h.handleGet(w, req, f)
+		h.handleGet(w, req, h.scopedRegistry(req), f)
 	}
 }
 
@@ -186,24 +204,24 @@ func (h *Handler) handleRegularArtifact(w http.ResponseWriter, req *http.Request
 		MediaType:  detectMediaType(filename),
 	}
 	if req.Method == http.MethodPut || req.Method == http.MethodPost {
-		h.handlePut(w, req, f)
+		h.handlePut(w, req, h.scopedRegistry(req), f)
 	} else { // GET, HEAD
-		h.handleGet(w, req, f)
+		h.handleGet(w, req, h.scopedRegistry(req), f)
 	}
 }
 
 // handlePut processes PUT/POST requests to add a file.
-func (h *Handler) handlePut(w http.ResponseWriter, req *http.Request, f *oci.RepoFile) {
+func (h *Handler) handlePut(w http.ResponseWriter, req *http.Request, registry handler.Registry, f *oci.RepoFile) {
 	logger := logging.FromContext(req.Context())
 
 	defer req.Body.Close()
 
-	body, err := h.maybeVerifyChecksum(req, f)
+	body, err := h.maybeVerifyChecksum(req, registry, f)
 	if err != nil {
 		logger.DebugContext(req.Context(), "checksum verification failed", "error", err)
 		code := httpStatus(err)
 		if code == 0 {
-			handler.WriteError(req.Context(), w, http.StatusInternalServerError, err, "internal error")
+			writeRegistryError(req.Context(), w, err, "internal error")
 			return
 		}
 		// Checksum-validation errors carry deliberately framed
@@ -212,22 +230,14 @@ func (h *Handler) handlePut(w http.ResponseWriter, req *http.Request, f *oci.Rep
 		return
 	}
 
-	desc, err := h.registry.AddFile(req.Context(), f, body)
+	desc, err := registry.AddFile(req.Context(), f, body)
 	if err != nil {
 		logger.DebugContext(req.Context(), "failed to add file", "error", err)
 		if errors.Is(err, oci.ErrAlreadyExists) {
 			http.Error(w, "file already exists in version", http.StatusConflict)
 			return
 		}
-		if oci.HasCode(err, http.StatusUnauthorized) {
-			http.Error(w, err.Error(), http.StatusUnauthorized)
-			return
-		}
-		if oci.HasCode(err, http.StatusForbidden) {
-			http.Error(w, err.Error(), http.StatusForbidden)
-			return
-		}
-		handler.WriteError(req.Context(), w, http.StatusInternalServerError, err, "internal error")
+		writeRegistryError(req.Context(), w, err, "internal error")
 		return
 	}
 	logger.DebugContext(req.Context(), "added file", "descriptor", desc)
@@ -240,7 +250,7 @@ func (h *Handler) handlePut(w http.ResponseWriter, req *http.Request, f *oci.Rep
 // For checksum filenames it buffers the (always tiny) body, validates it
 // against the previously-uploaded companion artifact, and returns a
 // reader over the buffered bytes so AddFile still sees an io.Reader.
-func (h *Handler) maybeVerifyChecksum(req *http.Request, f *oci.RepoFile) (io.Reader, error) {
+func (h *Handler) maybeVerifyChecksum(req *http.Request, registry handler.Registry, f *oci.RepoFile) (io.Reader, error) {
 	if ext, _, _ := checksumExt(f.Name); ext == "" {
 		// Forward the HTTP Content-Length so AddFile can short-circuit
 		// the peek-and-decide buffer for sized uploads (mvn deploy
@@ -259,7 +269,7 @@ func (h *Handler) maybeVerifyChecksum(req *http.Request, f *oci.RepoFile) (io.Re
 		return nil, badRequest("checksum body exceeds %d bytes", maxChecksumBodyBytes)
 	}
 
-	if err := verifyChecksumUpload(req.Context(), h.registry, f, body); err != nil {
+	if err := verifyChecksumUpload(req.Context(), registry, f, body); err != nil {
 		return nil, err
 	}
 
@@ -267,14 +277,14 @@ func (h *Handler) maybeVerifyChecksum(req *http.Request, f *oci.RepoFile) (io.Re
 	return bytes.NewReader(body), nil
 }
 
-func (h *Handler) handleGet(w http.ResponseWriter, req *http.Request, f *oci.RepoFile) {
+func (h *Handler) handleGet(w http.ResponseWriter, req *http.Request, registry handler.Registry, f *oci.RepoFile) {
 	logger := logging.FromContext(req.Context())
 
 	// HEAD wants headers only — never redirect. The redirect path is
 	// only worth taking when the response would otherwise transfer
 	// bytes; HEAD has no egress to save.
 	if req.Method != http.MethodHead {
-		if redirectURL, err := h.registry.BlobRedirectURL(req.Context(), f); err == nil && redirectURL != "" {
+		if redirectURL, err := registry.BlobRedirectURL(req.Context(), f); err == nil && redirectURL != "" {
 			logger.DebugContext(req.Context(), "redirecting blob fetch to backend", "url", redirectURL)
 			http.Redirect(w, req, redirectURL, http.StatusTemporaryRedirect)
 			return
@@ -284,22 +294,14 @@ func (h *Handler) handleGet(w http.ResponseWriter, req *http.Request, f *oci.Rep
 		}
 	}
 
-	desc, r, err := h.registry.ReadFile(req.Context(), f)
+	desc, r, err := registry.ReadFile(req.Context(), f)
 	if err != nil {
 		logger.DebugContext(req.Context(), "failed to read file", "error", err)
 		if errors.Is(err, errdef.ErrNotFound) {
 			http.Error(w, err.Error(), http.StatusNotFound)
 			return
 		}
-		if oci.HasCode(err, http.StatusUnauthorized) {
-			http.Error(w, err.Error(), http.StatusUnauthorized)
-			return
-		}
-		if oci.HasCode(err, http.StatusForbidden) {
-			http.Error(w, err.Error(), http.StatusForbidden)
-			return
-		}
-		handler.WriteError(req.Context(), w, http.StatusInternalServerError, err, "internal error")
+		writeRegistryError(req.Context(), w, err, "internal error")
 		return
 	}
 	defer r.Close()
@@ -324,4 +326,39 @@ func detectMediaType(filename string) string {
 		return mt
 	}
 	return "application/octet-stream"
+}
+
+func (h *Handler) usesNamespaceRegistry() bool {
+	_, ok := h.registry.(interface {
+		For(string) *namespace.ScopedRegistry
+	})
+	return ok
+}
+
+func (h *Handler) scopedRegistry(req *http.Request) handler.Registry {
+	switch r := h.registry.(type) {
+	case interface {
+		For(string) *namespace.ScopedRegistry
+	}:
+		return r.For(mux.Vars(req)["namespace"])
+	case handler.Registry:
+		return r
+	default:
+		panic(fmt.Sprintf("registry has unsupported type %T", h.registry))
+	}
+}
+
+func writeRegistryError(ctx context.Context, w http.ResponseWriter, err error, public string) {
+	switch {
+	case errors.Is(err, namespace.ErrInvalidOwningRepo):
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	case errors.Is(err, namespace.ErrNotFound), errors.Is(err, errdef.ErrNotFound):
+		http.Error(w, err.Error(), http.StatusNotFound)
+	case errors.Is(err, auth.ErrUnauthorized), oci.HasCode(err, http.StatusForbidden):
+		http.Error(w, err.Error(), http.StatusForbidden)
+	case oci.HasCode(err, http.StatusUnauthorized):
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+	default:
+		handler.WriteError(ctx, w, http.StatusInternalServerError, err, public)
+	}
 }

--- a/pkg/handler/maven/handler.go
+++ b/pkg/handler/maven/handler.go
@@ -50,15 +50,17 @@ var (
 )
 
 type Handler struct {
-	registry any
-	authMW   func(http.Handler) http.Handler
+	registry     handler.Registry
+	namespaceReg func(string) handler.Registry
+	authMW       func(http.Handler) http.Handler
 }
 
 // Option configures optional Handler behaviour.
 type Option func(*handlerConfig)
 
 type handlerConfig struct {
-	authMW func(http.Handler) http.Handler
+	authMW       func(http.Handler) http.Handler
+	namespaceReg func(string) handler.Registry
 }
 
 // WithAuthMiddleware installs an authentication middleware on
@@ -70,7 +72,18 @@ func WithAuthMiddleware(mw func(http.Handler) http.Handler) Option {
 	}
 }
 
-func NewHandler(registry any, opts ...Option) (*Handler, error) {
+// WithNamespaceRegistry installs a per-request registry resolver used by
+// namespace-prefixed routes. Production serve wiring supplies this option so
+// every request is authorized and scoped by namespace before it reaches the
+// OCI backend. Tests that exercise only protocol translation omit it and use
+// the legacy root routes backed by registry directly.
+func WithNamespaceRegistry(f func(string) handler.Registry) Option {
+	return func(c *handlerConfig) {
+		c.namespaceReg = f
+	}
+}
+
+func NewHandler(registry handler.Registry, opts ...Option) (*Handler, error) {
 	cfg := handlerConfig{}
 	for _, opt := range opts {
 		opt(&cfg)
@@ -78,7 +91,7 @@ func NewHandler(registry any, opts ...Option) (*Handler, error) {
 	if registry == nil {
 		return nil, fmt.Errorf("registry must not be nil")
 	}
-	return &Handler{registry: registry, authMW: cfg.authMW}, nil
+	return &Handler{registry: registry, namespaceReg: cfg.namespaceReg, authMW: cfg.authMW}, nil
 }
 
 func (h *Handler) Mux() http.Handler {
@@ -89,38 +102,21 @@ func (h *Handler) Mux() http.Handler {
 		router.Use(mux.MiddlewareFunc(h.authMW))
 	}
 
-	nsRouter := router.PathPrefix("/{namespace}/maven2").Subrouter()
-
-	// 1. Archetype Catalog
-	// Handles GET, HEAD, PUT, POST for /{namespace}/maven2/archetype-catalog.xml
-	nsRouter.HandleFunc("/archetype-catalog.xml", h.handleArchetypeCatalog).Methods(http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPost)
-
-	// 2. Snapshot Metadata (e.g., group/artifact/1.0-SNAPSHOT/maven-metadata.xml)
-	// Handles GET, HEAD, PUT, POST for snapshot metadata files.
-	// Example: /{groupId}/{artifactId}/{version}-SNAPSHOT/maven-metadata.xml
-	nsRouter.HandleFunc("/{repoParts:.+}/{versionSnapshot:.+-SNAPSHOT}/maven-metadata.xml", h.handleSnapshotMetadata).Methods(http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPost)
-
-	// 3. Artifact Metadata (e.g., group/artifact/maven-metadata.xml or group/artifact/version/maven-metadata.xml for releases)
-	// Handles GET, HEAD, PUT, POST for non-snapshot metadata files. This must be after snapshot metadata.
-	// Example: /{groupId}/{artifactId}/maven-metadata.xml
-	nsRouter.HandleFunc("/{repoParts:.+}/maven-metadata.xml", h.handleArtifactMetadata).Methods(http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPost)
-
-	// 4. Regular Artifact Files (e.g., group/artifact/version/file.jar)
-	// Handles GET, HEAD, PUT, POST for general artifact files. This is the most general route and must be last.
-	// Example: /{groupId}/{artifactId}/{version}/{filename.ext}
-	nsRouter.HandleFunc("/{repoParts:.+}/{version:.+}/{filename:.+}", h.handleRegularArtifact).Methods(http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPost)
-
-	if !h.usesNamespaceRegistry() {
-		// Legacy root routes keep unit tests that pass a raw handler.Registry focused
-		// on handler semantics; production serve always passes a namespace registry
-		// and clients should use /{namespace}/maven2 routes above.
-		router.HandleFunc("/archetype-catalog.xml", h.handleArchetypeCatalog).Methods(http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPost)
-		router.HandleFunc("/{repoParts:.+}/{versionSnapshot:.+-SNAPSHOT}/maven-metadata.xml", h.handleSnapshotMetadata).Methods(http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPost)
-		router.HandleFunc("/{repoParts:.+}/maven-metadata.xml", h.handleArtifactMetadata).Methods(http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPost)
-		router.HandleFunc("/{repoParts:.+}/{version:.+}/{filename:.+}", h.handleRegularArtifact).Methods(http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPost)
+	if h.namespaceReg != nil {
+		nsRouter := router.PathPrefix("/{namespace}/maven2").Subrouter()
+		registerRoutes(nsRouter, h)
+	} else {
+		registerRoutes(router, h)
 	}
 
 	return router
+}
+
+func registerRoutes(router *mux.Router, h *Handler) {
+	router.HandleFunc("/archetype-catalog.xml", h.handleArchetypeCatalog).Methods(http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPost)
+	router.HandleFunc("/{repoParts:.+}/{versionSnapshot:.+-SNAPSHOT}/maven-metadata.xml", h.handleSnapshotMetadata).Methods(http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPost)
+	router.HandleFunc("/{repoParts:.+}/maven-metadata.xml", h.handleArtifactMetadata).Methods(http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPost)
+	router.HandleFunc("/{repoParts:.+}/{version:.+}/{filename:.+}", h.handleRegularArtifact).Methods(http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPost)
 }
 
 // handleArchetypeCatalog handles requests for archetype-catalog.xml.
@@ -328,24 +324,11 @@ func detectMediaType(filename string) string {
 	return "application/octet-stream"
 }
 
-func (h *Handler) usesNamespaceRegistry() bool {
-	_, ok := h.registry.(interface {
-		For(string) *namespace.ScopedRegistry
-	})
-	return ok
-}
-
 func (h *Handler) scopedRegistry(req *http.Request) handler.Registry {
-	switch r := h.registry.(type) {
-	case interface {
-		For(string) *namespace.ScopedRegistry
-	}:
-		return r.For(mux.Vars(req)["namespace"])
-	case handler.Registry:
-		return r
-	default:
-		panic(fmt.Sprintf("registry has unsupported type %T", h.registry))
+	if h.namespaceReg != nil {
+		return h.namespaceReg(mux.Vars(req)["namespace"])
 	}
+	return h.registry
 }
 
 func writeRegistryError(ctx context.Context, w http.ResponseWriter, err error, public string) {

--- a/pkg/handler/maven/integration_test.go
+++ b/pkg/handler/maven/integration_test.go
@@ -45,7 +45,7 @@ func TestMavenIntegration_RealClients(t *testing.T) {
 		// for the same reason.
 		"--allow-overwrite=true",
 	)
-	base := h.OcifactoryURL.String()
+	base := h.OcifactoryURL.String() + "/default/maven2"
 
 	// Subtests are NOT t.Parallel(): both deploys would race on
 	// /com/example/test/hello/maven-metadata.xml (the artifact-level

--- a/pkg/handler/maven/namespace_test.go
+++ b/pkg/handler/maven/namespace_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/yolocs/ocifactory/pkg/auth"
+	"github.com/yolocs/ocifactory/pkg/handler"
 	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
 )
@@ -19,7 +20,7 @@ func TestNamespaceRoutes(t *testing.T) {
 	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
 	putMavenNamespace(t, store, "alpha", allowMavenSubjectSpec())
 	putMavenNamespace(t, store, "beta", allowMavenSubjectSpec())
-	h, err := NewHandler(reg)
+	h, err := NewHandler(fake, WithNamespaceRegistry(func(ns string) handler.Registry { return reg.For(ns) }))
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)
 	}
@@ -62,7 +63,7 @@ func TestNamespaceRoutesForbidden(t *testing.T) {
 	store := namespace.NewStore(fake)
 	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
 	putMavenNamespace(t, store, "alpha", namespace.Spec{Policy: namespace.Policy{Readers: []namespace.SubjectMatcher{{Issuer: "other"}}, Writers: []namespace.SubjectMatcher{{Issuer: "other"}}}})
-	h, err := NewHandler(reg)
+	h, err := NewHandler(fake, WithNamespaceRegistry(func(ns string) handler.Registry { return reg.For(ns) }))
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)
 	}

--- a/pkg/handler/maven/namespace_test.go
+++ b/pkg/handler/maven/namespace_test.go
@@ -1,0 +1,86 @@
+package maven
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/yolocs/ocifactory/pkg/auth"
+	"github.com/yolocs/ocifactory/pkg/namespace"
+	"github.com/yolocs/ocifactory/pkg/oci"
+)
+
+func TestNamespaceRoutes(t *testing.T) {
+	t.Parallel()
+
+	fake := oci.NewFakeRegistry()
+	store := namespace.NewStore(fake)
+	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	putMavenNamespace(t, store, "alpha", allowMavenSubjectSpec())
+	putMavenNamespace(t, store, "beta", allowMavenSubjectSpec())
+	h, err := NewHandler(reg)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	mux := h.Mux()
+	ctx := auth.WithAuthContext(t.Context(), &auth.AuthContext{Issuer: "issuer", ID: "alice"})
+
+	req := httptest.NewRequest(http.MethodPut, "/alpha/maven2/com/example/demo/1.0.0/demo-1.0.0.jar", strings.NewReader("jar"))
+	req = req.WithContext(ctx)
+	resp := httptest.NewRecorder()
+	mux.ServeHTTP(resp, req)
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("put status=%d body=%s", resp.Code, resp.Body.String())
+	}
+
+	for _, tc := range []struct {
+		name string
+		url  string
+		want int
+	}{
+		{name: "same namespace", url: "/alpha/maven2/com/example/demo/1.0.0/demo-1.0.0.jar", want: http.StatusOK},
+		{name: "other namespace", url: "/beta/maven2/com/example/demo/1.0.0/demo-1.0.0.jar", want: http.StatusNotFound},
+		{name: "unknown namespace", url: "/missing/maven2/com/example/demo/1.0.0/demo-1.0.0.jar", want: http.StatusNotFound},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(http.MethodGet, tc.url, nil).WithContext(ctx)
+			resp := httptest.NewRecorder()
+			mux.ServeHTTP(resp, req)
+			if resp.Code != tc.want {
+				t.Errorf("status=%d want=%d body=%s", resp.Code, tc.want, resp.Body.String())
+			}
+		})
+	}
+}
+
+func TestNamespaceRoutesForbidden(t *testing.T) {
+	t.Parallel()
+
+	fake := oci.NewFakeRegistry()
+	store := namespace.NewStore(fake)
+	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	putMavenNamespace(t, store, "alpha", namespace.Spec{Policy: namespace.Policy{Readers: []namespace.SubjectMatcher{{Issuer: "other"}}, Writers: []namespace.SubjectMatcher{{Issuer: "other"}}}})
+	h, err := NewHandler(reg)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/alpha/maven2/com/example/demo/1.0.0/demo-1.0.0.jar", nil).WithContext(auth.WithAuthContext(t.Context(), &auth.AuthContext{Issuer: "issuer", ID: "alice"}))
+	resp := httptest.NewRecorder()
+	h.Mux().ServeHTTP(resp, req)
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("status=%d want=%d body=%s", resp.Code, http.StatusForbidden, resp.Body.String())
+	}
+}
+
+func putMavenNamespace(t *testing.T, store *namespace.Store, name string, spec namespace.Spec) {
+	t.Helper()
+	if err := store.Put(t.Context(), &namespace.Namespace{Name: name, Spec: spec}); err != nil {
+		t.Fatalf("put namespace %s: %v", name, err)
+	}
+}
+
+func allowMavenSubjectSpec() namespace.Spec {
+	return namespace.Spec{Policy: namespace.Policy{Readers: []namespace.SubjectMatcher{{Issuer: "issuer"}}, Writers: []namespace.SubjectMatcher{{Issuer: "issuer"}}}}
+}

--- a/pkg/handler/python/handler.go
+++ b/pkg/handler/python/handler.go
@@ -16,8 +16,10 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/yolocs/ocifactory/pkg/auth"
 	"github.com/yolocs/ocifactory/pkg/handler"
 	"github.com/yolocs/ocifactory/pkg/logging"
+	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
 	"github.com/yolocs/ocifactory/pkg/renderer"
 	"oras.land/oras-go/v2/errdef"
@@ -89,7 +91,7 @@ var (
 )
 
 type Handler struct {
-	registry       handler.Registry
+	registry       any
 	renderer       *renderer.Renderer
 	indexCache     *simpleIndexCache
 	authMW         func(http.Handler) http.Handler
@@ -141,13 +143,16 @@ func WithAuthMiddleware(mw func(http.Handler) http.Handler) Option {
 }
 
 // NewHandler creates a new Handler.
-func NewHandler(registry handler.Registry, opts ...Option) (*Handler, error) {
+func NewHandler(registry any, opts ...Option) (*Handler, error) {
 	cfg := handlerConfig{
 		simpleIndexCacheTTL: DefaultSimpleIndexCacheTTL,
 		maxUploadBytes:      DefaultMaxUploadBytes,
 	}
 	for _, opt := range opts {
 		opt(&cfg)
+	}
+	if registry == nil {
+		return nil, fmt.Errorf("registry must not be nil")
 	}
 	r, err := renderer.New(fs)
 	if err != nil {
@@ -183,15 +188,30 @@ func (h *Handler) Mux() http.Handler {
 	}
 
 	// Handle both pip and twine operations
-	router.HandleFunc("/", h.handleFilePut).Methods("PUT", "POST").Name("write")
+	nsRouter := router.PathPrefix("/{namespace}").Subrouter()
 
-	router.HandleFunc("/packages/{package}/{version}/{filename}", h.handleFileGet).Methods("GET", "HEAD").Name("read")
+	// Handle both pip and twine operations.
+	nsRouter.HandleFunc("/", h.handleFilePut).Methods("PUT", "POST").Name("write")
 
-	router.HandleFunc("/simple/{package}/", h.handlePackageIndex).Methods("GET").Name("list")
-	router.HandleFunc("/simple/{package}", h.handlePackageIndex).Methods("GET").Name("list")
+	nsRouter.HandleFunc("/packages/{package}/{version}/{filename}", h.handleFileGet).Methods("GET", "HEAD").Name("read")
 
-	router.HandleFunc("/simple/", h.handleSimpleIndex).Methods("GET").Name("list")
-	router.HandleFunc("/simple", h.handleSimpleIndex).Methods("GET").Name("list")
+	nsRouter.HandleFunc("/simple/{package}/", h.handlePackageIndex).Methods("GET").Name("list")
+	nsRouter.HandleFunc("/simple/{package}", h.handlePackageIndex).Methods("GET").Name("list")
+
+	nsRouter.HandleFunc("/simple/", h.handleSimpleIndex).Methods("GET").Name("list")
+	nsRouter.HandleFunc("/simple", h.handleSimpleIndex).Methods("GET").Name("list")
+
+	if !h.usesNamespaceRegistry() {
+		// Legacy root routes keep unit tests that pass a raw handler.Registry focused
+		// on handler semantics; production serve always passes a namespace registry
+		// and clients should use the namespace-prefixed routes above.
+		router.HandleFunc("/", h.handleFilePut).Methods("PUT", "POST").Name("write")
+		router.HandleFunc("/packages/{package}/{version}/{filename}", h.handleFileGet).Methods("GET", "HEAD").Name("read")
+		router.HandleFunc("/simple/{package}/", h.handlePackageIndex).Methods("GET").Name("list")
+		router.HandleFunc("/simple/{package}", h.handlePackageIndex).Methods("GET").Name("list")
+		router.HandleFunc("/simple/", h.handleSimpleIndex).Methods("GET").Name("list")
+		router.HandleFunc("/simple", h.handleSimpleIndex).Methods("GET").Name("list")
+	}
 
 	return router
 }
@@ -201,9 +221,10 @@ func (h *Handler) Mux() http.Handler {
 // (already-normalized) package name; ListTags is enough to enumerate
 // them.
 func (h *Handler) handleSimpleIndex(w http.ResponseWriter, req *http.Request) {
-	tags, err := h.registry.ListTags(req.Context(), "index")
+	registry := h.scopedRegistry(req)
+	tags, err := registry.ListTags(req.Context(), "index")
 	if err != nil && !errors.Is(err, errdef.ErrNotFound) {
-		handler.WriteError(req.Context(), w, http.StatusInternalServerError, err, "failed to list package index")
+		writeRegistryError(req.Context(), w, err, "failed to list package index")
 		return
 	}
 
@@ -219,7 +240,7 @@ func (h *Handler) handleSimpleIndex(w http.ResponseWriter, req *http.Request) {
 			URL: (&url.URL{
 				Scheme: req.URL.Scheme,
 				Host:   req.URL.Host,
-				Path:   "/simple/" + tag + "/",
+				Path:   namespacePrefix(req) + "/simple/" + tag + "/",
 			}).String(),
 		})
 	}
@@ -345,7 +366,8 @@ func (h *Handler) handleFilePut(w http.ResponseWriter, req *http.Request) {
 		Name:       contentName,
 		MediaType:  detectMediaType(contentName),
 	}
-	if !h.streamAddFile(ctx, w, wheelRF, contentPart) {
+	registry := h.scopedRegistry(req)
+	if !h.streamAddFile(ctx, w, registry, wheelRF, contentPart) {
 		return
 	}
 
@@ -363,16 +385,20 @@ func (h *Handler) handleFilePut(w http.ResponseWriter, req *http.Request) {
 	// same call /simple/ already makes on the read side), so we
 	// trade an extra round-trip per upload for a clean immutable
 	// AddFile contract.
-	if err := h.ensureIndexSentinel(ctx, normalizedName); err != nil {
+	if err := h.ensureIndexSentinel(ctx, registry, normalizedName); err != nil {
 		logger.DebugContext(ctx, "failed to ensure index sentinel", "error", err)
 		var maxBytesErr *http.MaxBytesError
 		switch {
 		case errors.As(err, &maxBytesErr):
 			http.Error(w, fmt.Sprintf("upload exceeds %d-byte limit", maxBytesErr.Limit), http.StatusRequestEntityTooLarge)
+		case errors.Is(err, namespace.ErrInvalidOwningRepo):
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		case errors.Is(err, namespace.ErrNotFound) || errors.Is(err, errdef.ErrNotFound):
+			http.Error(w, err.Error(), http.StatusNotFound)
+		case errors.Is(err, auth.ErrUnauthorized) || oci.HasCode(err, http.StatusForbidden):
+			http.Error(w, err.Error(), http.StatusForbidden)
 		case oci.HasCode(err, http.StatusUnauthorized):
 			http.Error(w, err.Error(), http.StatusUnauthorized)
-		case oci.HasCode(err, http.StatusForbidden):
-			http.Error(w, err.Error(), http.StatusForbidden)
 		default:
 			handler.WriteError(ctx, w, http.StatusInternalServerError, err, "internal error")
 		}
@@ -396,7 +422,7 @@ func (h *Handler) handleFilePut(w http.ResponseWriter, req *http.Request) {
 		_ = p.Close()
 	}
 
-	h.indexCache.invalidate(normalizedName)
+	h.indexCache.invalidate(cacheKey(namespaceFromRequest(req), normalizedName))
 	w.WriteHeader(http.StatusCreated)
 }
 
@@ -409,8 +435,8 @@ func (h *Handler) handleFilePut(w http.ResponseWriter, req *http.Request) {
 // errdef.ErrNotFound from ListTags is treated as "no packages yet"
 // (zot returns it for empty repositories), matching how
 // handleSimpleIndex already absorbs the same shape.
-func (h *Handler) ensureIndexSentinel(ctx context.Context, normalizedName string) error {
-	tags, err := h.registry.ListTags(ctx, "index")
+func (h *Handler) ensureIndexSentinel(ctx context.Context, registry handler.Registry, normalizedName string) error {
+	tags, err := registry.ListTags(ctx, "index")
 	if err != nil && !errors.Is(err, errdef.ErrNotFound) {
 		return fmt.Errorf("list index tags: %w", err)
 	}
@@ -426,7 +452,7 @@ func (h *Handler) ensureIndexSentinel(ctx context.Context, normalizedName string
 		MediaType:  "text/plain",
 		Size:       int64(len(indexSentinelContent)),
 	}
-	if _, err := h.registry.AddFile(ctx, sentinelRF, strings.NewReader(indexSentinelContent)); err != nil {
+	if _, err := registry.AddFile(ctx, sentinelRF, strings.NewReader(indexSentinelContent)); err != nil {
 		return fmt.Errorf("add index sentinel: %w", err)
 	}
 	return nil
@@ -473,9 +499,9 @@ func writeMultipartReadError(w http.ResponseWriter, err error, logger *slog.Logg
 // MaxBytesError is detected inline so a request body that overflows
 // h.maxUploadBytes mid-stream (e.g. while AddFile is reading the wheel
 // body) returns 413 instead of a generic 500.
-func (h *Handler) streamAddFile(ctx context.Context, w http.ResponseWriter, f *oci.RepoFile, content io.Reader) bool {
+func (h *Handler) streamAddFile(ctx context.Context, w http.ResponseWriter, registry handler.Registry, f *oci.RepoFile, content io.Reader) bool {
 	logger := logging.FromContext(ctx)
-	desc, err := h.registry.AddFile(ctx, f, content)
+	desc, err := registry.AddFile(ctx, f, content)
 	if err != nil {
 		logger.DebugContext(ctx, "failed to add file", "error", err)
 		var maxBytesErr *http.MaxBytesError
@@ -484,10 +510,14 @@ func (h *Handler) streamAddFile(ctx context.Context, w http.ResponseWriter, f *o
 			http.Error(w, fmt.Sprintf("upload exceeds %d-byte limit", maxBytesErr.Limit), http.StatusRequestEntityTooLarge)
 		case errors.Is(err, oci.ErrAlreadyExists):
 			http.Error(w, "file already exists in version", http.StatusConflict)
+		case errors.Is(err, namespace.ErrInvalidOwningRepo):
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		case errors.Is(err, namespace.ErrNotFound) || errors.Is(err, errdef.ErrNotFound):
+			http.Error(w, err.Error(), http.StatusNotFound)
+		case errors.Is(err, auth.ErrUnauthorized) || oci.HasCode(err, http.StatusForbidden):
+			http.Error(w, err.Error(), http.StatusForbidden)
 		case oci.HasCode(err, http.StatusUnauthorized):
 			http.Error(w, err.Error(), http.StatusUnauthorized)
-		case oci.HasCode(err, http.StatusForbidden):
-			http.Error(w, err.Error(), http.StatusForbidden)
 		default:
 			handler.WriteError(ctx, w, http.StatusInternalServerError, err, "internal error")
 		}
@@ -516,7 +546,7 @@ func (h *Handler) handleFileGet(w http.ResponseWriter, req *http.Request) {
 		MediaType:  detectMediaType(filename),
 	}
 
-	h.handleGet(w, req, f)
+	h.handleGet(w, req, h.scopedRegistry(req), f)
 }
 
 func (h *Handler) handlePackageIndex(w http.ResponseWriter, req *http.Request) {
@@ -528,27 +558,20 @@ func (h *Handler) handlePackageIndex(w http.ResponseWriter, req *http.Request) {
 	}
 	pkg = normalize(pkg)
 
-	files, ok := h.indexCache.get(pkg)
+	key := cacheKey(namespaceFromRequest(req), pkg)
+	files, ok := h.indexCache.get(key)
 	if !ok {
 		var err error
-		files, err = h.resolvePackageFiles(req.Context(), pkg)
+		files, err = h.resolvePackageFiles(req.Context(), h.scopedRegistry(req), pkg)
 		if err != nil {
-			if errors.Is(err, errdef.ErrNotFound) {
+			if errors.Is(err, namespace.ErrNotFound) || errors.Is(err, errdef.ErrNotFound) {
 				http.Error(w, err.Error(), http.StatusNotFound)
 				return
 			}
-			if oci.HasCode(err, http.StatusUnauthorized) {
-				http.Error(w, err.Error(), http.StatusUnauthorized)
-				return
-			}
-			if oci.HasCode(err, http.StatusForbidden) {
-				http.Error(w, err.Error(), http.StatusForbidden)
-				return
-			}
-			handler.WriteError(req.Context(), w, http.StatusInternalServerError, err, "internal error")
+			writeRegistryError(req.Context(), w, err, "internal error")
 			return
 		}
-		h.indexCache.put(pkg, files)
+		h.indexCache.put(key, files)
 	}
 
 	rendered := make([]indexFile, 0, len(files))
@@ -570,8 +593,8 @@ func (h *Handler) handlePackageIndex(w http.ResponseWriter, req *http.Request) {
 // resolvePackageFiles enumerates a package's files. The returned slice
 // is what goes into the simple-index cache; both HTML and JSON
 // renderers pivot off it.
-func (h *Handler) resolvePackageFiles(ctx context.Context, pkg string) ([]cachedFile, error) {
-	rawFiles, err := h.registry.ListFiles(ctx, "packages/"+pkg)
+func (h *Handler) resolvePackageFiles(ctx context.Context, registry handler.Registry, pkg string) ([]cachedFile, error) {
+	rawFiles, err := registry.ListFiles(ctx, "packages/"+pkg)
 	if err != nil {
 		return nil, err
 	}
@@ -591,7 +614,7 @@ func renderedFileURL(req *http.Request, pkg string, f cachedFile) string {
 	u := url.URL{
 		Scheme: req.URL.Scheme,
 		Host:   req.URL.Host,
-		Path:   fmt.Sprintf("/packages/%s/%s/%s", pkg, f.OwningTag, f.Filename),
+		Path:   fmt.Sprintf("%s/packages/%s/%s/%s", namespacePrefix(req), pkg, f.OwningTag, f.Filename),
 	}
 	if f.Sha256 != "" {
 		u.Fragment = "sha256=" + f.Sha256
@@ -599,14 +622,14 @@ func renderedFileURL(req *http.Request, pkg string, f cachedFile) string {
 	return u.String()
 }
 
-func (h *Handler) handleGet(w http.ResponseWriter, req *http.Request, f *oci.RepoFile) {
+func (h *Handler) handleGet(w http.ResponseWriter, req *http.Request, registry handler.Registry, f *oci.RepoFile) {
 	logger := logging.FromContext(req.Context())
 
 	// HEAD wants headers only — never redirect. The redirect path is
 	// only worth taking when the response would otherwise transfer
 	// bytes; HEAD has no egress to save.
 	if req.Method != http.MethodHead {
-		if redirectURL, err := h.registry.BlobRedirectURL(req.Context(), f); err == nil && redirectURL != "" {
+		if redirectURL, err := registry.BlobRedirectURL(req.Context(), f); err == nil && redirectURL != "" {
 			logger.DebugContext(req.Context(), "redirecting blob fetch to backend", "url", redirectURL)
 			http.Redirect(w, req, redirectURL, http.StatusTemporaryRedirect)
 			return
@@ -616,22 +639,10 @@ func (h *Handler) handleGet(w http.ResponseWriter, req *http.Request, f *oci.Rep
 		}
 	}
 
-	desc, r, err := h.registry.ReadFile(req.Context(), f)
+	desc, r, err := registry.ReadFile(req.Context(), f)
 	if err != nil {
 		logger.DebugContext(req.Context(), "failed to read file", "error", err)
-		if errors.Is(err, errdef.ErrNotFound) {
-			http.Error(w, err.Error(), http.StatusNotFound)
-			return
-		}
-		if oci.HasCode(err, http.StatusUnauthorized) {
-			http.Error(w, err.Error(), http.StatusUnauthorized)
-			return
-		}
-		if oci.HasCode(err, http.StatusForbidden) {
-			http.Error(w, err.Error(), http.StatusForbidden)
-			return
-		}
-		handler.WriteError(req.Context(), w, http.StatusInternalServerError, err, "internal error")
+		writeRegistryError(req.Context(), w, err, "internal error")
 		return
 	}
 	defer r.Close()
@@ -656,4 +667,57 @@ func detectMediaType(filename string) string {
 		return mt
 	}
 	return "application/octet-stream"
+}
+
+func (h *Handler) usesNamespaceRegistry() bool {
+	_, ok := h.registry.(interface {
+		For(string) *namespace.ScopedRegistry
+	})
+	return ok
+}
+
+func (h *Handler) scopedRegistry(req *http.Request) handler.Registry {
+	switch r := h.registry.(type) {
+	case interface {
+		For(string) *namespace.ScopedRegistry
+	}:
+		return r.For(namespaceFromRequest(req))
+	case handler.Registry:
+		return r
+	default:
+		panic(fmt.Sprintf("registry has unsupported type %T", h.registry))
+	}
+}
+
+func namespaceFromRequest(req *http.Request) string {
+	if ns := mux.Vars(req)["namespace"]; ns != "" {
+		return ns
+	}
+	return ""
+}
+
+func namespacePrefix(req *http.Request) string {
+	if ns := namespaceFromRequest(req); ns != "" {
+		return "/" + ns
+	}
+	return ""
+}
+
+func cacheKey(namespace, pkg string) string {
+	return namespace + "/" + pkg
+}
+
+func writeRegistryError(ctx context.Context, w http.ResponseWriter, err error, public string) {
+	switch {
+	case errors.Is(err, namespace.ErrInvalidOwningRepo):
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	case errors.Is(err, namespace.ErrNotFound), errors.Is(err, errdef.ErrNotFound):
+		http.Error(w, err.Error(), http.StatusNotFound)
+	case errors.Is(err, auth.ErrUnauthorized), oci.HasCode(err, http.StatusForbidden):
+		http.Error(w, err.Error(), http.StatusForbidden)
+	case oci.HasCode(err, http.StatusUnauthorized):
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+	default:
+		handler.WriteError(ctx, w, http.StatusInternalServerError, err, public)
+	}
 }

--- a/pkg/handler/python/handler.go
+++ b/pkg/handler/python/handler.go
@@ -91,7 +91,8 @@ var (
 )
 
 type Handler struct {
-	registry       any
+	registry       handler.Registry
+	namespaceReg   func(string) handler.Registry
 	renderer       *renderer.Renderer
 	indexCache     *simpleIndexCache
 	authMW         func(http.Handler) http.Handler
@@ -104,6 +105,7 @@ type Option func(*handlerConfig)
 type handlerConfig struct {
 	simpleIndexCacheTTL time.Duration
 	authMW              func(http.Handler) http.Handler
+	namespaceReg        func(string) handler.Registry
 	maxUploadBytes      int64
 }
 
@@ -142,8 +144,19 @@ func WithAuthMiddleware(mw func(http.Handler) http.Handler) Option {
 	}
 }
 
+// WithNamespaceRegistry installs a per-request registry resolver used by
+// namespace-prefixed routes. Production serve wiring supplies this option so
+// every request is authorized and scoped by namespace before it reaches the
+// OCI backend. Tests that exercise only protocol translation omit it and use
+// the legacy root routes backed by registry directly.
+func WithNamespaceRegistry(f func(string) handler.Registry) Option {
+	return func(c *handlerConfig) {
+		c.namespaceReg = f
+	}
+}
+
 // NewHandler creates a new Handler.
-func NewHandler(registry any, opts ...Option) (*Handler, error) {
+func NewHandler(registry handler.Registry, opts ...Option) (*Handler, error) {
 	cfg := handlerConfig{
 		simpleIndexCacheTTL: DefaultSimpleIndexCacheTTL,
 		maxUploadBytes:      DefaultMaxUploadBytes,
@@ -160,6 +173,7 @@ func NewHandler(registry any, opts ...Option) (*Handler, error) {
 	}
 	return &Handler{
 		registry:       registry,
+		namespaceReg:   cfg.namespaceReg,
 		renderer:       r,
 		indexCache:     newSimpleIndexCache(cfg.simpleIndexCacheTTL),
 		authMW:         cfg.authMW,
@@ -187,33 +201,23 @@ func (h *Handler) Mux() http.Handler {
 		router.Use(mux.MiddlewareFunc(h.authMW))
 	}
 
-	// Handle both pip and twine operations
-	nsRouter := router.PathPrefix("/{namespace}").Subrouter()
-
-	// Handle both pip and twine operations.
-	nsRouter.HandleFunc("/", h.handleFilePut).Methods("PUT", "POST").Name("write")
-
-	nsRouter.HandleFunc("/packages/{package}/{version}/{filename}", h.handleFileGet).Methods("GET", "HEAD").Name("read")
-
-	nsRouter.HandleFunc("/simple/{package}/", h.handlePackageIndex).Methods("GET").Name("list")
-	nsRouter.HandleFunc("/simple/{package}", h.handlePackageIndex).Methods("GET").Name("list")
-
-	nsRouter.HandleFunc("/simple/", h.handleSimpleIndex).Methods("GET").Name("list")
-	nsRouter.HandleFunc("/simple", h.handleSimpleIndex).Methods("GET").Name("list")
-
-	if !h.usesNamespaceRegistry() {
-		// Legacy root routes keep unit tests that pass a raw handler.Registry focused
-		// on handler semantics; production serve always passes a namespace registry
-		// and clients should use the namespace-prefixed routes above.
-		router.HandleFunc("/", h.handleFilePut).Methods("PUT", "POST").Name("write")
-		router.HandleFunc("/packages/{package}/{version}/{filename}", h.handleFileGet).Methods("GET", "HEAD").Name("read")
-		router.HandleFunc("/simple/{package}/", h.handlePackageIndex).Methods("GET").Name("list")
-		router.HandleFunc("/simple/{package}", h.handlePackageIndex).Methods("GET").Name("list")
-		router.HandleFunc("/simple/", h.handleSimpleIndex).Methods("GET").Name("list")
-		router.HandleFunc("/simple", h.handleSimpleIndex).Methods("GET").Name("list")
+	if h.namespaceReg != nil {
+		nsRouter := router.PathPrefix("/{namespace}").Subrouter()
+		registerRoutes(nsRouter, h)
+	} else {
+		registerRoutes(router, h)
 	}
 
 	return router
+}
+
+func registerRoutes(router *mux.Router, h *Handler) {
+	router.HandleFunc("/", h.handleFilePut).Methods("PUT", "POST").Name("write")
+	router.HandleFunc("/packages/{package}/{version}/{filename}", h.handleFileGet).Methods("GET", "HEAD").Name("read")
+	router.HandleFunc("/simple/{package}/", h.handlePackageIndex).Methods("GET").Name("list")
+	router.HandleFunc("/simple/{package}", h.handlePackageIndex).Methods("GET").Name("list")
+	router.HandleFunc("/simple/", h.handleSimpleIndex).Methods("GET").Name("list")
+	router.HandleFunc("/simple", h.handleSimpleIndex).Methods("GET").Name("list")
 }
 
 // handleSimpleIndex renders the root simple index — the list of every
@@ -669,24 +673,11 @@ func detectMediaType(filename string) string {
 	return "application/octet-stream"
 }
 
-func (h *Handler) usesNamespaceRegistry() bool {
-	_, ok := h.registry.(interface {
-		For(string) *namespace.ScopedRegistry
-	})
-	return ok
-}
-
 func (h *Handler) scopedRegistry(req *http.Request) handler.Registry {
-	switch r := h.registry.(type) {
-	case interface {
-		For(string) *namespace.ScopedRegistry
-	}:
-		return r.For(namespaceFromRequest(req))
-	case handler.Registry:
-		return r
-	default:
-		panic(fmt.Sprintf("registry has unsupported type %T", h.registry))
+	if h.namespaceReg != nil {
+		return h.namespaceReg(namespaceFromRequest(req))
 	}
+	return h.registry
 }
 
 func namespaceFromRequest(req *http.Request) string {

--- a/pkg/handler/python/integration_test.go
+++ b/pkg/handler/python/integration_test.go
@@ -97,7 +97,7 @@ func TestPythonIntegration_RealClients(t *testing.T) {
 			"install",
 			"--no-cache-dir",
 			"--no-deps",
-			"--index-url", h.OcifactoryURL.String()+"/simple/",
+			"--index-url", h.OcifactoryURL.String()+"/default/simple/",
 			"--trusted-host", trustedHostFromBase(t, h.OcifactoryURL.String()),
 			fmt.Sprintf("%s==%s", pkgName, version),
 		)
@@ -113,7 +113,7 @@ func uploadWithTwine(t *testing.T, base string, whl *testWheel) {
 
 	cmd := exec.Command(
 		"twine", "upload",
-		"--repository-url", base+"/",
+		"--repository-url", base+"/default/",
 		"--non-interactive",
 		"--disable-progress-bar",
 		"--verbose",
@@ -140,7 +140,7 @@ func downloadAndCheck(t *testing.T, base, pkgName, version string, whl *testWhee
 		"--no-cache-dir",
 		"--no-deps",
 		"--dest", dst,
-		"--index-url", base+"/simple/",
+		"--index-url", base+"/default/simple/",
 		"--trusted-host", trustedHostFromBase(t, base),
 		fmt.Sprintf("%s==%s", pkgName, version),
 	)

--- a/pkg/handler/python/namespace_test.go
+++ b/pkg/handler/python/namespace_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/yolocs/ocifactory/pkg/auth"
+	"github.com/yolocs/ocifactory/pkg/handler"
 	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
 )
@@ -21,7 +22,7 @@ func TestNamespaceRoutes(t *testing.T) {
 	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
 	putPythonNamespace(t, store, "alpha", allowPythonSubjectSpec())
 	putPythonNamespace(t, store, "beta", allowPythonSubjectSpec())
-	h, err := NewHandler(reg)
+	h, err := NewHandler(fake, WithNamespaceRegistry(func(ns string) handler.Registry { return reg.For(ns) }))
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)
 	}
@@ -66,7 +67,7 @@ func TestNamespaceRoutesForbidden(t *testing.T) {
 	store := namespace.NewStore(fake)
 	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
 	putPythonNamespace(t, store, "alpha", namespace.Spec{Policy: namespace.Policy{Readers: []namespace.SubjectMatcher{{Issuer: "other"}}, Writers: []namespace.SubjectMatcher{{Issuer: "other"}}}})
-	h, err := NewHandler(reg)
+	h, err := NewHandler(fake, WithNamespaceRegistry(func(ns string) handler.Registry { return reg.For(ns) }))
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)
 	}

--- a/pkg/handler/python/namespace_test.go
+++ b/pkg/handler/python/namespace_test.go
@@ -1,0 +1,113 @@
+package python
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/yolocs/ocifactory/pkg/auth"
+	"github.com/yolocs/ocifactory/pkg/namespace"
+	"github.com/yolocs/ocifactory/pkg/oci"
+)
+
+func TestNamespaceRoutes(t *testing.T) {
+	t.Parallel()
+
+	fake := oci.NewFakeRegistry()
+	store := namespace.NewStore(fake)
+	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	putPythonNamespace(t, store, "alpha", allowPythonSubjectSpec())
+	putPythonNamespace(t, store, "beta", allowPythonSubjectSpec())
+	h, err := NewHandler(reg)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	mux := h.Mux()
+	ctx := auth.WithAuthContext(t.Context(), &auth.AuthContext{Issuer: "issuer", ID: "alice"})
+
+	body, contentType := pythonUploadBody(t, "Demo", "1.0.0", "demo-1.0.0.whl", "wheel")
+	req := httptest.NewRequest(http.MethodPost, "/alpha/", body)
+	req = req.WithContext(ctx)
+	req.Header.Set("Content-Type", contentType)
+	resp := httptest.NewRecorder()
+	mux.ServeHTTP(resp, req)
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("upload status=%d body=%s", resp.Code, resp.Body.String())
+	}
+
+	for _, tc := range []struct {
+		name string
+		url  string
+		want int
+	}{
+		{name: "same namespace", url: "/alpha/simple/demo/", want: http.StatusOK},
+		{name: "other namespace", url: "/beta/packages/demo/1.0.0/demo-1.0.0.whl", want: http.StatusNotFound},
+		{name: "unknown namespace", url: "/missing/simple/", want: http.StatusNotFound},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(http.MethodGet, tc.url, nil).WithContext(ctx)
+			resp := httptest.NewRecorder()
+			mux.ServeHTTP(resp, req)
+			if resp.Code != tc.want {
+				t.Errorf("status=%d want=%d body=%s", resp.Code, tc.want, resp.Body.String())
+			}
+		})
+	}
+}
+
+func TestNamespaceRoutesForbidden(t *testing.T) {
+	t.Parallel()
+
+	fake := oci.NewFakeRegistry()
+	store := namespace.NewStore(fake)
+	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	putPythonNamespace(t, store, "alpha", namespace.Spec{Policy: namespace.Policy{Readers: []namespace.SubjectMatcher{{Issuer: "other"}}, Writers: []namespace.SubjectMatcher{{Issuer: "other"}}}})
+	h, err := NewHandler(reg)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/alpha/simple/", nil).WithContext(auth.WithAuthContext(t.Context(), &auth.AuthContext{Issuer: "issuer", ID: "alice"}))
+	resp := httptest.NewRecorder()
+	h.Mux().ServeHTTP(resp, req)
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("status=%d want=%d body=%s", resp.Code, http.StatusForbidden, resp.Body.String())
+	}
+}
+
+func pythonUploadBody(t *testing.T, pkg, version, filename, content string) (*strings.Reader, string) {
+	t.Helper()
+	var b bytes.Buffer
+	w := multipart.NewWriter(&b)
+	if err := w.WriteField("name", pkg); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.WriteField("version", version); err != nil {
+		t.Fatal(err)
+	}
+	fw, err := w.CreateFormFile("content", filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fw.Write([]byte(content)); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return strings.NewReader(b.String()), w.FormDataContentType()
+}
+
+func putPythonNamespace(t *testing.T, store *namespace.Store, name string, spec namespace.Spec) {
+	t.Helper()
+	if err := store.Put(t.Context(), &namespace.Namespace{Name: name, Spec: spec}); err != nil {
+		t.Fatalf("put namespace %s: %v", name, err)
+	}
+}
+
+func allowPythonSubjectSpec() namespace.Spec {
+	return namespace.Spec{Policy: namespace.Policy{Readers: []namespace.SubjectMatcher{{Issuer: "issuer"}}, Writers: []namespace.SubjectMatcher{{Issuer: "issuer"}}}}
+}

--- a/pkg/namespace/registry.go
+++ b/pkg/namespace/registry.go
@@ -113,6 +113,8 @@ type Registry struct {
 	factory     AuthzFactory
 	cacheTTL    time.Duration
 
+	defaultNamespaceAllowAll bool
+
 	// flight collapses concurrent first-misses for the same namespace
 	// so a cold-start burst pays one Store.Get + factory(...) rather
 	// than N. Keyed by namespace name.
@@ -144,6 +146,14 @@ func WithPackageIndexSuffix(s string) RegistryOption {
 // Defaults to [NewPolicyAuthorizer].
 func WithAuthzFactory(f AuthzFactory) RegistryOption {
 	return func(r *Registry) { r.factory = f }
+}
+
+// WithDefaultNamespaceAllowAll makes the data plane synthesize a dev-only
+// "default" namespace with allow-all authorization when the Store has no
+// persisted default namespace. Existing persisted namespace metadata still
+// wins. This is intended for tests and local development only.
+func WithDefaultNamespaceAllowAll(allow bool) RegistryOption {
+	return func(r *Registry) { r.defaultNamespaceAllowAll = allow }
 }
 
 // WithPolicyCacheTTL overrides [DefaultPolicyCacheTTL]. A value of
@@ -248,6 +258,11 @@ func (r *Registry) authorizerFor(ctx context.Context, namespace string) (auth.Au
 		}
 		ns, err := r.store.Get(ctx, namespace)
 		if err != nil {
+			if errors.Is(err, ErrNotFound) && r.defaultNamespaceAllowAll && namespace == "default" {
+				entry := cachedPolicy{authorizer: auth.AllowAll}
+				r.cache.put(namespace, entry)
+				return entry, nil
+			}
 			if errors.Is(err, ErrNotFound) {
 				neg := cachedPolicy{notFound: true}
 				r.cache.put(namespace, neg)


### PR DESCRIPTION
### Motivation

- Introduce per-namespace routing so handlers enforce per-namespace authz and prefix backend OCI repos correctly; this implements the namespace wrapper planned in the design and addresses namespace-related issues (Closes #72 and #73). 
- Provide a developer/test convenience to synthesize a permissive `default` namespace for integration tests and local runs without persisting metadata.

### Description

- Added a serve flag `--default-namespace-allow-all` (mapped to `serveConfig.DefaultNamespaceAllowAll`) and wired it into `runServe` to construct a `namespace.Registry` via `namespace.NewRegistry(..., namespace.WithDefaultNamespaceAllowAll(...))` for Python and Maven handlers.
- Extended `pkg/namespace.Registry` with a `WithDefaultNamespaceAllowAll` option and a `defaultNamespaceAllowAll` path: when enabled and the `default` namespace is missing, the wrapper synthesizes an allow-all authorizer for `default` so integration tests and local dev can use `/default` without pre-seeding metadata.
- Plumbed namespace awareness into handlers: Python routes are now available under `/{namespace}/...` and Maven under `/{namespace}/maven2/...`, and each request resolves a scoped registry via `ScopedRegistry` so every backend call is prefixed and authorized per-namespace; legacy root routes are preserved behind a compatibility check so existing unit tests that pass a raw `handler.Registry` still work.
- Normalized error mapping and response codes for namespace-related and auth errors via a helper `writeRegistryError(ctx,w,err,public)` and added helper methods `usesNamespaceRegistry()` / `scopedRegistry()` / `namespaceFromRequest()` / `namespacePrefix()` in both handlers.
- Modified the Python handler to use per-request registry values (index sentinel writes, file upload/download, package index cache keys and URLs) and adjusted the Maven handler similarly (request-scoped `ReadFile`/`AddFile`, checksum verification, and route wiring).
- Updated integration harness and tests to exercise the synthetic `default` namespace (`/default/simple/` and `/default/maven2`) and added unit tests that verify namespace isolation, unknown-namespace 404s, and policy-denied 403s for both Python and Maven handlers.

### Testing

- Ran unit suites: `go test ./pkg/handler/python ./pkg/handler/maven ./pkg/commands ./pkg/namespace` and these packages passed.
- Ran integration suites: `go test -tags=integration ./pkg/handler/python ./pkg/handler/maven` and the Python/Maven integration tests passed with the harness using `--default-namespace-allow-all`.
- Ran repository-wide checks: `go vet ./...` succeeded and `go test ./...` was executed; all packages passed except an environment-specific failure in `pkg/serving` (`TestStartHTTPHandler_ServesAndShutsDownOnContextCancel` returned `Forbidden` instead of the expected test response), which appears to be a local environment binding/permission artifact rather than a change introduced by these patches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a009b94b184832e93c7a4d3d94e4fcc)