### PR TITLE
Add SchemaVersion field to namespace.Spec

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -70,3 +70,19 @@ served by a process. If you experimented with namespace metadata from the short
 window before this admin service existed, recreate those namespaces through the
 admin API so Python, Maven, and future repo types all read the same control-plane
 documents.
+
+## `schema_version`
+
+Persisted specs carry an integer `schema_version` field. ocifactory stamps it
+on every write — operators do not set it manually and clients can omit it from
+PUT bodies. The contract is:
+
+- The current binary writes `schema_version: 1`.
+- Bodies without the field (written by older builds, before this field
+  existed) are treated as version 1 on read; no backfill is required.
+- A body claiming a `schema_version` higher than this binary understands is
+  rejected with `HTTP 400` rather than silently loaded with fields dropped.
+  Upgrade ocifactory before working with those namespaces.
+
+The field exists so future, backwards-incompatible changes to the on-disk
+shape have an in-band way to migrate without operator-coordinated downtime.

--- a/pkg/handler/admin/handler.go
+++ b/pkg/handler/admin/handler.go
@@ -120,6 +120,7 @@ func (h *Handler) putNamespace(w http.ResponseWriter, r *http.Request) {
 		writeAdminError(r.Context(), w, err)
 		return
 	}
+	spec.Normalize()
 
 	status := http.StatusOK
 	// The 200-vs-201 distinction is best-effort: concurrent creates can
@@ -171,7 +172,9 @@ func (h *Handler) deleteNamespace(w http.ResponseWriter, r *http.Request) {
 
 func writeAdminError(ctx context.Context, w http.ResponseWriter, err error) {
 	switch {
-	case errors.Is(err, namespace.ErrInvalidName), errors.Is(err, namespace.ErrInvalidPolicy):
+	case errors.Is(err, namespace.ErrInvalidName),
+		errors.Is(err, namespace.ErrInvalidPolicy),
+		errors.Is(err, namespace.ErrUnsupportedSchemaVersion):
 		writeJSON(w, http.StatusBadRequest, errorResponse{Error: err.Error()})
 	case errors.Is(err, namespace.ErrNotFound):
 		writeJSON(w, http.StatusNotFound, errorResponse{Error: err.Error()})

--- a/pkg/handler/admin/handler_test.go
+++ b/pkg/handler/admin/handler_test.go
@@ -21,6 +21,15 @@ func TestHandler_NamespaceCRUD(t *testing.T) {
 	allowAlice := namespace.Spec{Policy: namespace.Policy{Readers: []namespace.SubjectMatcher{{Email: "alice@example.com"}}}}
 	allowBob := namespace.Spec{Policy: namespace.Policy{Readers: []namespace.SubjectMatcher{{Email: "bob@example.com"}}}}
 
+	// Admin PUT stamps CurrentSchemaVersion via Spec.Normalize before
+	// persisting, so the response body — and any subsequent GET —
+	// carries it back. allowAlicePersisted / allowBobPersisted are the
+	// wantBody shape after that normalization.
+	allowAlicePersisted := allowAlice
+	allowAlicePersisted.SchemaVersion = namespace.CurrentSchemaVersion
+	allowBobPersisted := allowBob
+	allowBobPersisted.SchemaVersion = namespace.CurrentSchemaVersion
+
 	tests := []struct {
 		name       string
 		method     string
@@ -37,7 +46,7 @@ func TestHandler_NamespaceCRUD(t *testing.T) {
 			path:       "/admin/v1/namespaces/alpha",
 			body:       allowAlice,
 			wantStatus: http.StatusCreated,
-			wantBody:   &namespace.Namespace{Name: "alpha", Spec: allowAlice},
+			wantBody:   &namespace.Namespace{Name: "alpha", Spec: allowAlicePersisted},
 		},
 		{
 			name:   "put existing namespace",
@@ -49,7 +58,15 @@ func TestHandler_NamespaceCRUD(t *testing.T) {
 				putNamespaceNow(t, store, "alpha", allowAlice)
 			},
 			wantStatus: http.StatusOK,
-			wantBody:   &namespace.Namespace{Name: "alpha", Spec: allowBob},
+			wantBody:   &namespace.Namespace{Name: "alpha", Spec: allowBobPersisted},
+		},
+		{
+			name:       "put rejects future schema version",
+			method:     http.MethodPut,
+			path:       "/admin/v1/namespaces/futureversion",
+			rawBody:    `{"schema_version":999}`,
+			wantStatus: http.StatusBadRequest,
+			wantBody:   map[string]string{"error": "unsupported namespace schema_version 999 (this ocifactory understands up to 1)"},
 		},
 		{
 			name:       "put invalid name",
@@ -106,7 +123,7 @@ func TestHandler_NamespaceCRUD(t *testing.T) {
 			method:     http.MethodGet,
 			path:       "/admin/v1/namespaces",
 			wantStatus: http.StatusOK,
-			wantBody:   map[string][]string{"namespaces": []string{}},
+			wantBody:   map[string][]string{"namespaces": {}},
 		},
 		{
 			name:   "list namespaces",
@@ -118,7 +135,7 @@ func TestHandler_NamespaceCRUD(t *testing.T) {
 				putNamespaceNow(t, store, "beta", namespace.Spec{})
 			},
 			wantStatus: http.StatusOK,
-			wantBody:   map[string][]string{"namespaces": []string{"alpha", "beta"}},
+			wantBody:   map[string][]string{"namespaces": {"alpha", "beta"}},
 		},
 		{
 			name:   "delete non-empty namespace",
@@ -194,6 +211,47 @@ func TestHandler_NamespaceCRUD(t *testing.T) {
 			}
 			assertJSONBody(t, resp, tc.wantBody)
 		})
+	}
+}
+
+// TestHandler_PutStampsSchemaVersionOnDisk proves the admin write
+// path calls Spec.Normalize even when the request body omits
+// schema_version: the persisted body must carry the current version
+// so future ocifactory binaries can distinguish shapes without
+// sniffing.
+func TestHandler_PutStampsSchemaVersionOnDisk(t *testing.T) {
+	t.Parallel()
+
+	reg := oci.NewFakeRegistry()
+	store := namespace.NewStore(reg)
+	nsReg := namespace.NewRegistry(reg, store)
+	h, err := admin.NewHandler(store, nsReg)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	srv := httptest.NewServer(h.Mux())
+	t.Cleanup(srv.Close)
+
+	body := bytes.NewReader([]byte(`{"policy":{"readers":[{"email":"alice@example.com"}]}}`))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, srv.URL+"/admin/v1/namespaces/alpha", body)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+
+	stored, err := store.Get(t.Context(), "alpha")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if stored.Spec.SchemaVersion != namespace.CurrentSchemaVersion {
+		t.Errorf("persisted SchemaVersion = %d, want %d", stored.Spec.SchemaVersion, namespace.CurrentSchemaVersion)
 	}
 }
 

--- a/pkg/namespace/namespace.go
+++ b/pkg/namespace/namespace.go
@@ -4,7 +4,23 @@
 // (e.g. /myteam/simple/..., /myteam/maven2/...).
 package namespace
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// CurrentSchemaVersion is the [Spec] shape ocifactory writes today.
+// Bump only as part of a deliberate, backwards-incompatible change to
+// the persisted shape; pair the bump with a read-side migration so
+// older bodies remain loadable.
+const CurrentSchemaVersion = 1
+
+// ErrUnsupportedSchemaVersion is the sentinel returned by
+// [Spec.Validate] when a body claims a schema version higher than
+// [CurrentSchemaVersion]. Callers can surface it as a 400 to keep the
+// operator-facing message clear.
+var ErrUnsupportedSchemaVersion = errors.New("unsupported namespace schema_version")
 
 // Namespace is a namespace and its spec. Name is the identifier as
 // it appears in URLs; validation rules live on [ValidateName].
@@ -15,6 +31,14 @@ type Namespace struct {
 
 // Spec is the persisted body of a [Namespace].
 type Spec struct {
+	// SchemaVersion identifies the persisted-shape this body was
+	// written against. Unset/zero is treated as 1 so legacy bodies
+	// (written before this field was introduced) load without a
+	// coordinated migration. ocifactory rejects bodies whose
+	// SchemaVersion is greater than [CurrentSchemaVersion] rather
+	// than silently dropping fields an older binary can't see.
+	SchemaVersion int `json:"schema_version,omitempty"`
+
 	// Policy is the authz block. An empty Policy is deny-all.
 	//
 	// omitzero (Go 1.24+) is required here: omitempty does not omit
@@ -33,5 +57,22 @@ func (s *Spec) Validate() error {
 	if s == nil {
 		return nil
 	}
+	v := s.SchemaVersion
+	if v == 0 {
+		v = 1
+	}
+	if v > CurrentSchemaVersion {
+		return fmt.Errorf("%w %d (this ocifactory understands up to %d)", ErrUnsupportedSchemaVersion, v, CurrentSchemaVersion)
+	}
 	return s.Policy.Validate()
+}
+
+// Normalize stamps [CurrentSchemaVersion] onto s. The admin write path
+// calls it before persisting so every body on disk carries an explicit
+// version. Idempotent.
+func (s *Spec) Normalize() {
+	if s == nil {
+		return
+	}
+	s.SchemaVersion = CurrentSchemaVersion
 }

--- a/pkg/namespace/spec_test.go
+++ b/pkg/namespace/spec_test.go
@@ -2,6 +2,8 @@ package namespace
 
 import (
 	"encoding/json"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -89,6 +91,16 @@ func TestSpec_JSONRoundtrip(t *testing.T) {
 			},
 			want: `{"policy":{"writers":[{"sub_match":"ci-bot","kind":"basictoken"}]}}`,
 		},
+		{
+			name: "schema-version-current",
+			spec: Spec{
+				SchemaVersion: CurrentSchemaVersion,
+				Policy: Policy{
+					Readers: []SubjectMatcher{{Email: "alice@example.com"}},
+				},
+			},
+			want: `{"schema_version":1,"policy":{"readers":[{"email":"alice@example.com"}]}}`,
+		},
 	}
 
 	for _, tc := range tests {
@@ -112,4 +124,123 @@ func TestSpec_JSONRoundtrip(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSpec_Validate_SchemaVersion covers the three states the field
+// can be in on disk: legacy (zero), current, and future-unknown.
+func TestSpec_Validate_SchemaVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		spec    Spec
+		wantErr error
+	}{
+		{
+			name: "zero-treated-as-current",
+			spec: Spec{},
+		},
+		{
+			name: "explicit-current",
+			spec: Spec{SchemaVersion: CurrentSchemaVersion},
+		},
+		{
+			name:    "future-unknown",
+			spec:    Spec{SchemaVersion: CurrentSchemaVersion + 1},
+			wantErr: ErrUnsupportedSchemaVersion,
+		},
+		{
+			name:    "future-way-out",
+			spec:    Spec{SchemaVersion: 999},
+			wantErr: ErrUnsupportedSchemaVersion,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.spec.Validate()
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Fatalf("Validate() = %v, want nil", err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("Validate() error %v, want errors.Is %v", err, tc.wantErr)
+			}
+			// The operator-facing message must name the highest version
+			// this binary understands so the upgrade path is obvious.
+			if msg := err.Error(); !strings.Contains(msg, "understands up to") {
+				t.Errorf("Validate() error %q missing supported-max hint", msg)
+			}
+		})
+	}
+}
+
+// TestSpec_Validate_NilReceiver guards the documented nil-safe path
+// used by callers that don't always allocate a spec.
+func TestSpec_Validate_NilReceiver(t *testing.T) {
+	t.Parallel()
+
+	var s *Spec
+	if err := s.Validate(); err != nil {
+		t.Errorf("(*Spec)(nil).Validate() = %v, want nil", err)
+	}
+}
+
+// TestSpec_Normalize asserts Normalize stamps CurrentSchemaVersion
+// idempotently and leaves other fields untouched. The legacy-promotion
+// case is the load-bearing one: bodies written before the field
+// existed must come out of the write path stamped with v1.
+func TestSpec_Normalize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   Spec
+		want Spec
+	}{
+		{
+			name: "legacy-promoted",
+			in:   Spec{Policy: Policy{Readers: []SubjectMatcher{{Email: "alice@example.com"}}}},
+			want: Spec{SchemaVersion: CurrentSchemaVersion, Policy: Policy{Readers: []SubjectMatcher{{Email: "alice@example.com"}}}},
+		},
+		{
+			name: "already-current",
+			in:   Spec{SchemaVersion: CurrentSchemaVersion},
+			want: Spec{SchemaVersion: CurrentSchemaVersion},
+		},
+		{
+			name: "older-value-overwritten",
+			in:   Spec{SchemaVersion: 0},
+			want: Spec{SchemaVersion: CurrentSchemaVersion},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tc.in
+			got.Normalize()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Normalize() mismatch (-want +got):\n%s", diff)
+			}
+			// Idempotent.
+			got.Normalize()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Normalize() second pass mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestSpec_Normalize_NilReceiver guards the documented nil-safe path.
+func TestSpec_Normalize_NilReceiver(t *testing.T) {
+	t.Parallel()
+
+	var s *Spec
+	s.Normalize()
 }

--- a/pkg/namespace/store.go
+++ b/pkg/namespace/store.go
@@ -143,6 +143,9 @@ func (s *Store) Get(ctx context.Context, name string) (*Namespace, error) {
 	if err := json.Unmarshal(body, &spec); err != nil {
 		return nil, fmt.Errorf("decode namespace %q spec: %w", name, err)
 	}
+	if err := spec.Validate(); err != nil {
+		return nil, fmt.Errorf("validate namespace %q spec: %w", name, err)
+	}
 	return &Namespace{Name: name, Spec: spec}, nil
 }
 

--- a/pkg/namespace/store_test.go
+++ b/pkg/namespace/store_test.go
@@ -248,6 +248,50 @@ func TestStore_WithPrefix_RoutesToConfiguredRepos(t *testing.T) {
 	}
 }
 
+// TestStore_Get_UnsupportedSchemaVersion proves an older binary
+// reading a body written by a future binary surfaces the explicit
+// schema-version error rather than silently dropping fields.
+func TestStore_Get_UnsupportedSchemaVersion(t *testing.T) {
+	t.Parallel()
+
+	_, s, ctx := newTestStore(t)
+
+	future := &Namespace{Name: "myteam", Spec: Spec{SchemaVersion: CurrentSchemaVersion + 1}}
+	if err := s.Put(ctx, future); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	_, err := s.Get(ctx, "myteam")
+	if !errors.Is(err, ErrUnsupportedSchemaVersion) {
+		t.Errorf("Get() error %v, want errors.Is ErrUnsupportedSchemaVersion", err)
+	}
+}
+
+// TestStore_Get_LegacySchemaVersionAccepted covers the migration
+// contract: bodies persisted before the field existed (zero) load
+// without an error and round-trip unchanged.
+func TestStore_Get_LegacySchemaVersionAccepted(t *testing.T) {
+	t.Parallel()
+
+	_, s, ctx := newTestStore(t)
+
+	// Build a legacy on-disk shape by going through Put with
+	// SchemaVersion=0 — the field is omitempty so the persisted body
+	// has no schema_version key, matching what pre-feature ocifactory
+	// would have written.
+	if err := s.Put(ctx, &Namespace{Name: "myteam", Spec: sampleSpec()}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	got, err := s.Get(ctx, "myteam")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Spec.SchemaVersion != 0 {
+		t.Errorf("legacy body SchemaVersion = %d, want 0 (preserved on read)", got.Spec.SchemaVersion)
+	}
+}
+
 // TestStore_OnDiskLayout pins the metadata path so a refactor that
 // breaks the on-disk shape trips this test rather than silently
 // migrating every operator's existing storage.


### PR DESCRIPTION
Adds an integer schema_version field, written on every persisted
namespace, so future backwards-incompatible changes to the on-disk
shape can be migrated in-band without coordinated operator downtime.

- Spec.SchemaVersion with omitempty JSON tag, plus a
  CurrentSchemaVersion constant.
- Spec.Validate treats 0 as 1 so legacy bodies remain readable, and
  rejects bodies above CurrentSchemaVersion with a clean error
  (ErrUnsupportedSchemaVersion).
- Spec.Normalize stamps CurrentSchemaVersion; admin PUT calls it
  before persisting and surfaces unknown-version errors as HTTP 400.
- Store.Get validates the unmarshalled spec so an older binary
  loading a future body errors clearly rather than dropping fields.
- Tests cover legacy/current/future versions, the admin PUT
  stamping contract, and the read-side rejection.
- docs/admin.md documents the field's contract.

Closes #88

https://claude.ai/code/session_01GB3KqNaj6f9UeTa3Ydq7Du