### PR TITLE
Add --maven-max-upload-bytes upload cap to maven handler

### DIFF
--- a/docs/repos/maven.md
+++ b/docs/repos/maven.md
@@ -229,13 +229,9 @@ artifact. Tracked by [#49](https://github.com/yolocs/ocifactory/issues/49).
 | Flag | Default | Purpose |
 |---|---|---|
 | `--allow-overwrite` | `false` | **REQUIRED to set to `true` for any working Maven deployment** — see the warning at the top. |
+| `--maven-max-upload-bytes` | `1073741824` (1 GiB) | Caps the total request body the upload endpoint accepts. Defends against an authenticated client streaming arbitrary bytes to burn instance hours / egress before the OCI backend rejects the layer. Set to `0` to disable; tighten for cost-sensitive deployments. Oversize requests are rejected with `413 Payload Too Large` before they touch the OCI backend. |
 | `--disable-streaming-push` | `false` | Force buffered+monolithic uploads through the OCI backend instead of chunked PATCH. Set only if your backend has broken chunked-PATCH support. |
 | `--disable-blob-redirect` | `false` | Disable `307` redirects to backend-issued presigned URLs on blob downloads. Set when exposing backend URLs to clients is unacceptable (egress restrictions, DLP, audit). |
-
-Maven uploads carry a `Content-Length` header and stream straight to
-the OCI backend; there is no Maven-specific upload-size knob. The
-effective upload limit is whatever your OCI backend enforces on a
-single layer push.
 
 Common server-wide flags (`--port`, `--backend-registry`,
 `--enable-metrics`, the `--authn-*` and `--backend-auth-*` families)

--- a/pkg/commands/serve.go
+++ b/pkg/commands/serve.go
@@ -69,6 +69,7 @@ const (
 	flagAllowOverwrite                  = "allow-overwrite"
 	flagSimpleIndexCacheTTL             = "simple-index-cache-ttl"
 	flagPythonMaxUploadBytes            = "python-max-upload-bytes"
+	flagMavenMaxUploadBytes             = "maven-max-upload-bytes"
 	flagEnableMetrics                   = "enable-metrics"
 	flagMetricsPath                     = "metrics-path"
 	flagDisableAuthn                    = "disable-authn"
@@ -96,6 +97,7 @@ type serveConfig struct {
 	AllowOverwrite       bool          `mapstructure:"allow-overwrite"`
 	SimpleIndexCacheTTL  time.Duration `mapstructure:"simple-index-cache-ttl"`
 	PythonMaxUploadBytes int64         `mapstructure:"python-max-upload-bytes"`
+	MavenMaxUploadBytes  int64         `mapstructure:"maven-max-upload-bytes"`
 	EnableMetrics        bool          `mapstructure:"enable-metrics"`
 	MetricsPath          string        `mapstructure:"metrics-path"`
 
@@ -285,6 +287,11 @@ func registerServeFlags(flags *pflag.FlagSet) {
 			"endpoint. Defends against an authenticated client streaming "+
 			"arbitrary bytes to burn instance hours / egress before the OCI "+
 			"backend rejects the layer. Set to 0 to disable the cap.")
+	flags.Int64(flagMavenMaxUploadBytes, maven.DefaultMaxUploadBytes,
+		"Cap on the total request-body size accepted by the maven upload "+
+			"endpoint. Defends against an authenticated client streaming "+
+			"arbitrary bytes to burn instance hours / egress before the OCI "+
+			"backend rejects the layer. Set to 0 to disable the cap.")
 	flags.Bool(flagEnableMetrics, true,
 		"Expose Prometheus metrics at --metrics-path and instrument the "+
 			"HTTP and OCI backend layers. When false, the no-op recorder is "+
@@ -372,7 +379,10 @@ func runServe(ctx context.Context, cfg *serveConfig) error {
 			return fmt.Errorf("failed to create namespace registry: %w", err)
 		}
 		nsReg := namespace.NewRegistry(r, namespace.NewStore(storeReg))
-		mh, err := maven.NewHandler(nsReg, maven.WithAuthMiddleware(authMW))
+		mh, err := maven.NewHandler(nsReg,
+			maven.WithAuthMiddleware(authMW),
+			maven.WithMaxUploadBytes(cfg.MavenMaxUploadBytes),
+		)
 		if err != nil {
 			return fmt.Errorf("failed to create maven handler: %w", err)
 		}

--- a/pkg/commands/serve_test.go
+++ b/pkg/commands/serve_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/yolocs/ocifactory/pkg/handler/maven"
 	"github.com/yolocs/ocifactory/pkg/handler/python"
 	"github.com/yolocs/ocifactory/pkg/testutil"
 )
@@ -251,6 +252,7 @@ func TestServeCmd_EnvVarBindings(t *testing.T) {
 		MetricsPath:          "/metrics",
 		SimpleIndexCacheTTL:  13 * time.Second,
 		PythonMaxUploadBytes: python.DefaultMaxUploadBytes,
+		MavenMaxUploadBytes:  maven.DefaultMaxUploadBytes,
 		DisableAuthn:         true,
 		AuthnKind:            "oidc",
 		AuthnOIDCIssuers: []string{

--- a/pkg/handler/maven/handler.go
+++ b/pkg/handler/maven/handler.go
@@ -20,6 +20,12 @@ import (
 const (
 	RepoType     = "maven"
 	ArtifactType = "application/vnd.ocifactory.maven"
+
+	// DefaultMaxUploadBytes caps the total request-body size accepted
+	// by every PUT route. 1 GiB matches python's default; mvn deploy
+	// of artifacts above 1 GiB is rare and the operator can opt in
+	// via WithMaxUploadBytes / --maven-max-upload-bytes.
+	DefaultMaxUploadBytes int64 = 1 << 30
 )
 
 var (
@@ -48,15 +54,17 @@ var (
 )
 
 type Handler struct {
-	registry *namespace.Registry
-	authMW   func(http.Handler) http.Handler
+	registry       *namespace.Registry
+	authMW         func(http.Handler) http.Handler
+	maxUploadBytes int64
 }
 
 // Option configures optional Handler behaviour.
 type Option func(*handlerConfig)
 
 type handlerConfig struct {
-	authMW func(http.Handler) http.Handler
+	authMW         func(http.Handler) http.Handler
+	maxUploadBytes int64
 }
 
 // WithAuthMiddleware installs an authentication middleware on
@@ -68,6 +76,15 @@ func WithAuthMiddleware(mw func(http.Handler) http.Handler) Option {
 	}
 }
 
+// WithMaxUploadBytes caps the total request-body size accepted by
+// every Maven PUT route. The default is DefaultMaxUploadBytes
+// (1 GiB). A non-positive value disables the cap (not recommended).
+func WithMaxUploadBytes(n int64) Option {
+	return func(c *handlerConfig) {
+		c.maxUploadBytes = n
+	}
+}
+
 // NewHandler creates a new Handler.
 //
 // registry is the data-plane wrapper that hands out per-request
@@ -75,11 +92,17 @@ func WithAuthMiddleware(mw func(http.Handler) http.Handler) Option {
 // handler func resolves the namespace from the request URL
 // (`/{namespace}/maven2/...`) and obtains a scoped view at the top.
 func NewHandler(registry *namespace.Registry, opts ...Option) (*Handler, error) {
-	cfg := handlerConfig{}
+	cfg := handlerConfig{
+		maxUploadBytes: DefaultMaxUploadBytes,
+	}
 	for _, opt := range opts {
 		opt(&cfg)
 	}
-	return &Handler{registry: registry, authMW: cfg.authMW}, nil
+	return &Handler{
+		registry:       registry,
+		authMW:         cfg.authMW,
+		maxUploadBytes: cfg.maxUploadBytes,
+	}, nil
 }
 
 // Mux returns the maven handler's router. Every route lives under
@@ -220,12 +243,21 @@ func (h *Handler) handleRegularArtifact(w http.ResponseWriter, req *http.Request
 func (h *Handler) handlePut(w http.ResponseWriter, req *http.Request, scoped handler.Registry, f *oci.RepoFile) {
 	logger := logging.FromContext(req.Context())
 
+	if h.maxUploadBytes > 0 {
+		req.Body = http.MaxBytesReader(w, req.Body, h.maxUploadBytes)
+	}
+
 	defer req.Body.Close()
 
 	body, err := h.maybeVerifyChecksum(req, scoped, f)
 	if err != nil {
 		logger.DebugContext(req.Context(), "checksum verification failed", "error", err)
 		if handler.WriteNamespaceError(w, err) {
+			return
+		}
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			http.Error(w, fmt.Sprintf("upload exceeds %d-byte limit", maxBytesErr.Limit), http.StatusRequestEntityTooLarge)
 			return
 		}
 		code := httpStatus(err)
@@ -245,19 +277,19 @@ func (h *Handler) handlePut(w http.ResponseWriter, req *http.Request, scoped han
 		if handler.WriteNamespaceError(w, err) {
 			return
 		}
-		if errors.Is(err, oci.ErrAlreadyExists) {
+		var maxBytesErr *http.MaxBytesError
+		switch {
+		case errors.As(err, &maxBytesErr):
+			http.Error(w, fmt.Sprintf("upload exceeds %d-byte limit", maxBytesErr.Limit), http.StatusRequestEntityTooLarge)
+		case errors.Is(err, oci.ErrAlreadyExists):
 			http.Error(w, "file already exists in version", http.StatusConflict)
-			return
-		}
-		if oci.HasCode(err, http.StatusUnauthorized) {
+		case oci.HasCode(err, http.StatusUnauthorized):
 			http.Error(w, err.Error(), http.StatusUnauthorized)
-			return
-		}
-		if oci.HasCode(err, http.StatusForbidden) {
+		case oci.HasCode(err, http.StatusForbidden):
 			http.Error(w, err.Error(), http.StatusForbidden)
-			return
+		default:
+			handler.WriteError(req.Context(), w, http.StatusInternalServerError, err, "internal error")
 		}
-		handler.WriteError(req.Context(), w, http.StatusInternalServerError, err, "internal error")
 		return
 	}
 	logger.DebugContext(req.Context(), "added file", "descriptor", desc)

--- a/pkg/handler/maven/handler_test.go
+++ b/pkg/handler/maven/handler_test.go
@@ -1,6 +1,7 @@
 package maven
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"net/http"
@@ -432,6 +433,106 @@ func pathToRepoFile(t *testing.T, p string) *oci.RepoFile {
 		OwningTag:  parts[len(parts)-2],                     // versionId
 		Name:       fn,
 		MediaType:  detectMediaType(fn),
+	}
+}
+
+// TestHandlePut_MaxUploadBytes confirms WithMaxUploadBytes returns 413
+// for an oversize body, 201 at-or-under the cap, and that the cap can
+// be disabled by passing a non-positive value.
+func TestHandlePut_MaxUploadBytes(t *testing.T) {
+	t.Parallel()
+
+	const cap = 1 << 14 // 16 KiB
+
+	cases := []struct {
+		name           string
+		maxUploadBytes int64
+		bodySize       int
+		wantStatus     int
+		wantBackendHit bool
+	}{
+		{
+			name:           "under cap",
+			maxUploadBytes: cap,
+			bodySize:       cap - 1,
+			wantStatus:     http.StatusCreated,
+			wantBackendHit: true,
+		},
+		{
+			name:           "exactly at cap",
+			maxUploadBytes: cap,
+			bodySize:       cap,
+			wantStatus:     http.StatusCreated,
+			wantBackendHit: true,
+		},
+		{
+			name:           "just over cap",
+			maxUploadBytes: cap,
+			bodySize:       cap + 1,
+			wantStatus:     http.StatusRequestEntityTooLarge,
+			wantBackendHit: false,
+		},
+		{
+			name:           "way over cap",
+			maxUploadBytes: cap,
+			bodySize:       1 << 20, // 1 MiB
+			wantStatus:     http.StatusRequestEntityTooLarge,
+			wantBackendHit: false,
+		},
+		{
+			name:           "cap disabled accepts 10 MiB",
+			maxUploadBytes: 0,
+			bodySize:       10 << 20,
+			wantStatus:     http.StatusCreated,
+			wantBackendHit: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			reg := oci.NewFakeRegistry()
+			h, _ := newTestHandler(t, reg, WithMaxUploadBytes(tc.maxUploadBytes))
+
+			body := bytes.Repeat([]byte("a"), tc.bodySize)
+			req := httptest.NewRequest(
+				http.MethodPut,
+				nsPath("/com/example/project/1.0.0/project-1.0.0.jar"),
+				bytes.NewReader(body),
+			)
+			rec := httptest.NewRecorder()
+			h.Mux().ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Errorf("status = %d, want %d (body=%s)", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			if rec.Code == http.StatusRequestEntityTooLarge && rec.Body.Len() == 0 {
+				t.Errorf("413 response had empty body, want non-empty error message")
+			}
+			// Backend was contacted iff the artifact key was written.
+			// The test handler setup writes namespace-metadata blobs
+			// unconditionally, so check for the artifact key directly.
+			artifactKey := testNS + "/com/example/project/1.0.0/project-1.0.0.jar"
+			_, hit := reg.Files[artifactKey]
+			if hit != tc.wantBackendHit {
+				t.Errorf("backend hit = %v, want %v", hit, tc.wantBackendHit)
+			}
+		})
+	}
+}
+
+// TestHandlePut_DefaultMaxUploadBytes confirms NewHandler defaults the
+// cap to DefaultMaxUploadBytes when no WithMaxUploadBytes option is
+// supplied.
+func TestHandlePut_DefaultMaxUploadBytes(t *testing.T) {
+	t.Parallel()
+
+	reg := oci.NewFakeRegistry()
+	h, _ := newTestHandler(t, reg)
+
+	if got, want := h.maxUploadBytes, DefaultMaxUploadBytes; got != want {
+		t.Errorf("default maxUploadBytes = %d, want %d", got, want)
 	}
 }
 


### PR DESCRIPTION
Mirrors the existing python upload cap. Wraps every maven PUT body in
http.MaxBytesReader so oversize uploads are rejected with 413 before
reaching the OCI backend, defending against authenticated clients
streaming arbitrary bytes to burn instance hours / egress.

- pkg/handler/maven: DefaultMaxUploadBytes (1 GiB) + WithMaxUploadBytes
  option, enforced in handlePut and surfaced as 413 from both the
  checksum-verify and AddFile error paths.
- pkg/commands/serve: --maven-max-upload-bytes flag wired through
  serveConfig, defaults to 1 GiB, 0 disables.
- docs/repos/maven.md: knob documented alongside --allow-overwrite;
  drop the now-inaccurate "no Maven-specific upload-size knob" note.
- Tests: table-driven cap coverage (under, at, just-over, way-over,
  disabled) asserting status and that the artifact key was not written
  to the fake backend when rejected.

Closes #85

https://claude.ai/code/session_013K3PzVGvUZeiVgCSfC2Rhq