### PR TITLE
Replace soft delete with cascade delete on admin DELETE namespace

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -39,19 +39,52 @@ All endpoints are JSON-only and versioned under `/admin/v1`.
 |---|---|---|---|
 | `PUT` | `/admin/v1/namespaces/{name}` | `namespace.Spec` JSON | `201` with a `namespace.Namespace` on create; `200` on update. |
 | `GET` | `/admin/v1/namespaces/{name}` | none | `200` with a `namespace.Namespace`. |
-| `DELETE` | `/admin/v1/namespaces/{name}` | none | `204` when the namespace exists and is empty. |
+| `DELETE` | `/admin/v1/namespaces/{name}[?cascade=true]` | none | `204` on success. |
 | `GET` | `/admin/v1/namespaces` | none | `200 {"namespaces":[...]}`. |
 
 Errors use `{"error":"message"}`. Invalid namespace names and invalid specs
-return `400`; missing namespaces return `404`; soft-delete of a non-empty
-namespace returns `409`.
+return `400`; missing namespaces return `404`; deleting a non-empty namespace
+without `?cascade=true` returns `409`.
 
-## Soft delete
+## Cascade delete
 
-`DELETE` is intentionally conservative in this phase. ocifactory checks the
-namespace package index and refuses to delete a namespace that still contains
-packages. Remove package data through a future cascade-delete flow before
-deleting those namespaces.
+`DELETE /admin/v1/namespaces/{name}` removes a namespace's metadata and its
+entry in the global index. A namespace that still holds packages must opt in to
+a cascade with `?cascade=true`; without it the call returns `409` and a body of
+`{"error":"namespace is not empty; pass ?cascade=true to delete all packages"}`.
+The explicit query parameter is a guardrail against typo-DELETEs nuking a
+namespace full of artifacts; an empty namespace deletes either way.
+
+```bash
+# Empty namespace: either form succeeds.
+curl -X DELETE https://admin.example.com/admin/v1/namespaces/empty
+
+# Non-empty namespace: opt in.
+curl -X DELETE 'https://admin.example.com/admin/v1/namespaces/team-a?cascade=true'
+```
+
+When `?cascade=true` is set, the admin service enumerates every sub-repo the
+data plane has recorded for the namespace, deletes each one, drops the package
+index repo, and finally removes the namespace metadata. The package index entry
+for each sub-repo is dropped right after that sub-repo is deleted, so a partial
+backend failure is resumable: a retried `DELETE` picks up where the previous
+attempt stopped instead of restarting from scratch.
+
+The OCI registry does not give us an atomic multi-repo transaction, so cascade
+is best-effort across two boundaries:
+
+- **Partial failure mid-cascade** returns `500` with the underlying error. The
+  namespace metadata is left intact so a retry is meaningful.
+- **Concurrent writes during cascade** can leave a single sub-repo's index tag
+  behind (the write landed after the snapshot listing). Operators are expected
+  to block external writes before issuing `DELETE`. The current implementation
+  intentionally does not introduce a "deleting" state on the namespace; that
+  state machine is deferred until a real user reports the race.
+
+Deleting an unknown namespace returns `404`. Synthetic namespaces that some
+future data-plane configuration may serve without storing in OCI (for example,
+a `default` namespace under a forthcoming `--default-namespace-allow-all`
+mode) are not visible to the admin store and likewise return `404` on `DELETE`.
 
 ## Health, readiness, and metrics
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/testcontainers/testcontainers-go v0.42.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.20.0
 	oras.land/oras-go/v2 v2.6.0
 )
 
@@ -84,7 +85,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.50.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect

--- a/pkg/handler/admin/handler.go
+++ b/pkg/handler/admin/handler.go
@@ -28,25 +28,28 @@ type Store interface {
 	Delete(ctx context.Context, name string) error
 }
 
-// PackageLister reports package-index entries for a namespace so DELETE can
-// refuse soft deletion of non-empty namespaces.
-type PackageLister interface {
+// PackageRegistry enumerates and bulk-deletes the OCI sub-repos a
+// namespace holds. The admin DELETE flow uses ListPackages to gate
+// the 409 / cascade decision and CascadeDelete to drop every sub-repo
+// before the namespace metadata is removed.
+type PackageRegistry interface {
 	ListPackages(ctx context.Context, name string) ([]string, error)
+	CascadeDelete(ctx context.Context, name string) error
 }
 
 // Handler serves the admin HTTP API.
 type Handler struct {
 	store    Store
-	packages PackageLister
+	packages PackageRegistry
 }
 
 // NewHandler returns an admin API handler backed by store and packages.
-func NewHandler(store Store, packages PackageLister) (*Handler, error) {
+func NewHandler(store Store, packages PackageRegistry) (*Handler, error) {
 	if store == nil {
 		return nil, fmt.Errorf("store is required")
 	}
 	if packages == nil {
-		return nil, fmt.Errorf("package lister is required")
+		return nil, fmt.Errorf("package registry is required")
 	}
 	return &Handler{store: store, packages: packages}, nil
 }
@@ -149,24 +152,44 @@ func (h *Handler) deleteNamespace(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Soft delete is a best-effort guard until cascade delete lands: an
-	// upload racing between ListPackages and Store.Delete can still leave
-	// package sentinels behind. The follow-up cascade flow owns closing
-	// that window.
+	// ?cascade=true opts in to wiping every sub-repo under the
+	// namespace before dropping its metadata. The explicit query
+	// param is a guardrail against typo-DELETEs nuking a namespace
+	// full of artifacts; an empty namespace deletes either way so
+	// the common "I'm done with this" path stays a single curl.
+	cascade := parseCascade(r.URL.Query().Get("cascade"))
+
 	packages, err := h.packages.ListPackages(r.Context(), name)
 	if err != nil {
 		writeAdminError(r.Context(), w, err)
 		return
 	}
-	if len(packages) > 0 {
-		writeJSON(w, http.StatusConflict, errorResponse{Error: "namespace is not empty"})
+	if len(packages) > 0 && !cascade {
+		writeJSON(w, http.StatusConflict, errorResponse{Error: "namespace is not empty; pass ?cascade=true to delete all packages"})
 		return
+	}
+	if cascade {
+		if err := h.packages.CascadeDelete(r.Context(), name); err != nil {
+			writeAdminError(r.Context(), w, err)
+			return
+		}
 	}
 	if err := h.store.Delete(r.Context(), name); err != nil {
 		writeAdminError(r.Context(), w, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// parseCascade accepts the standard truthy spellings ("true", "1",
+// "yes"). Anything else — including the absence of the query param —
+// is false so a stray "?cascade=maybe" doesn't surprise the operator.
+func parseCascade(v string) bool {
+	switch v {
+	case "true", "1", "yes":
+		return true
+	}
+	return false
 }
 
 func writeAdminError(ctx context.Context, w http.ResponseWriter, err error) {

--- a/pkg/handler/admin/handler_test.go
+++ b/pkg/handler/admin/handler_test.go
@@ -2,14 +2,21 @@ package admin_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path"
+	"slices"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/yolocs/ocifactory/pkg/auth"
 	"github.com/yolocs/ocifactory/pkg/handler/admin"
 	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
@@ -106,7 +113,7 @@ func TestHandler_NamespaceCRUD(t *testing.T) {
 			method:     http.MethodGet,
 			path:       "/admin/v1/namespaces",
 			wantStatus: http.StatusOK,
-			wantBody:   map[string][]string{"namespaces": []string{}},
+			wantBody:   map[string][]string{"namespaces": {}},
 		},
 		{
 			name:   "list namespaces",
@@ -118,10 +125,10 @@ func TestHandler_NamespaceCRUD(t *testing.T) {
 				putNamespaceNow(t, store, "beta", namespace.Spec{})
 			},
 			wantStatus: http.StatusOK,
-			wantBody:   map[string][]string{"namespaces": []string{"alpha", "beta"}},
+			wantBody:   map[string][]string{"namespaces": {"alpha", "beta"}},
 		},
 		{
-			name:   "delete non-empty namespace",
+			name:   "delete non-empty namespace without cascade",
 			method: http.MethodDelete,
 			path:   "/admin/v1/namespaces/alpha",
 			seed: func(t *testing.T, reg *oci.FakeRegistry, store *namespace.Store) {
@@ -130,7 +137,7 @@ func TestHandler_NamespaceCRUD(t *testing.T) {
 				reg.AddTag(path.Join("alpha", "ocifactory-packages"), hex.EncodeToString([]byte("pkg")))
 			},
 			wantStatus: http.StatusConflict,
-			wantBody:   map[string]string{"error": "namespace is not empty"},
+			wantBody:   map[string]string{"error": "namespace is not empty; pass ?cascade=true to delete all packages"},
 		},
 		{
 			name:   "delete empty namespace",
@@ -143,11 +150,28 @@ func TestHandler_NamespaceCRUD(t *testing.T) {
 			wantStatus: http.StatusNoContent,
 		},
 		{
+			name:   "delete empty namespace with cascade is a no-op cascade",
+			method: http.MethodDelete,
+			path:   "/admin/v1/namespaces/beta?cascade=true",
+			seed: func(t *testing.T, reg *oci.FakeRegistry, store *namespace.Store) {
+				t.Helper()
+				putNamespaceNow(t, store, "beta", namespace.Spec{})
+			},
+			wantStatus: http.StatusNoContent,
+		},
+		{
 			name:       "delete unknown namespace",
 			method:     http.MethodDelete,
 			path:       "/admin/v1/namespaces/beta",
 			wantStatus: http.StatusNotFound,
 			wantBody:   map[string]string{"error": "namespace not found: beta"},
+		},
+		{
+			name:       "delete unknown namespace with cascade is still 404",
+			method:     http.MethodDelete,
+			path:       "/admin/v1/namespaces/default?cascade=true",
+			wantStatus: http.StatusNotFound,
+			wantBody:   map[string]string{"error": "namespace not found: default"},
 		},
 	}
 
@@ -207,11 +231,11 @@ func TestNewHandler_RequiresDependencies(t *testing.T) {
 	tests := []struct {
 		name      string
 		store     admin.Store
-		packages  admin.PackageLister
+		packages  admin.PackageRegistry
 		wantError string
 	}{
 		{name: "missing store", packages: nsReg, wantError: "store is required"},
-		{name: "missing package lister", store: store, wantError: "package lister is required"},
+		{name: "missing package registry", store: store, wantError: "package registry is required"},
 	}
 
 	for _, tc := range tests {
@@ -229,6 +253,200 @@ func putNamespaceNow(t *testing.T, store *namespace.Store, name string, spec nam
 	t.Helper()
 	if err := store.Put(t.Context(), &namespace.Namespace{Name: name, Spec: spec}); err != nil {
 		t.Fatalf("Store.Put(%q): %v", name, err)
+	}
+}
+
+// TestHandler_DeleteCascade exercises the full cascade flow against a
+// fully-populated namespace: writes land in the OCI fake via the
+// namespace.ScopedRegistry (the same code path data-plane handlers
+// use), then DELETE ?cascade=true must wipe every sub-repo plus the
+// package index plus the namespace metadata.
+func TestHandler_DeleteCascade(t *testing.T) {
+	t.Parallel()
+
+	fake := oci.NewFakeRegistry()
+	store := namespace.NewStore(fake)
+	nsReg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	putNamespaceNow(t, store, "alpha", allowAllAdminSpec())
+
+	scoped := nsReg.For("alpha")
+	ctx := allowAllCtx(t)
+	for _, repo := range []string{"packages/foo", "packages/bar", "tools/cli"} {
+		writeAdminFile(t, ctx, scoped, repo, "1.0.0", "f.txt", "body")
+	}
+
+	h, err := admin.NewHandler(store, nsReg)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	srv := httptest.NewServer(h.Mux())
+	t.Cleanup(srv.Close)
+
+	doAdminRequest(t, srv.URL+"/admin/v1/namespaces/alpha?cascade=true", http.MethodDelete, http.StatusNoContent)
+
+	// Every sub-repo gone.
+	for _, repo := range []string{"alpha/packages/foo", "alpha/packages/bar", "alpha/tools/cli"} {
+		for k := range fake.Files {
+			if strings.HasPrefix(k, repo+"/") {
+				t.Errorf("file %q remained after cascade", k)
+			}
+		}
+	}
+	// Package index repo gone.
+	if got, ok := fake.Tags["alpha/ocifactory-packages"]; ok {
+		t.Errorf("package index tags = %v, want absent", got)
+	}
+	// Namespace metadata + global index entry gone.
+	if got, ok := fake.Tags["alpha"]; ok {
+		t.Errorf("namespace metadata tags = %v, want absent", got)
+	}
+	if got, ok := fake.Tags["ocifactory-namespaces"]; ok && slices.Contains(got, "alpha") {
+		t.Errorf("global namespace index = %v, still contains alpha", got)
+	}
+
+	// Re-create the same-name namespace and write a package: the
+	// in-process indexed-LRU sweep must let recordPackage land a
+	// fresh tag in the new index repo.
+	putNamespaceNow(t, store, "alpha", allowAllAdminSpec())
+	writeAdminFile(t, ctx, nsReg.For("alpha"), "packages/foo", "2.0.0", "f.txt", "body")
+	pkgs, err := nsReg.ListPackages(t.Context(), "alpha")
+	if err != nil {
+		t.Fatalf("ListPackages after re-create: %v", err)
+	}
+	if diff := cmp.Diff([]string{"packages/foo"}, pkgs); diff != "" {
+		t.Errorf("ListPackages after re-create mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestHandler_DeleteCascade_Resumable simulates a partial failure
+// mid-cascade and verifies a retried DELETE converges. The
+// flakyBackend fails the third DeleteRepoFiles call; the first
+// DELETE returns 500, the second succeeds.
+func TestHandler_DeleteCascade_Resumable(t *testing.T) {
+	t.Parallel()
+
+	fake := oci.NewFakeRegistry()
+	flaky := &flakyBackend{FakeRegistry: fake}
+	store := namespace.NewStore(flaky)
+	nsReg := namespace.NewRegistry(flaky, store, namespace.WithPolicyCacheTTL(0))
+	putNamespaceNow(t, store, "alpha", allowAllAdminSpec())
+
+	scoped := nsReg.For("alpha")
+	ctx := allowAllCtx(t)
+	repos := []string{"packages/aaa", "packages/bbb", "packages/ccc", "packages/ddd"}
+	for _, repo := range repos {
+		writeAdminFile(t, ctx, scoped, repo, "1.0.0", "f.txt", "body")
+	}
+
+	h, err := admin.NewHandler(store, nsReg)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	srv := httptest.NewServer(h.Mux())
+	t.Cleanup(srv.Close)
+
+	flaky.failAfter.Store(2) // succeed twice, fail the third call
+	doAdminRequest(t, srv.URL+"/admin/v1/namespaces/alpha?cascade=true", http.MethodDelete, http.StatusInternalServerError)
+
+	// At least one sub-repo is still around (the one whose delete
+	// was rejected). The namespace metadata is intact.
+	if _, ok := fake.Tags["alpha"]; !ok {
+		t.Fatal("namespace metadata gone after partial cascade; resumability is impossible")
+	}
+	survivors := 0
+	for _, repo := range repos {
+		if _, ok := fake.Tags["alpha/"+repo]; ok {
+			survivors++
+		}
+	}
+	if survivors == 0 {
+		t.Fatal("expected at least one sub-repo to survive the partial cascade")
+	}
+
+	// Stop the failure injection and retry. The cascade must
+	// converge: every sub-repo gone, namespace metadata gone.
+	flaky.failAfter.Store(-1)
+	doAdminRequest(t, srv.URL+"/admin/v1/namespaces/alpha?cascade=true", http.MethodDelete, http.StatusNoContent)
+
+	for _, repo := range repos {
+		if _, ok := fake.Tags["alpha/"+repo]; ok {
+			t.Errorf("sub-repo alpha/%s remained after retry", repo)
+		}
+	}
+	if _, ok := fake.Tags["alpha"]; ok {
+		t.Error("namespace metadata still present after successful retry")
+	}
+}
+
+func allowAllAdminSpec() namespace.Spec {
+	return namespace.Spec{Policy: namespace.Policy{
+		Readers: []namespace.SubjectMatcher{{Issuer: "https://accounts.google.com"}},
+		Writers: []namespace.SubjectMatcher{{Issuer: "https://accounts.google.com"}},
+	}}
+}
+
+func allowAllCtx(t *testing.T) context.Context {
+	t.Helper()
+	return auth.WithAuthContext(t.Context(), &auth.AuthContext{
+		Issuer: "https://accounts.google.com",
+		ID:     "alice",
+		Email:  "alice@example.com",
+	})
+}
+
+func writeAdminFile(t *testing.T, ctx context.Context, scoped *namespace.ScopedRegistry, repo, tag, name, body string) {
+	t.Helper()
+	rf := &oci.RepoFile{
+		OwningRepo: repo,
+		OwningTag:  tag,
+		Name:       name,
+		MediaType:  "application/octet-stream",
+		Size:       int64(len(body)),
+	}
+	if _, err := scoped.AddFile(ctx, rf, strings.NewReader(body)); err != nil {
+		t.Fatalf("AddFile %s/%s/%s: %v", repo, tag, name, err)
+	}
+}
+
+func doAdminRequest(t *testing.T, url, method string, wantStatus int) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), method, url, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != wantStatus {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("%s %s: status = %d, want %d (body: %s)", method, url, resp.StatusCode, wantStatus, body)
+	}
+}
+
+// flakyBackend wraps an oci.FakeRegistry and returns an injected
+// error from DeleteRepoFiles when failAfter reaches zero. Used to
+// simulate a partial cascade failure for resumability tests.
+// failAfter is decremented on each call; negative values disable the
+// failure injection.
+type flakyBackend struct {
+	*oci.FakeRegistry
+	failAfter atomic.Int32
+}
+
+func (f *flakyBackend) DeleteRepoFiles(ctx context.Context, repo string) error {
+	for {
+		remaining := f.failAfter.Load()
+		if remaining == 0 {
+			return errors.New("simulated backend failure")
+		}
+		if remaining < 0 {
+			return f.FakeRegistry.DeleteRepoFiles(ctx, repo)
+		}
+		if f.failAfter.CompareAndSwap(remaining, remaining-1) {
+			return f.FakeRegistry.DeleteRepoFiles(ctx, repo)
+		}
 	}
 }
 

--- a/pkg/namespace/registry.go
+++ b/pkg/namespace/registry.go
@@ -459,6 +459,70 @@ func (r *Registry) ListPackages(ctx context.Context, namespace string) ([]string
 	return r.listPackages(ctx, namespace)
 }
 
+// CascadeDelete removes every sub-repo recorded in namespace's
+// package index, dropping each index tag right after its sub-repo is
+// deleted so a retried call after a partial failure picks up where
+// the previous attempt stopped. The package index repo itself is
+// dropped last (defensive: catches stray tags that never decoded), as
+// is the in-process LRU of indexed (namespace, owning-repo) keys —
+// without that sweep a re-created same-name namespace would not
+// re-record its packages.
+//
+// INTENDED FOR CONTROL-PLANE USE ONLY: bypasses data-plane
+// authorization. Callers (typically the admin DELETE endpoint) must
+// already sit on the admin trust boundary.
+//
+// Concurrent writes during cascade can leave a single sub-repo's tag
+// behind (the wrapper recorded it after ListPackages snapshotted the
+// index). Operators are expected to block external writes before
+// issuing DELETE; see issue #74 for the documented limitation.
+func (r *Registry) CascadeDelete(ctx context.Context, namespace string) error {
+	if err := ValidateName(namespace); err != nil {
+		return err
+	}
+	packages, err := r.listPackages(ctx, namespace)
+	if err != nil {
+		return err
+	}
+	indexRepo := r.packageIndexRepo(namespace)
+	for _, owningRepo := range packages {
+		subRepo := path.Join(namespace, owningRepo)
+		if err := r.inner.DeleteRepoFiles(ctx, subRepo); err != nil {
+			return fmt.Errorf("delete sub-repo %q: %w", subRepo, err)
+		}
+		encoded, encErr := encodeTag(owningRepo)
+		if encErr != nil {
+			// listPackages only returns tags that round-tripped through
+			// decodeTag, so re-encoding must succeed. Treat as a bug
+			// and skip the index drop rather than failing the whole
+			// cascade — the trailing DeleteRepoFiles(indexRepo) will
+			// reap any residue.
+			logging.FromContext(ctx).WarnContext(ctx, "cascade delete: encode failed on cleanup",
+				"namespace", namespace, "owning_repo", owningRepo, "error", encErr,
+			)
+		} else if err := r.inner.DeleteTagFiles(ctx, indexRepo, encoded); err != nil && !errors.Is(err, errdef.ErrNotFound) {
+			return fmt.Errorf("drop package index tag for %q: %w", owningRepo, err)
+		}
+		r.indexed.Remove(indexedKey(namespace, owningRepo))
+	}
+	// Final defensive sweep of the index repo itself catches
+	// undecodable tags listPackages skipped and lets a future
+	// same-name namespace start from an empty index.
+	if err := r.inner.DeleteRepoFiles(ctx, indexRepo); err != nil {
+		return fmt.Errorf("delete package index repo: %w", err)
+	}
+	// Drop any remaining in-process indexed-LRU entries for this
+	// namespace. The keys carry the namespace as a "<ns>\x00..."
+	// prefix; iterate the snapshot returned by Keys() and remove.
+	prefix := namespace + "\x00"
+	for _, k := range r.indexed.Keys() {
+		if strings.HasPrefix(k, prefix) {
+			r.indexed.Remove(k)
+		}
+	}
+	return nil
+}
+
 // ListPackages authorizes the bound namespace for read and returns
 // package-index entries for that namespace.
 func (s *ScopedRegistry) ListPackages(ctx context.Context) ([]string, error) {

--- a/pkg/namespace/registry_test.go
+++ b/pkg/namespace/registry_test.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -812,6 +813,174 @@ func TestScopedRegistry_DeleteRepoFiles_SweepsBackendIndex(t *testing.T) {
 	if !slices.Contains(pkgs, repoFoo) {
 		t.Errorf("ListPackages re-add = %v, want to contain %q", pkgs, repoFoo)
 	}
+}
+
+// TestRegistry_CascadeDelete_HappyPath writes packages through the
+// scoped registry, then runs cascade and verifies every sub-repo and
+// the package index repo are gone.
+func TestRegistry_CascadeDelete_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	fake, reg, store := setup(t)
+	putNamespace(t, store, "alpha", allowAllSpec())
+	ctx := aliceCtx(t)
+	scoped := reg.For("alpha")
+
+	repos := []string{repoFoo, repoBar, "tools/cli"}
+	for _, r := range repos {
+		if _, err := scoped.AddFile(ctx, newRepoFile(r, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+			t.Fatalf("AddFile %s: %v", r, err)
+		}
+	}
+
+	if err := reg.CascadeDelete(t.Context(), "alpha"); err != nil {
+		t.Fatalf("CascadeDelete: %v", err)
+	}
+
+	for _, r := range repos {
+		prefix := "alpha/" + r + "/"
+		for k := range fake.Files {
+			if strings.HasPrefix(k, prefix) {
+				t.Errorf("file %q remained after cascade", k)
+			}
+		}
+		if _, ok := fake.Tags["alpha/"+r]; ok {
+			t.Errorf("tags for alpha/%s remained after cascade", r)
+		}
+	}
+	if _, ok := fake.Tags["alpha/ocifactory-packages"]; ok {
+		t.Error("package index repo remained after cascade")
+	}
+}
+
+// TestRegistry_CascadeDelete_Empty: cascading an empty namespace is
+// a no-op that still succeeds.
+func TestRegistry_CascadeDelete_Empty(t *testing.T) {
+	t.Parallel()
+
+	_, reg, store := setup(t)
+	putNamespace(t, store, "alpha", allowAllSpec())
+
+	if err := reg.CascadeDelete(t.Context(), "alpha"); err != nil {
+		t.Errorf("CascadeDelete empty: %v", err)
+	}
+}
+
+// TestRegistry_CascadeDelete_InvalidName rejects malformed input
+// before touching the backend.
+func TestRegistry_CascadeDelete_InvalidName(t *testing.T) {
+	t.Parallel()
+
+	_, reg, _ := setup(t)
+	if err := reg.CascadeDelete(t.Context(), "Bad_Name"); !errors.Is(err, namespace.ErrInvalidName) {
+		t.Errorf("CascadeDelete bad name = %v, want errors.Is(ErrInvalidName)", err)
+	}
+}
+
+// TestRegistry_CascadeDelete_Resumable: a backend that fails the
+// third DeleteRepoFiles call leaves a partial state. A retried
+// cascade converges; everything is gone.
+func TestRegistry_CascadeDelete_Resumable(t *testing.T) {
+	t.Parallel()
+
+	fake := oci.NewFakeRegistry()
+	flaky := &flakyDeleteBackend{FakeRegistry: fake}
+	store := namespace.NewStore(flaky)
+	reg := namespace.NewRegistry(flaky, store, namespace.WithPolicyCacheTTL(0))
+	putNamespace(t, store, "alpha", allowAllSpec())
+	ctx := aliceCtx(t)
+	scoped := reg.For("alpha")
+
+	repos := []string{"packages/aaa", "packages/bbb", "packages/ccc", "packages/ddd"}
+	for _, r := range repos {
+		if _, err := scoped.AddFile(ctx, newRepoFile(r, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+			t.Fatalf("AddFile %s: %v", r, err)
+		}
+	}
+
+	flaky.failOn.Store(3) // fail the 3rd DeleteRepoFiles call
+	if err := reg.CascadeDelete(t.Context(), "alpha"); err == nil {
+		t.Fatal("CascadeDelete returned nil, want error from injected failure")
+	}
+	survivors := 0
+	for _, r := range repos {
+		if _, ok := fake.Tags["alpha/"+r]; ok {
+			survivors++
+		}
+	}
+	if survivors == 0 {
+		t.Fatal("expected partial cascade to leave at least one sub-repo behind")
+	}
+
+	flaky.failOn.Store(-1)
+	if err := reg.CascadeDelete(t.Context(), "alpha"); err != nil {
+		t.Fatalf("CascadeDelete retry: %v", err)
+	}
+	for _, r := range repos {
+		if _, ok := fake.Tags["alpha/"+r]; ok {
+			t.Errorf("sub-repo alpha/%s remained after retry", r)
+		}
+	}
+	if _, ok := fake.Tags["alpha/ocifactory-packages"]; ok {
+		t.Error("package index repo remained after retry")
+	}
+}
+
+// TestRegistry_CascadeDelete_ClearsIndexedLRU: after cascade,
+// re-creating the same-name namespace and writing a package must land
+// a fresh entry in the new index repo (proving the in-process LRU
+// sweep happened).
+func TestRegistry_CascadeDelete_ClearsIndexedLRU(t *testing.T) {
+	t.Parallel()
+
+	fake, reg, store := setup(t)
+	putNamespace(t, store, "alpha", allowAllSpec())
+	ctx := aliceCtx(t)
+	scoped := reg.For("alpha")
+
+	if _, err := scoped.AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+		t.Fatalf("AddFile: %v", err)
+	}
+
+	if err := reg.CascadeDelete(t.Context(), "alpha"); err != nil {
+		t.Fatalf("CascadeDelete: %v", err)
+	}
+	if err := store.Delete(t.Context(), "alpha"); err != nil {
+		t.Fatalf("store.Delete: %v", err)
+	}
+
+	putNamespace(t, store, "alpha", allowAllSpec())
+	if _, err := reg.For("alpha").AddFile(ctx, newRepoFile(repoFoo, "2.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+		t.Fatalf("AddFile after re-create: %v", err)
+	}
+
+	pkgs, err := reg.ListPackages(t.Context(), "alpha")
+	if err != nil {
+		t.Fatalf("ListPackages: %v", err)
+	}
+	if diff := cmp.Diff([]string{repoFoo}, pkgs); diff != "" {
+		t.Errorf("ListPackages after re-create mismatch (-want +got):\n%s", diff)
+	}
+	// Sanity: the recorded package landed back in the index repo.
+	if got, ok := fake.Tags["alpha/ocifactory-packages"]; !ok || len(got) == 0 {
+		t.Errorf("package index repo = %v (ok=%v), want a tag for re-recorded package", got, ok)
+	}
+}
+
+// flakyDeleteBackend fails DeleteRepoFiles when failOn matches the
+// call count. failOn < 1 disables the injection.
+type flakyDeleteBackend struct {
+	*oci.FakeRegistry
+	failOn atomic.Int32
+	calls  atomic.Int32
+}
+
+func (f *flakyDeleteBackend) DeleteRepoFiles(ctx context.Context, repo string) error {
+	count := f.calls.Add(1)
+	if want := f.failOn.Load(); want > 0 && count == want {
+		return errors.New("simulated delete failure")
+	}
+	return f.FakeRegistry.DeleteRepoFiles(ctx, repo)
 }
 
 // TestRegistry_PolicyCache_HotPathSkipsStore counts spec.json reads


### PR DESCRIPTION
Adds Registry.CascadeDelete that enumerates the per-namespace package
index, deletes every recorded sub-repo, drops each index tag right
after the sub-repo it points to so a retried call resumes where a
partial failure stopped, and finally drops the package index repo plus
the in-process indexed-LRU entries for the namespace.

The admin DELETE handler now opts into cascade via ?cascade=true: an
empty namespace deletes either way; a non-empty namespace without the
flag returns 409 so a typo in `curl -X DELETE` does not nuke a
namespace full of artifacts. docs/admin.md documents the new contract,
the resumability story, and the documented race with concurrent
writes.

Closes #74

https://claude.ai/code/session_015MSazNK4gN7z6dEbbQFtmo