### PR TITLE
Add admin namespace API (ocifactory admin serve)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ Design pillars (in priority order):
 | `/healthz`, `/readyz`, `/metrics` endpoints (registered at server level) | Done |
 | `pkg/auth` — Pluggable frontend authentication (Authenticator, AuthContext, Chain, OIDC) | Done, tested. OIDC-only — static passwords are out-of-tree by design. Configured via `OCIFACTORY_AUTHN_*` flags / env vars. |
 | `pkg/auth/backend` — Pluggable backend credential `Provider` interface and in-tree adapters (`anonymous`, `gcpadc`, `staticenv`, `dockerconfig`) | Done, tested. Wired into `oci.Registry` via `WithBackendAuth`. Configured via `OCIFACTORY_BACKEND_AUTH_*` flags / env vars. |
+| `ocifactory admin serve` — control-plane namespace CRUD API | Done, tested. Operator docs: [`docs/admin.md`](docs/admin.md). |
 | `pkg/handler/echo` — No-op auth target for the GitHub OIDC CI job | Done. Not a real artifact format; no OCI backend, no `handler.Registry`. Exists to give CI a concrete request to make against a real OIDC issuer. |
 | `cmd/ocifactory serve` | Works for `--repo-type=python|maven|echo` (echo runs without `--backend-registry`) |
 | Go module proxy support | Not started |

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -61,3 +61,12 @@ The admin service reuses the same observability endpoints as the data plane:
 - `/readyz` calls `Store.List` against the OCI-backed namespace index under the
   standard readiness timeout.
 - `/metrics` exposes Prometheus metrics when metrics are enabled.
+
+## Namespace metadata storage
+
+Namespace metadata is stored with OCI artifact type
+`application/vnd.ocifactory.namespace`, independent of the data-plane format
+served by a process. If you experimented with namespace metadata from the short
+window before this admin service existed, recreate those namespaces through the
+admin API so Python, Maven, and future repo types all read the same control-plane
+documents.

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -1,0 +1,63 @@
+# Admin service
+
+`ocifactory admin serve` runs the control-plane HTTP service. It is a separate
+listener from the data plane (`ocifactory serve`) and should be deployed on a
+separate hostname behind platform or network access controls.
+
+> **Security requirement:** the admin service intentionally has no internal
+> authentication or authorization middleware. Put it behind Cloud Run
+> authenticated invoker, an internal load balancer ACL, an identity-aware proxy,
+> or equivalent controls before exposing it to operators.
+
+## Start the service
+
+```bash
+ocifactory admin serve \
+  --backend-registry=zot.local:5000/ocifactory \
+  --port=8081 \
+  --namespace-prefix=control-plane
+```
+
+Useful flags:
+
+| Flag | Purpose |
+|---|---|
+| `--backend-registry` | Required. OCI registry URL that stores namespace metadata and the namespace index. |
+| `--port` | Listener port. Defaults to `8081`; `PORT` is also honored for PaaS deployments. |
+| `--namespace-prefix` | Optional OCI repository prefix for namespace metadata and the global namespace index. Defaults to empty. Use a lowercase OCI-safe path segment such as `control-plane`. |
+| `--backend-auth-kind` and related `--backend-auth-*` flags | Same backend credential providers as the data-plane service. |
+| `--enable-metrics`, `--metrics-path` | Expose and configure Prometheus metrics. |
+
+The service logs a WARN during startup to remind operators that it trusts the
+network/platform in front of it.
+
+## HTTP API
+
+All endpoints are JSON-only and versioned under `/admin/v1`.
+
+| Method | Path | Body | Success response |
+|---|---|---|---|
+| `PUT` | `/admin/v1/namespaces/{name}` | `namespace.Spec` JSON | `201` with a `namespace.Namespace` on create; `200` on update. |
+| `GET` | `/admin/v1/namespaces/{name}` | none | `200` with a `namespace.Namespace`. |
+| `DELETE` | `/admin/v1/namespaces/{name}` | none | `204` when the namespace exists and is empty. |
+| `GET` | `/admin/v1/namespaces` | none | `200 {"namespaces":[...]}`. |
+
+Errors use `{"error":"message"}`. Invalid namespace names and invalid specs
+return `400`; missing namespaces return `404`; soft-delete of a non-empty
+namespace returns `409`.
+
+## Soft delete
+
+`DELETE` is intentionally conservative in this phase. ocifactory checks the
+namespace package index and refuses to delete a namespace that still contains
+packages. Remove package data through a future cascade-delete flow before
+deleting those namespaces.
+
+## Health, readiness, and metrics
+
+The admin service reuses the same observability endpoints as the data plane:
+
+- `/healthz` returns liveness.
+- `/readyz` calls `Store.List` against the OCI-backed namespace index under the
+  standard readiness timeout.
+- `/metrics` exposes Prometheus metrics when metrics are enabled.

--- a/pkg/commands/admin.go
+++ b/pkg/commands/admin.go
@@ -23,14 +23,11 @@ const (
 )
 
 type adminServeConfig struct {
-	Port                 string `mapstructure:"port"`
-	BackendRegistry      string `mapstructure:"backend-registry"`
-	NamespacePrefix      string `mapstructure:"namespace-prefix"`
-	DisableStreamingPush bool   `mapstructure:"disable-streaming-push"`
-	DisableBlobRedirect  bool   `mapstructure:"disable-blob-redirect"`
-	AllowOverwrite       bool   `mapstructure:"allow-overwrite"`
-	EnableMetrics        bool   `mapstructure:"enable-metrics"`
-	MetricsPath          string `mapstructure:"metrics-path"`
+	Port            string `mapstructure:"port"`
+	BackendRegistry string `mapstructure:"backend-registry"`
+	NamespacePrefix string `mapstructure:"namespace-prefix"`
+	EnableMetrics   bool   `mapstructure:"enable-metrics"`
+	MetricsPath     string `mapstructure:"metrics-path"`
 
 	BackendAuthKind                 string   `mapstructure:"backend-auth-kind"`
 	BackendAuthGCPADCScopes         []string `mapstructure:"backend-auth-gcpadc-scopes"`
@@ -60,6 +57,16 @@ func (c *adminServeConfig) Validate() error {
 		c.RegistryURL = u
 	}
 	return merr
+}
+
+func (c *adminServeConfig) backendAuthConfig() backendAuthConfig {
+	return backendAuthConfig{
+		Kind:                 c.BackendAuthKind,
+		GCPADCScopes:         c.BackendAuthGCPADCScopes,
+		StaticEnvUserEnv:     c.BackendAuthStaticEnvUserEnv,
+		StaticEnvPasswordEnv: c.BackendAuthStaticEnvPasswordEnv,
+		DockerConfigPath:     c.BackendAuthDockerConfigPath,
+	}
 }
 
 func newAdminCmd() *cobra.Command {
@@ -107,12 +114,6 @@ func registerAdminServeFlags(flags *pflag.FlagSet) {
 	flags.String(flagBackendRegistry, "", "The URL to the backend OCI registry.")
 	flags.String(flagNamespacePrefix, namespace.DefaultPrefix,
 		"OCI repository prefix for namespace metadata and the global namespace index.")
-	flags.Bool(flagDisableStreamingPush, false,
-		"Force every blob upload through the buffered + monolithic path instead of streaming via chunked PATCH.")
-	flags.Bool(flagDisableBlobRedirect, false,
-		"Disable backend blob redirects for OCI registry operations.")
-	flags.Bool(flagAllowOverwrite, false,
-		"Allow overwriting OCI files that already exist. Admin namespace metadata PUT uses upsert semantics regardless of this setting.")
 	flags.Bool(flagEnableMetrics, true,
 		"Expose Prometheus metrics at --metrics-path and instrument HTTP and OCI backend layers.")
 	flags.String(flagMetricsPath, "/metrics", "Path that serves Prometheus exposition when metrics are enabled.")
@@ -129,22 +130,13 @@ func runAdminServe(ctx context.Context, cfg *adminServeConfig) error {
 	logging.NewFromEnv("OCIFACTORY_").WarnContext(ctx, "ADMIN SERVICE HAS NO INTERNAL AUTHENTICATION — deploy it behind platform/network access controls; see docs/admin.md")
 
 	rec, metricsHandler := buildRecorder(cfg.EnableMetrics)
-	bp, err := buildBackendAuth(ctx, &serveConfig{
-		BackendAuthKind:                 cfg.BackendAuthKind,
-		BackendAuthGCPADCScopes:         cfg.BackendAuthGCPADCScopes,
-		BackendAuthStaticEnvUserEnv:     cfg.BackendAuthStaticEnvUserEnv,
-		BackendAuthStaticEnvPasswordEnv: cfg.BackendAuthStaticEnvPasswordEnv,
-		BackendAuthDockerConfigPath:     cfg.BackendAuthDockerConfigPath,
-	})
+	bp, err := buildBackendAuth(ctx, cfg.backendAuthConfig())
 	if err != nil {
 		return fmt.Errorf("failed to build backend credentials: %w", err)
 	}
 
 	reg, err := oci.NewRegistry(cfg.RegistryURL,
 		oci.WithArtifactType(namespace.ArtifactType),
-		oci.WithStreamingPushDisabled(cfg.DisableStreamingPush),
-		oci.WithBlobRedirectDisabled(cfg.DisableBlobRedirect),
-		oci.WithAllowOverwrite(cfg.AllowOverwrite),
 		oci.WithMetrics(rec),
 		oci.WithBackendAuth(bp),
 	)
@@ -152,6 +144,10 @@ func runAdminServe(ctx context.Context, cfg *adminServeConfig) error {
 		return fmt.Errorf("failed to create registry: %w", err)
 	}
 	store := namespace.NewStore(reg, namespace.WithPrefix(cfg.NamespacePrefix))
+	// The admin service does not authorize data-plane requests, but
+	// namespace.Registry already owns the package-index decoding logic
+	// needed for soft-delete emptiness checks. Keep it here only as a
+	// control-plane PackageLister.
 	nsReg := namespace.NewRegistry(reg, store)
 	ah, err := adminhandler.NewHandler(store, nsReg)
 	if err != nil {
@@ -163,20 +159,14 @@ func runAdminServe(ctx context.Context, cfg *adminServeConfig) error {
 	if !cfg.EnableMetrics {
 		metricsPath = ""
 	}
-	h = handler.ObservabilityHandler(h, storePinger{store: store}, metricsHandler, metricsPath)
+	h = handler.ObservabilityHandler(h, handler.PingerFunc(func(ctx context.Context) error {
+		_, err := store.List(ctx)
+		return err
+	}), metricsHandler, metricsPath)
 
 	srv, err := handler.NewServer(cfg.Port, handler.Loggeer, handler.MetricsMiddleware(rec))
 	if err != nil {
 		return fmt.Errorf("failed to create server: %w", err)
 	}
 	return srv.Start(ctx, h)
-}
-
-type storePinger struct {
-	store *namespace.Store
-}
-
-func (p storePinger) Ping(ctx context.Context) error {
-	_, err := p.store.List(ctx)
-	return err
 }

--- a/pkg/commands/admin.go
+++ b/pkg/commands/admin.go
@@ -1,0 +1,182 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"github.com/yolocs/ocifactory/pkg/auth/backend"
+	"github.com/yolocs/ocifactory/pkg/handler"
+	adminhandler "github.com/yolocs/ocifactory/pkg/handler/admin"
+	"github.com/yolocs/ocifactory/pkg/logging"
+	"github.com/yolocs/ocifactory/pkg/namespace"
+	"github.com/yolocs/ocifactory/pkg/oci"
+)
+
+const (
+	flagNamespacePrefix = "namespace-prefix"
+)
+
+type adminServeConfig struct {
+	Port                 string `mapstructure:"port"`
+	BackendRegistry      string `mapstructure:"backend-registry"`
+	NamespacePrefix      string `mapstructure:"namespace-prefix"`
+	DisableStreamingPush bool   `mapstructure:"disable-streaming-push"`
+	DisableBlobRedirect  bool   `mapstructure:"disable-blob-redirect"`
+	AllowOverwrite       bool   `mapstructure:"allow-overwrite"`
+	EnableMetrics        bool   `mapstructure:"enable-metrics"`
+	MetricsPath          string `mapstructure:"metrics-path"`
+
+	BackendAuthKind                 string   `mapstructure:"backend-auth-kind"`
+	BackendAuthGCPADCScopes         []string `mapstructure:"backend-auth-gcpadc-scopes"`
+	BackendAuthStaticEnvUserEnv     string   `mapstructure:"backend-auth-staticenv-user-env"`
+	BackendAuthStaticEnvPasswordEnv string   `mapstructure:"backend-auth-staticenv-password-env"`
+	BackendAuthDockerConfigPath     string   `mapstructure:"backend-auth-dockerconfig-path"`
+
+	RegistryURL *url.URL `mapstructure:"-"`
+}
+
+func (c *adminServeConfig) Validate() error {
+	var merr error
+	if c.Port == "" {
+		merr = errors.Join(merr, fmt.Errorf("port is required"))
+	}
+	if c.BackendRegistry == "" {
+		merr = errors.Join(merr, fmt.Errorf("backend-registry is required"))
+		return merr
+	}
+	if !strings.HasPrefix(c.BackendRegistry, "http://") && !strings.HasPrefix(c.BackendRegistry, "https://") {
+		c.BackendRegistry = "https://" + c.BackendRegistry
+	}
+	u, err := url.Parse(c.BackendRegistry)
+	if err != nil {
+		merr = errors.Join(merr, fmt.Errorf("failed to parse backend-registry URL: %w", err))
+	} else {
+		c.RegistryURL = u
+	}
+	return merr
+}
+
+func newAdminCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "admin",
+		Short: "Run ocifactory control-plane commands.",
+	}
+	cmd.AddCommand(newAdminServeCmd())
+	return cmd
+}
+
+func newAdminServeCmd() *cobra.Command {
+	v := viper.New()
+	v.SetEnvPrefix(envPrefix)
+	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	v.AutomaticEnv()
+	_ = v.BindEnv(flagPort, "PORT")
+	return buildAdminServeCmd(v)
+}
+
+func buildAdminServeCmd(v *viper.Viper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "serve",
+		Short: "Run the control-plane admin HTTP service.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var cfg adminServeConfig
+			if err := v.Unmarshal(&cfg); err != nil {
+				return fmt.Errorf("unmarshal config: %w", err)
+			}
+			if err := cfg.Validate(); err != nil {
+				return fmt.Errorf("invalid flags: %w", err)
+			}
+			return runAdminServe(cmd.Context(), &cfg)
+		},
+	}
+	registerAdminServeFlags(cmd.Flags())
+	if err := v.BindPFlags(cmd.Flags()); err != nil {
+		panic(fmt.Errorf("bind flags to viper: %w", err))
+	}
+	return cmd
+}
+
+func registerAdminServeFlags(flags *pflag.FlagSet) {
+	flags.String(flagPort, "8081", "The port the admin server listens to.")
+	flags.String(flagBackendRegistry, "", "The URL to the backend OCI registry.")
+	flags.String(flagNamespacePrefix, namespace.DefaultPrefix,
+		"OCI repository prefix for namespace metadata and the global namespace index.")
+	flags.Bool(flagDisableStreamingPush, false,
+		"Force every blob upload through the buffered + monolithic path instead of streaming via chunked PATCH.")
+	flags.Bool(flagDisableBlobRedirect, false,
+		"Disable backend blob redirects for OCI registry operations.")
+	flags.Bool(flagAllowOverwrite, false,
+		"Allow overwriting OCI files that already exist. Admin namespace metadata PUT uses upsert semantics regardless of this setting.")
+	flags.Bool(flagEnableMetrics, true,
+		"Expose Prometheus metrics at --metrics-path and instrument HTTP and OCI backend layers.")
+	flags.String(flagMetricsPath, "/metrics", "Path that serves Prometheus exposition when metrics are enabled.")
+
+	flags.String(flagBackendAuthKind, backend.KindAnonymous,
+		fmt.Sprintf("Credential provider for the backend OCI registry. Allowed: %v.", backend.AllKinds))
+	flags.StringSlice(flagBackendAuthGCPADCScopes, nil, "Comma-separated OAuth2 scopes for the gcpadc backend auth kind. Empty = cloud-platform.")
+	flags.String(flagBackendAuthStaticEnvUserEnv, "", "Name of the env var holding the username for the staticenv backend auth kind.")
+	flags.String(flagBackendAuthStaticEnvPasswordEnv, "", "Name of the env var holding the password for the staticenv backend auth kind.")
+	flags.String(flagBackendAuthDockerConfigPath, "", "Path to a docker-format config.json for the dockerconfig backend auth kind. Empty = ~/.docker/config.json.")
+}
+
+func runAdminServe(ctx context.Context, cfg *adminServeConfig) error {
+	logging.NewFromEnv("OCIFACTORY_").WarnContext(ctx, "ADMIN SERVICE HAS NO INTERNAL AUTHENTICATION — deploy it behind platform/network access controls; see docs/admin.md")
+
+	rec, metricsHandler := buildRecorder(cfg.EnableMetrics)
+	bp, err := buildBackendAuth(ctx, &serveConfig{
+		BackendAuthKind:                 cfg.BackendAuthKind,
+		BackendAuthGCPADCScopes:         cfg.BackendAuthGCPADCScopes,
+		BackendAuthStaticEnvUserEnv:     cfg.BackendAuthStaticEnvUserEnv,
+		BackendAuthStaticEnvPasswordEnv: cfg.BackendAuthStaticEnvPasswordEnv,
+		BackendAuthDockerConfigPath:     cfg.BackendAuthDockerConfigPath,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to build backend credentials: %w", err)
+	}
+
+	reg, err := oci.NewRegistry(cfg.RegistryURL,
+		oci.WithArtifactType(namespace.ArtifactType),
+		oci.WithStreamingPushDisabled(cfg.DisableStreamingPush),
+		oci.WithBlobRedirectDisabled(cfg.DisableBlobRedirect),
+		oci.WithAllowOverwrite(cfg.AllowOverwrite),
+		oci.WithMetrics(rec),
+		oci.WithBackendAuth(bp),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create registry: %w", err)
+	}
+	store := namespace.NewStore(reg, namespace.WithPrefix(cfg.NamespacePrefix))
+	nsReg := namespace.NewRegistry(reg, store)
+	ah, err := adminhandler.NewHandler(store, nsReg)
+	if err != nil {
+		return fmt.Errorf("failed to create admin handler: %w", err)
+	}
+
+	h := handler.WrapWithFormat(adminhandler.FormatLabel)(ah.Mux())
+	metricsPath := cfg.MetricsPath
+	if !cfg.EnableMetrics {
+		metricsPath = ""
+	}
+	h = handler.ObservabilityHandler(h, storePinger{store: store}, metricsHandler, metricsPath)
+
+	srv, err := handler.NewServer(cfg.Port, handler.Loggeer, handler.MetricsMiddleware(rec))
+	if err != nil {
+		return fmt.Errorf("failed to create server: %w", err)
+	}
+	return srv.Start(ctx, h)
+}
+
+type storePinger struct {
+	store *namespace.Store
+}
+
+func (p storePinger) Ping(ctx context.Context) error {
+	_, err := p.store.List(ctx)
+	return err
+}

--- a/pkg/commands/admin_test.go
+++ b/pkg/commands/admin_test.go
@@ -85,9 +85,6 @@ func TestAdminServeCmd_Flags(t *testing.T) {
 		flagPort,
 		flagBackendRegistry,
 		flagNamespacePrefix,
-		flagDisableStreamingPush,
-		flagAllowOverwrite,
-		flagDisableBlobRedirect,
 		flagEnableMetrics,
 		flagMetricsPath,
 		flagBackendAuthKind,
@@ -104,8 +101,18 @@ func TestAdminServeCmd_Flags(t *testing.T) {
 			}
 		})
 	}
-	if f := cmd.Flags().Lookup(flagRepoType); f != nil {
-		t.Fatalf("admin serve registered data-plane flag %q", flagRepoType)
+	notRegistered := []string{
+		flagRepoType,
+		flagDisableStreamingPush,
+		flagAllowOverwrite,
+		flagDisableBlobRedirect,
+		flagSimpleIndexCacheTTL,
+		flagPythonMaxUploadBytes,
+	}
+	for _, flagName := range notRegistered {
+		if f := cmd.Flags().Lookup(flagName); f != nil {
+			t.Fatalf("admin serve registered data-plane flag %q", flagName)
+		}
 	}
 }
 

--- a/pkg/commands/admin_test.go
+++ b/pkg/commands/admin_test.go
@@ -1,0 +1,178 @@
+package commands
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/yolocs/ocifactory/pkg/auth/backend"
+)
+
+func minimalAdminServeConfig() adminServeConfig {
+	return adminServeConfig{
+		Port:            "8081",
+		BackendRegistry: "http://example.com",
+		EnableMetrics:   true,
+		MetricsPath:     "/metrics",
+		BackendAuthKind: backend.KindAnonymous,
+	}
+}
+
+func TestAdminServeConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mut     func(*adminServeConfig)
+		wantErr string
+		wantURL *url.URL
+	}{
+		{
+			name:    "valid",
+			wantURL: &url.URL{Scheme: "http", Host: "example.com"},
+		},
+		{
+			name: "default https scheme",
+			mut: func(c *adminServeConfig) {
+				c.BackendRegistry = "registry.example.com/ocifactory"
+			},
+			wantURL: &url.URL{Scheme: "https", Host: "registry.example.com", Path: "/ocifactory"},
+		},
+		{
+			name: "missing port",
+			mut: func(c *adminServeConfig) {
+				c.Port = ""
+			},
+			wantErr: "port is required",
+			wantURL: &url.URL{Scheme: "http", Host: "example.com"},
+		},
+		{
+			name: "missing backend registry",
+			mut: func(c *adminServeConfig) {
+				c.BackendRegistry = ""
+			},
+			wantErr: "backend-registry is required",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := minimalAdminServeConfig()
+			if tc.mut != nil {
+				tc.mut(&cfg)
+			}
+			err := cfg.Validate()
+			if diff := cmp.Diff(tc.wantErr, errString(err)); diff != "" {
+				t.Errorf("Validate() error mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantURL, cfg.RegistryURL, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Validate() RegistryURL mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAdminServeCmd_Flags(t *testing.T) {
+	t.Parallel()
+
+	cmd := newAdminServeCmd()
+	tests := []string{
+		flagPort,
+		flagBackendRegistry,
+		flagNamespacePrefix,
+		flagDisableStreamingPush,
+		flagAllowOverwrite,
+		flagDisableBlobRedirect,
+		flagEnableMetrics,
+		flagMetricsPath,
+		flagBackendAuthKind,
+		flagBackendAuthGCPADCScopes,
+		flagBackendAuthStaticEnvUserEnv,
+		flagBackendAuthStaticEnvPasswordEnv,
+		flagBackendAuthDockerConfigPath,
+	}
+	for _, flagName := range tests {
+		t.Run(flagName, func(t *testing.T) {
+			t.Parallel()
+			if f := cmd.Flags().Lookup(flagName); f == nil {
+				t.Fatalf("flag %q not registered", flagName)
+			}
+		})
+	}
+	if f := cmd.Flags().Lookup(flagRepoType); f != nil {
+		t.Fatalf("admin serve registered data-plane flag %q", flagRepoType)
+	}
+}
+
+func TestAdminCmd_IsRegistered(t *testing.T) {
+	t.Parallel()
+
+	root := newRootCmd()
+	adminCmd, _, err := root.Find([]string{"admin"})
+	if err != nil {
+		t.Fatalf("Find(admin): %v", err)
+	}
+	if diff := cmp.Diff("admin", adminCmd.Name()); diff != "" {
+		t.Errorf("admin command name mismatch (-want +got):\n%s", diff)
+	}
+	serveCmd, _, err := root.Find([]string{"admin", "serve"})
+	if err != nil {
+		t.Fatalf("Find(admin serve): %v", err)
+	}
+	if diff := cmp.Diff("serve", serveCmd.Name()); diff != "" {
+		t.Errorf("admin serve command name mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestAdminServeCmd_EnvVarBindings mutates process-global env, so cannot t.Parallel.
+func TestAdminServeCmd_EnvVarBindings(t *testing.T) {
+	t.Setenv("OCIFACTORY_BACKEND_REGISTRY", "zot.example.com:5000/ocifactory")
+	t.Setenv("OCIFACTORY_NAMESPACE_PREFIX", "control-plane")
+	t.Setenv("OCIFACTORY_BACKEND_AUTH_KIND", "staticenv")
+	t.Setenv("OCIFACTORY_BACKEND_AUTH_STATICENV_USER_ENV", "REG_USER")
+	t.Setenv("OCIFACTORY_BACKEND_AUTH_STATICENV_PASSWORD_ENV", "REG_PASS")
+	t.Setenv("PORT", "9091")
+
+	v := viper.New()
+	v.SetEnvPrefix(envPrefix)
+	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	v.AutomaticEnv()
+	_ = v.BindEnv(flagPort, "PORT")
+
+	cmd := buildAdminServeCmd(v)
+	var got adminServeConfig
+	cmd.RunE = func(c *cobra.Command, _ []string) error {
+		return v.Unmarshal(&got)
+	}
+
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	want := adminServeConfig{
+		Port:                            "9091",
+		BackendRegistry:                 "zot.example.com:5000/ocifactory",
+		NamespacePrefix:                 "control-plane",
+		EnableMetrics:                   true,
+		MetricsPath:                     "/metrics",
+		BackendAuthKind:                 "staticenv",
+		BackendAuthStaticEnvUserEnv:     "REG_USER",
+		BackendAuthStaticEnvPasswordEnv: "REG_PASS",
+	}
+	if diff := cmp.Diff(want, got, cmpopts.EquateEmpty()); diff != "" {
+		t.Errorf("config mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -14,7 +14,7 @@ func newRootCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	cmd.AddCommand(newServeCmd())
+	cmd.AddCommand(newServeCmd(), newAdminCmd())
 	return cmd
 }
 

--- a/pkg/commands/serve.go
+++ b/pkg/commands/serve.go
@@ -349,7 +349,14 @@ func runServe(ctx context.Context, cfg *serveConfig) error {
 		if err != nil {
 			return fmt.Errorf("failed to create registry: %w", err)
 		}
-		nsReg := namespace.NewRegistry(r, namespace.NewStore(r))
+		storeReg, err := oci.NewRegistry(
+			cfg.RegistryURL,
+			append(registryOpts, oci.WithArtifactType(namespace.ArtifactType))...,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to create namespace registry: %w", err)
+		}
+		nsReg := namespace.NewRegistry(r, namespace.NewStore(storeReg))
 		mh, err := maven.NewHandler(nsReg, maven.WithAuthMiddleware(authMW))
 		if err != nil {
 			return fmt.Errorf("failed to create maven handler: %w", err)
@@ -363,7 +370,14 @@ func runServe(ctx context.Context, cfg *serveConfig) error {
 		if err != nil {
 			return fmt.Errorf("failed to create registry: %w", err)
 		}
-		nsReg := namespace.NewRegistry(r, namespace.NewStore(r))
+		storeReg, err := oci.NewRegistry(
+			cfg.RegistryURL,
+			append(registryOpts, oci.WithArtifactType(namespace.ArtifactType))...,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to create namespace registry: %w", err)
+		}
+		nsReg := namespace.NewRegistry(r, namespace.NewStore(storeReg))
 		ph, err := python.NewHandler(nsReg,
 			python.WithSimpleIndexCacheTTL(cfg.SimpleIndexCacheTTL),
 			python.WithMaxUploadBytes(cfg.PythonMaxUploadBytes),

--- a/pkg/commands/serve.go
+++ b/pkg/commands/serve.go
@@ -116,6 +116,24 @@ type serveConfig struct {
 	RegistryURL *url.URL `mapstructure:"-"`
 }
 
+type backendAuthConfig struct {
+	Kind                 string
+	GCPADCScopes         []string
+	StaticEnvUserEnv     string
+	StaticEnvPasswordEnv string
+	DockerConfigPath     string
+}
+
+func (c *serveConfig) backendAuthConfig() backendAuthConfig {
+	return backendAuthConfig{
+		Kind:                 c.BackendAuthKind,
+		GCPADCScopes:         c.BackendAuthGCPADCScopes,
+		StaticEnvUserEnv:     c.BackendAuthStaticEnvUserEnv,
+		StaticEnvPasswordEnv: c.BackendAuthStaticEnvPasswordEnv,
+		DockerConfigPath:     c.BackendAuthDockerConfigPath,
+	}
+}
+
 // Validate checks that c is internally consistent and populates
 // c.RegistryURL by parsing c.BackendRegistry. Returns the joined
 // validation errors. Any URL the operator gave without an
@@ -322,7 +340,7 @@ func runServe(ctx context.Context, cfg *serveConfig) error {
 	}
 	authMW := auth.Middleware(authn)
 
-	bp, err := buildBackendAuth(ctx, cfg)
+	bp, err := buildBackendAuth(ctx, cfg.backendAuthConfig())
 	if err != nil {
 		return fmt.Errorf("failed to build backend credentials: %w", err)
 	}
@@ -349,10 +367,7 @@ func runServe(ctx context.Context, cfg *serveConfig) error {
 		if err != nil {
 			return fmt.Errorf("failed to create registry: %w", err)
 		}
-		storeReg, err := oci.NewRegistry(
-			cfg.RegistryURL,
-			append(registryOpts, oci.WithArtifactType(namespace.ArtifactType))...,
-		)
+		storeReg, err := newNamespaceMetadataRegistry(cfg.RegistryURL, registryOpts)
 		if err != nil {
 			return fmt.Errorf("failed to create namespace registry: %w", err)
 		}
@@ -370,10 +385,7 @@ func runServe(ctx context.Context, cfg *serveConfig) error {
 		if err != nil {
 			return fmt.Errorf("failed to create registry: %w", err)
 		}
-		storeReg, err := oci.NewRegistry(
-			cfg.RegistryURL,
-			append(registryOpts, oci.WithArtifactType(namespace.ArtifactType))...,
-		)
+		storeReg, err := newNamespaceMetadataRegistry(cfg.RegistryURL, registryOpts)
 		if err != nil {
 			return fmt.Errorf("failed to create namespace registry: %w", err)
 		}
@@ -426,6 +438,12 @@ func runServe(ctx context.Context, cfg *serveConfig) error {
 	return srv.Start(ctx, h)
 }
 
+func newNamespaceMetadataRegistry(registryURL *url.URL, baseOpts []oci.RegistryOption) (*oci.Registry, error) {
+	opts := append([]oci.RegistryOption{}, baseOpts...)
+	opts = append(opts, oci.WithArtifactType(namespace.ArtifactType))
+	return oci.NewRegistry(registryURL, opts...)
+}
+
 // buildAuthn constructs the auth.Authenticator the server installs
 // in front of every protected route. Two paths:
 //
@@ -469,14 +487,14 @@ func buildAuthn(ctx context.Context, cfg *serveConfig) (auth.Authenticator, erro
 // set --backend-auth-kind / OCIFACTORY_BACKEND_AUTH_KIND, the
 // default is anonymous and a warning is logged so the implicit
 // no-credential intent isn't silent.
-func buildBackendAuth(ctx context.Context, cfg *serveConfig) (backend.Provider, error) {
+func buildBackendAuth(ctx context.Context, cfg backendAuthConfig) (backend.Provider, error) {
 	logger := logging.NewFromEnv("OCIFACTORY_")
 	bcfg := backend.Config{
-		Kind:                 cfg.BackendAuthKind,
-		GCPADCScopes:         cfg.BackendAuthGCPADCScopes,
-		StaticEnvUserEnv:     cfg.BackendAuthStaticEnvUserEnv,
-		StaticEnvPasswordEnv: cfg.BackendAuthStaticEnvPasswordEnv,
-		DockerConfigPath:     cfg.BackendAuthDockerConfigPath,
+		Kind:                 cfg.Kind,
+		GCPADCScopes:         cfg.GCPADCScopes,
+		StaticEnvUserEnv:     cfg.StaticEnvUserEnv,
+		StaticEnvPasswordEnv: cfg.StaticEnvPasswordEnv,
+		DockerConfigPath:     cfg.DockerConfigPath,
 	}
 	if bcfg.Kind == "" || bcfg.Kind == backend.KindAnonymous {
 		logger.WarnContext(ctx, "no backend credential provider configured (set --backend-auth-kind / "+

--- a/pkg/handler/admin/handler.go
+++ b/pkg/handler/admin/handler.go
@@ -86,6 +86,9 @@ func (h *Handler) listNamespaces(w http.ResponseWriter, r *http.Request) {
 		writeInternal(r.Context(), w, err)
 		return
 	}
+	if names == nil {
+		names = []string{}
+	}
 	writeJSON(w, http.StatusOK, listResponse{Namespaces: names})
 }
 
@@ -119,6 +122,9 @@ func (h *Handler) putNamespace(w http.ResponseWriter, r *http.Request) {
 	}
 
 	status := http.StatusOK
+	// The 200-vs-201 distinction is best-effort: concurrent creates can
+	// both observe ErrNotFound before either Put lands. PUT remains
+	// idempotent because Store.Put is an upsert.
 	if _, err := h.store.Get(r.Context(), name); err != nil {
 		if errors.Is(err, namespace.ErrNotFound) {
 			status = http.StatusCreated
@@ -143,6 +149,10 @@ func (h *Handler) deleteNamespace(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Soft delete is a best-effort guard until cascade delete lands: an
+	// upload racing between ListPackages and Store.Delete can still leave
+	// package sentinels behind. The follow-up cascade flow owns closing
+	// that window.
 	packages, err := h.packages.ListPackages(r.Context(), name)
 	if err != nil {
 		writeAdminError(r.Context(), w, err)

--- a/pkg/handler/admin/handler.go
+++ b/pkg/handler/admin/handler.go
@@ -1,0 +1,181 @@
+// Package admin exposes ocifactory control-plane HTTP endpoints.
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/yolocs/ocifactory/pkg/handler"
+	"github.com/yolocs/ocifactory/pkg/namespace"
+)
+
+const (
+	// FormatLabel is the metrics format label used by the admin service.
+	FormatLabel = "admin"
+
+	contentTypeJSON = "application/json"
+)
+
+// Store is the namespace metadata persistence surface the admin API needs.
+type Store interface {
+	Get(ctx context.Context, name string) (*namespace.Namespace, error)
+	List(ctx context.Context) ([]string, error)
+	Put(ctx context.Context, ns *namespace.Namespace) error
+	Delete(ctx context.Context, name string) error
+}
+
+// PackageLister reports package-index entries for a namespace so DELETE can
+// refuse soft deletion of non-empty namespaces.
+type PackageLister interface {
+	ListPackages(ctx context.Context, name string) ([]string, error)
+}
+
+// Handler serves the admin HTTP API.
+type Handler struct {
+	store    Store
+	packages PackageLister
+}
+
+// NewHandler returns an admin API handler backed by store and packages.
+func NewHandler(store Store, packages PackageLister) (*Handler, error) {
+	if store == nil {
+		return nil, fmt.Errorf("store is required")
+	}
+	if packages == nil {
+		return nil, fmt.Errorf("package lister is required")
+	}
+	return &Handler{store: store, packages: packages}, nil
+}
+
+// Mux returns the admin API router.
+func (h *Handler) Mux() http.Handler {
+	r := mux.NewRouter()
+	r.Use(handler.RouteNameOpMiddleware)
+
+	r.HandleFunc("/admin/v1/namespaces", h.listNamespaces).
+		Methods(http.MethodGet).
+		Name("admin_namespaces_list")
+	r.HandleFunc("/admin/v1/namespaces/{name}", h.putNamespace).
+		Methods(http.MethodPut).
+		Name("admin_namespaces_put")
+	r.HandleFunc("/admin/v1/namespaces/{name}", h.getNamespace).
+		Methods(http.MethodGet).
+		Name("admin_namespaces_get")
+	r.HandleFunc("/admin/v1/namespaces/{name}", h.deleteNamespace).
+		Methods(http.MethodDelete).
+		Name("admin_namespaces_delete")
+
+	return r
+}
+
+type listResponse struct {
+	Namespaces []string `json:"namespaces"`
+}
+
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
+func (h *Handler) listNamespaces(w http.ResponseWriter, r *http.Request) {
+	names, err := h.store.List(r.Context())
+	if err != nil {
+		writeInternal(r.Context(), w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, listResponse{Namespaces: names})
+}
+
+func (h *Handler) getNamespace(w http.ResponseWriter, r *http.Request) {
+	name := mux.Vars(r)["name"]
+	ns, err := h.store.Get(r.Context(), name)
+	if err != nil {
+		writeAdminError(r.Context(), w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, ns)
+}
+
+func (h *Handler) putNamespace(w http.ResponseWriter, r *http.Request) {
+	name := mux.Vars(r)["name"]
+	if err := namespace.ValidateName(name); err != nil {
+		writeAdminError(r.Context(), w, err)
+		return
+	}
+
+	var spec namespace.Spec
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&spec); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: fmt.Sprintf("invalid JSON body: %v", err)})
+		return
+	}
+	if err := spec.Validate(); err != nil {
+		writeAdminError(r.Context(), w, err)
+		return
+	}
+
+	status := http.StatusOK
+	if _, err := h.store.Get(r.Context(), name); err != nil {
+		if errors.Is(err, namespace.ErrNotFound) {
+			status = http.StatusCreated
+		} else {
+			writeAdminError(r.Context(), w, err)
+			return
+		}
+	}
+
+	ns := &namespace.Namespace{Name: name, Spec: spec}
+	if err := h.store.Put(r.Context(), ns); err != nil {
+		writeAdminError(r.Context(), w, err)
+		return
+	}
+	writeJSON(w, status, ns)
+}
+
+func (h *Handler) deleteNamespace(w http.ResponseWriter, r *http.Request) {
+	name := mux.Vars(r)["name"]
+	if _, err := h.store.Get(r.Context(), name); err != nil {
+		writeAdminError(r.Context(), w, err)
+		return
+	}
+
+	packages, err := h.packages.ListPackages(r.Context(), name)
+	if err != nil {
+		writeAdminError(r.Context(), w, err)
+		return
+	}
+	if len(packages) > 0 {
+		writeJSON(w, http.StatusConflict, errorResponse{Error: "namespace is not empty"})
+		return
+	}
+	if err := h.store.Delete(r.Context(), name); err != nil {
+		writeAdminError(r.Context(), w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func writeAdminError(ctx context.Context, w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, namespace.ErrInvalidName), errors.Is(err, namespace.ErrInvalidPolicy):
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: err.Error()})
+	case errors.Is(err, namespace.ErrNotFound):
+		writeJSON(w, http.StatusNotFound, errorResponse{Error: err.Error()})
+	default:
+		writeInternal(ctx, w, err)
+	}
+}
+
+func writeInternal(ctx context.Context, w http.ResponseWriter, err error) {
+	handler.WriteError(ctx, w, http.StatusInternalServerError, err, "internal server error")
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", contentTypeJSON)
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/pkg/handler/admin/handler_test.go
+++ b/pkg/handler/admin/handler_test.go
@@ -1,0 +1,249 @@
+package admin_test
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/yolocs/ocifactory/pkg/handler/admin"
+	"github.com/yolocs/ocifactory/pkg/namespace"
+	"github.com/yolocs/ocifactory/pkg/oci"
+)
+
+func TestHandler_NamespaceCRUD(t *testing.T) {
+	t.Parallel()
+
+	allowAlice := namespace.Spec{Policy: namespace.Policy{Readers: []namespace.SubjectMatcher{{Email: "alice@example.com"}}}}
+	allowBob := namespace.Spec{Policy: namespace.Policy{Readers: []namespace.SubjectMatcher{{Email: "bob@example.com"}}}}
+
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		body       any
+		seed       func(t *testing.T, reg *oci.FakeRegistry, store *namespace.Store)
+		wantStatus int
+		wantBody   any
+	}{
+		{
+			name:       "put new namespace",
+			method:     http.MethodPut,
+			path:       "/admin/v1/namespaces/alpha",
+			body:       allowAlice,
+			wantStatus: http.StatusCreated,
+			wantBody:   &namespace.Namespace{Name: "alpha", Spec: allowAlice},
+		},
+		{
+			name:   "put existing namespace",
+			method: http.MethodPut,
+			path:   "/admin/v1/namespaces/alpha",
+			body:   allowBob,
+			seed: func(t *testing.T, reg *oci.FakeRegistry, store *namespace.Store) {
+				t.Helper()
+				putNamespaceNow(t, store, "alpha", allowAlice)
+			},
+			wantStatus: http.StatusOK,
+			wantBody:   &namespace.Namespace{Name: "alpha", Spec: allowBob},
+		},
+		{
+			name:       "put invalid name",
+			method:     http.MethodPut,
+			path:       "/admin/v1/namespaces/Bad_Name",
+			body:       namespace.Spec{},
+			wantStatus: http.StatusBadRequest,
+			wantBody:   map[string]string{"error": "invalid namespace name: \"Bad_Name\" contains invalid character 'B'"},
+		},
+		{
+			name:       "put invalid spec",
+			method:     http.MethodPut,
+			path:       "/admin/v1/namespaces/badspec",
+			body:       namespace.Spec{Policy: namespace.Policy{Readers: []namespace.SubjectMatcher{{}}}},
+			wantStatus: http.StatusBadRequest,
+			wantBody:   map[string]string{"error": "readers[0]: invalid policy: matcher must populate at least one field"},
+		},
+		{
+			name:   "get existing namespace",
+			method: http.MethodGet,
+			path:   "/admin/v1/namespaces/alpha",
+			seed: func(t *testing.T, reg *oci.FakeRegistry, store *namespace.Store) {
+				t.Helper()
+				putNamespaceNow(t, store, "alpha", allowBob)
+			},
+			wantStatus: http.StatusOK,
+			wantBody:   &namespace.Namespace{Name: "alpha", Spec: allowBob},
+		},
+		{
+			name:       "get unknown namespace",
+			method:     http.MethodGet,
+			path:       "/admin/v1/namespaces/missing",
+			wantStatus: http.StatusNotFound,
+			wantBody:   map[string]string{"error": "namespace not found: missing"},
+		},
+		{
+			name:   "list namespaces",
+			method: http.MethodGet,
+			path:   "/admin/v1/namespaces",
+			seed: func(t *testing.T, reg *oci.FakeRegistry, store *namespace.Store) {
+				t.Helper()
+				putNamespaceNow(t, store, "alpha", namespace.Spec{})
+				putNamespaceNow(t, store, "beta", namespace.Spec{})
+			},
+			wantStatus: http.StatusOK,
+			wantBody:   map[string][]string{"namespaces": []string{"alpha", "beta"}},
+		},
+		{
+			name:   "delete non-empty namespace",
+			method: http.MethodDelete,
+			path:   "/admin/v1/namespaces/alpha",
+			seed: func(t *testing.T, reg *oci.FakeRegistry, store *namespace.Store) {
+				t.Helper()
+				putNamespaceNow(t, store, "alpha", namespace.Spec{})
+				reg.AddTag(path.Join("alpha", "ocifactory-packages"), hex.EncodeToString([]byte("pkg")))
+			},
+			wantStatus: http.StatusConflict,
+			wantBody:   map[string]string{"error": "namespace is not empty"},
+		},
+		{
+			name:   "delete empty namespace",
+			method: http.MethodDelete,
+			path:   "/admin/v1/namespaces/beta",
+			seed: func(t *testing.T, reg *oci.FakeRegistry, store *namespace.Store) {
+				t.Helper()
+				putNamespaceNow(t, store, "beta", namespace.Spec{})
+			},
+			wantStatus: http.StatusNoContent,
+		},
+		{
+			name:       "delete unknown namespace",
+			method:     http.MethodDelete,
+			path:       "/admin/v1/namespaces/beta",
+			wantStatus: http.StatusNotFound,
+			wantBody:   map[string]string{"error": "namespace not found: beta"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			reg := oci.NewFakeRegistry()
+			store := namespace.NewStore(reg)
+			nsReg := namespace.NewRegistry(reg, store)
+			h, err := admin.NewHandler(store, nsReg)
+			if err != nil {
+				t.Fatalf("NewHandler: %v", err)
+			}
+			srv := httptest.NewServer(h.Mux())
+			t.Cleanup(srv.Close)
+
+			if tc.seed != nil {
+				tc.seed(t, reg, store)
+			}
+			var body []byte
+			if tc.body != nil {
+				var err error
+				body, err = json.Marshal(tc.body)
+				if err != nil {
+					t.Fatalf("Marshal body: %v", err)
+				}
+			}
+			req, err := http.NewRequestWithContext(t.Context(), tc.method, srv.URL+tc.path, bytes.NewReader(body))
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("Do: %v", err)
+			}
+			defer resp.Body.Close()
+			if diff := cmp.Diff(tc.wantStatus, resp.StatusCode); diff != "" {
+				t.Fatalf("status mismatch (-want +got):\n%s", diff)
+			}
+			if tc.wantBody == nil {
+				return
+			}
+			assertJSONBody(t, resp, tc.wantBody)
+		})
+	}
+}
+
+func TestNewHandler_RequiresDependencies(t *testing.T) {
+	t.Parallel()
+
+	reg := oci.NewFakeRegistry()
+	store := namespace.NewStore(reg)
+	nsReg := namespace.NewRegistry(reg, store)
+
+	tests := []struct {
+		name      string
+		store     admin.Store
+		packages  admin.PackageLister
+		wantError string
+	}{
+		{name: "missing store", packages: nsReg, wantError: "store is required"},
+		{name: "missing package lister", store: store, wantError: "package lister is required"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := admin.NewHandler(tc.store, tc.packages)
+			if diff := cmp.Diff(tc.wantError, errString(err)); diff != "" {
+				t.Errorf("NewHandler() error mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func putNamespaceNow(t *testing.T, store *namespace.Store, name string, spec namespace.Spec) {
+	t.Helper()
+	if err := store.Put(t.Context(), &namespace.Namespace{Name: name, Spec: spec}); err != nil {
+		t.Fatalf("Store.Put(%q): %v", name, err)
+	}
+}
+
+func assertJSONBody(t *testing.T, resp *http.Response, want any) {
+	t.Helper()
+	if got, want := resp.Header.Get("Content-Type"), "application/json"; got != want {
+		t.Fatalf("Content-Type = %q, want %q", got, want)
+	}
+	switch want := want.(type) {
+	case *namespace.Namespace:
+		var got namespace.Namespace
+		if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+			t.Fatalf("Decode namespace: %v", err)
+		}
+		if diff := cmp.Diff(*want, got); diff != "" {
+			t.Errorf("body mismatch (-want +got):\n%s", diff)
+		}
+	case map[string]string:
+		var got map[string]string
+		if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+			t.Fatalf("Decode error body: %v", err)
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("body mismatch (-want +got):\n%s", diff)
+		}
+	case map[string][]string:
+		var got map[string][]string
+		if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+			t.Fatalf("Decode list body: %v", err)
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("body mismatch (-want +got):\n%s", diff)
+		}
+	default:
+		t.Fatalf("unsupported want body type %T", want)
+	}
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/pkg/handler/admin/handler_test.go
+++ b/pkg/handler/admin/handler_test.go
@@ -26,6 +26,7 @@ func TestHandler_NamespaceCRUD(t *testing.T) {
 		method     string
 		path       string
 		body       any
+		rawBody    string
 		seed       func(t *testing.T, reg *oci.FakeRegistry, store *namespace.Store)
 		wantStatus int
 		wantBody   any
@@ -67,6 +68,22 @@ func TestHandler_NamespaceCRUD(t *testing.T) {
 			wantBody:   map[string]string{"error": "readers[0]: invalid policy: matcher must populate at least one field"},
 		},
 		{
+			name:       "put malformed json",
+			method:     http.MethodPut,
+			path:       "/admin/v1/namespaces/badjson",
+			rawBody:    `}`,
+			wantStatus: http.StatusBadRequest,
+			wantBody:   map[string]string{"error": "invalid JSON body: invalid character '}' looking for beginning of value"},
+		},
+		{
+			name:       "put unknown json field",
+			method:     http.MethodPut,
+			path:       "/admin/v1/namespaces/unknownfield",
+			rawBody:    `{"bogus":true}`,
+			wantStatus: http.StatusBadRequest,
+			wantBody:   map[string]string{"error": "invalid JSON body: json: unknown field \"bogus\""},
+		},
+		{
 			name:   "get existing namespace",
 			method: http.MethodGet,
 			path:   "/admin/v1/namespaces/alpha",
@@ -83,6 +100,13 @@ func TestHandler_NamespaceCRUD(t *testing.T) {
 			path:       "/admin/v1/namespaces/missing",
 			wantStatus: http.StatusNotFound,
 			wantBody:   map[string]string{"error": "namespace not found: missing"},
+		},
+		{
+			name:       "list namespaces empty",
+			method:     http.MethodGet,
+			path:       "/admin/v1/namespaces",
+			wantStatus: http.StatusOK,
+			wantBody:   map[string][]string{"namespaces": []string{}},
 		},
 		{
 			name:   "list namespaces",
@@ -144,7 +168,9 @@ func TestHandler_NamespaceCRUD(t *testing.T) {
 				tc.seed(t, reg, store)
 			}
 			var body []byte
-			if tc.body != nil {
+			if tc.rawBody != "" {
+				body = []byte(tc.rawBody)
+			} else if tc.body != nil {
 				var err error
 				body, err = json.Marshal(tc.body)
 				if err != nil {

--- a/pkg/handler/integrationtest/harness.go
+++ b/pkg/handler/integrationtest/harness.go
@@ -28,8 +28,6 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"github.com/yolocs/ocifactory/pkg/auth/backend"
-	"github.com/yolocs/ocifactory/pkg/handler/maven"
-	"github.com/yolocs/ocifactory/pkg/handler/python"
 	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
 )
@@ -92,14 +90,11 @@ func Start(t *testing.T, repoType string, extraArgs ...string) *Harness {
 	// deterministic and avoids racing with the first GET.
 	//
 	// The seeded policy admits the AlwaysAnonymous AuthContext the
-	// subprocess installs via --disable-authn. The seed registry
-	// MUST use the same artifact type as the subprocess: pkg/oci's
-	// ReadFile filters file referrers by artifactType, so a seed
-	// written under the default artifact type would be invisible to
-	// a subprocess running with --repo-type=python|maven. Production
-	// deployments register namespaces with real subject matchers and
-	// never use AlwaysAnonymous.
-	seedDefaultNamespace(t, ctx, zotURL, backendRepo, artifactTypeFor(t, repoType))
+	// subprocess installs via --disable-authn. Namespace metadata uses
+	// a format-independent artifact type so the same seed is visible to
+	// every data-plane repo type. Production deployments register
+	// namespaces with real subject matchers and never use AlwaysAnonymous.
+	seedDefaultNamespace(t, ctx, zotURL, backendRepo)
 
 	logPath := filepath.Join(t.TempDir(), "ocifactory.log")
 	logFile, err := os.Create(logPath)
@@ -302,16 +297,14 @@ func SkipIfMissing(t *testing.T, bins ...string) {
 // backend the ocifactory subprocess will read from. The seeded policy
 // admits the AlwaysAnonymous AuthContext that --disable-authn installs.
 //
-// artifactType MUST match the value the subprocess will use (i.e.
-// python.ArtifactType / maven.ArtifactType): pkg/oci tags the file
-// manifest with artifactType+".file" and ReadFile filters referrers
-// by that exact string, so a seed under the wrong artifact type is
-// invisible to the subprocess.
+// Namespace metadata uses namespace.ArtifactType rather than the served
+// format's artifact type so all data-plane repo types read the same
+// control-plane documents.
 //
 // Tests share zot but not the namespace metadata: each test harness
 // owns its own backendRepo prefix, so concurrent integration tests do
 // not race on the same metadata tag.
-func seedDefaultNamespace(t *testing.T, ctx context.Context, zotURL *url.URL, backendRepo, artifactType string) {
+func seedDefaultNamespace(t *testing.T, ctx context.Context, zotURL *url.URL, backendRepo string) {
 	t.Helper()
 	regURL := &url.URL{Scheme: zotURL.Scheme, Host: zotURL.Host, Path: "/" + backendRepo}
 	// Anonymous matches what the subprocess uses
@@ -319,7 +312,7 @@ func seedDefaultNamespace(t *testing.T, ctx context.Context, zotURL *url.URL, ba
 	// doesn't flip behaviour silently.
 	inner, err := oci.NewRegistry(regURL,
 		oci.WithBackendAuth(backend.Anonymous()),
-		oci.WithArtifactType(artifactType),
+		oci.WithArtifactType(namespace.ArtifactType),
 	)
 	if err != nil {
 		t.Fatalf("seed: oci.NewRegistry: %v", err)
@@ -334,22 +327,5 @@ func seedDefaultNamespace(t *testing.T, ctx context.Context, zotURL *url.URL, ba
 		Spec: namespace.Spec{Policy: policy},
 	}); err != nil {
 		t.Fatalf("seed default namespace: %v", err)
-	}
-}
-
-// artifactTypeFor maps a --repo-type value to the artifact type the
-// matching format handler advertises. The seed registry must use the
-// same artifact type as the subprocess so the spec.json file
-// manifest's referrer filter matches on the read side.
-func artifactTypeFor(t *testing.T, repoType string) string {
-	t.Helper()
-	switch repoType {
-	case python.RepoType:
-		return python.ArtifactType
-	case maven.RepoType:
-		return maven.ArtifactType
-	default:
-		t.Fatalf("integrationtest harness has no artifact type registered for repoType=%q", repoType)
-		return ""
 	}
 }

--- a/pkg/namespace/namespace.go
+++ b/pkg/namespace/namespace.go
@@ -9,8 +9,8 @@ import "encoding/json"
 // Namespace is a namespace and its spec. Name is the identifier as
 // it appears in URLs; validation rules live on [ValidateName].
 type Namespace struct {
-	Name string
-	Spec Spec
+	Name string `json:"name"`
+	Spec Spec   `json:"spec"`
 }
 
 // Spec is the persisted body of a [Namespace].
@@ -26,4 +26,12 @@ type Spec struct {
 	// across roundtrips so a newer ocifactory's keys aren't silently
 	// dropped by an older one.
 	Format map[string]json.RawMessage `json:"format,omitempty"`
+}
+
+// Validate returns nil iff s is safe to persist and enforce.
+func (s *Spec) Validate() error {
+	if s == nil {
+		return nil
+	}
+	return s.Policy.Validate()
 }

--- a/pkg/namespace/registry.go
+++ b/pkg/namespace/registry.go
@@ -445,8 +445,10 @@ func (s *ScopedRegistry) ListFiles(ctx context.Context, repo string) ([]*oci.Rep
 
 // ListPackages returns every owning-repo the wrapper has recorded a
 // write for in namespace's package index without applying data-plane
-// authorization. It is intended for control-plane cleanup checks.
-// Tags are decoded back to their original "/"-form.
+// authorization. INTENDED FOR CONTROL-PLANE USE ONLY: callers must
+// already be on the admin trust boundary because this method can
+// enumerate any namespace's package index. Tags are decoded back to
+// their original "/"-form.
 //
 // An absent index repo is reported as an empty list — a namespace
 // that has never been written to legitimately has no packages.

--- a/pkg/namespace/registry.go
+++ b/pkg/namespace/registry.go
@@ -443,23 +443,36 @@ func (s *ScopedRegistry) ListFiles(ctx context.Context, repo string) ([]*oci.Rep
 	return out, nil
 }
 
-// ListPackages authorizes the bound namespace for read and returns
-// every owning-repo the wrapper has recorded a write for in the
-// namespace's package index. Tags are decoded back to their original
-// "/"-form.
+// ListPackages returns every owning-repo the wrapper has recorded a
+// write for in namespace's package index without applying data-plane
+// authorization. It is intended for control-plane cleanup checks.
+// Tags are decoded back to their original "/"-form.
 //
 // An absent index repo is reported as an empty list — a namespace
 // that has never been written to legitimately has no packages.
+func (r *Registry) ListPackages(ctx context.Context, namespace string) ([]string, error) {
+	if err := ValidateName(namespace); err != nil {
+		return nil, err
+	}
+	return r.listPackages(ctx, namespace)
+}
+
+// ListPackages authorizes the bound namespace for read and returns
+// package-index entries for that namespace.
 func (s *ScopedRegistry) ListPackages(ctx context.Context) ([]string, error) {
 	if err := s.parent.authorize(ctx, s.namespace, auth.OpRead); err != nil {
 		return nil, err
 	}
-	tags, err := s.parent.inner.ListTags(ctx, s.parent.packageIndexRepo(s.namespace))
+	return s.parent.listPackages(ctx, s.namespace)
+}
+
+func (r *Registry) listPackages(ctx context.Context, namespace string) ([]string, error) {
+	tags, err := r.inner.ListTags(ctx, r.packageIndexRepo(namespace))
 	if err != nil {
 		if errors.Is(err, errdef.ErrNotFound) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("list package index for %q: %w", s.namespace, err)
+		return nil, fmt.Errorf("list package index for %q: %w", namespace, err)
 	}
 	out := make([]string, 0, len(tags))
 	for _, t := range tags {
@@ -472,7 +485,7 @@ func (s *ScopedRegistry) ListPackages(ctx context.Context) ([]string, error) {
 			// tag is no reason to deny callers their other
 			// packages.
 			logging.FromContext(ctx).WarnContext(ctx, "namespace package index: skipping undecodable tag",
-				"namespace", s.namespace, "tag", t, "error", derr,
+				"namespace", namespace, "tag", t, "error", derr,
 			)
 			continue
 		}

--- a/pkg/namespace/store.go
+++ b/pkg/namespace/store.go
@@ -15,6 +15,11 @@ import (
 )
 
 const (
+	// ArtifactType is the OCI artifact type used for namespace metadata.
+	// It is intentionally format-independent so the admin service and
+	// every data-plane format can read the same namespace documents.
+	ArtifactType = "application/vnd.ocifactory.namespace"
+
 	// DefaultPrefix is empty: namespace "foo" maps to the top-level
 	// OCI repo "foo", and the catalogue index lives at top-level
 	// "ocifactory-namespaces". Operators with a shared OCI registry


### PR DESCRIPTION
### Motivation

- Provide a separate control-plane HTTP service to manage namespace metadata (create/update/list/delete) without registering data-plane artifact handlers.
- Operators must be able to manage namespaces persisted in the OCI backend (the existing `pkg/namespace.Store`) and the admin service must be deployed behind platform-level access controls, so the service intentionally has no internal authn.

### Description

- Add `ocifactory admin serve` CLI (`pkg/commands/admin.go`) with backend-auth, metrics, `--namespace-prefix`, and a startup WARN that the admin service has no internal authentication.
- Implement the admin HTTP API in `pkg/handler/admin` exposing JSON CRUD under `/admin/v1/namespaces` with validation, structured JSON error responses, route names for metrics, and soft-delete semantics that refuse deletion when the namespace package index is non-empty.
- Make namespace artifacts format-independent by adding `namespace.ArtifactType`, add JSON tags on `namespace.Namespace`, and add `Spec.Validate()`; wire a separate OCI registry instance for namespace metadata so admin and data-plane handlers read the same docs (`pkg/commands/serve.go` changes).
- Add a control-plane-friendly `Registry.ListPackages` (plus `listPackages` internal helper) that returns package-index entries without applying per-request data-plane auth, and add tests and docs (`docs/admin.md`) describing the API and deployment model.

### Testing

- Ran `go test -race ./pkg/commands/... ./pkg/handler/admin/...` and the new handler/command tests passed.
- Ran full `go test ./...` and `NO_PROXY='*' go test ./...` to avoid a loopback-proxy issue; the suite passed after the environment adjustment.
- Ran `go vet ./...` and `go build ./...`; both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00ec919710832ea15804584880bb18)