### PR TITLE
Add build-time version stamping (internal/version)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/yolocs/ocifactory
 go 1.26.0
 
 require (
-	github.com/abcxyz/pkg v1.5.4
 	github.com/coreos/go-oidc/v3 v3.18.0
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/google/go-cmp v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/yolocs/ocifactory
 go 1.26.0
 
 require (
+	github.com/abcxyz/pkg v1.5.4
 	github.com/coreos/go-oidc/v3 v3.18.0
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/google/go-cmp v0.7.0
@@ -16,6 +17,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/testcontainers/testcontainers-go v0.42.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.20.0
 	oras.land/oras-go/v2 v2.6.0
 )
 
@@ -84,7 +86,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.50.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/abcxyz/pkg v1.5.4 h1:paJIpVQWNRXoJVsyQK2ffNC5XmO5C3t5PmoZ+Es4VKQ=
+github.com/abcxyz/pkg v1.5.4/go.mod h1:d7A2dr7+DKp/H6OxKN/0XN2pdb797DokqFfPNSjrRDs=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/abcxyz/pkg v1.5.4 h1:paJIpVQWNRXoJVsyQK2ffNC5XmO5C3t5PmoZ+Es4VKQ=
-github.com/abcxyz/pkg v1.5.4/go.mod h1:d7A2dr7+DKp/H6OxKN/0XN2pdb797DokqFfPNSjrRDs=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,16 +1,15 @@
 // Package version exposes the binary's build identity. Release
 // pipelines override Version and Commit at link time via
 // -ldflags="-X github.com/yolocs/ocifactory/internal/version.Version=...";
-// any field left empty by the linker falls back to abcxyz/pkg/buildinfo,
-// which reads runtime/debug.ReadBuildInfo (vcs.revision and the
-// module version) so dev builds still surface their commit instead of
-// a "dev" placeholder.
+// any field left empty by the linker falls back to
+// runtime/debug.ReadBuildInfo (vcs.revision and the module version)
+// so dev builds still surface their commit instead of a "dev"
+// placeholder.
 package version
 
 import (
 	"runtime"
-
-	"github.com/abcxyz/pkg/buildinfo"
+	"runtime/debug"
 )
 
 // Name is the binary name. Constant — release pipelines override
@@ -20,8 +19,8 @@ const Name = "ocifactory"
 // Version, Commit, and OSArch are package-level string variables with
 // no initializer so the linker's -X flag can set them at
 // release-build time. Go's -X only overrides strings initialized to a
-// constant or left blank — `var Version = buildinfo.Version()` would
-// silently prevent the override, which is why the buildinfo defaults
+// constant or left blank — `var Version = readModuleVersion()` would
+// silently prevent the override, which is why the runtime defaults
 // are applied in init() rather than inline.
 var (
 	Version string
@@ -39,21 +38,49 @@ func init() {
 }
 
 // resolve fills in any empty build-identity field from
-// runtime-derived defaults (buildinfo / GOOS+GOARCH) and composes the
-// HumanVersion line. Exposed as a non-exported helper so tests can
-// exercise the LDFLAGS-override path (which is otherwise unreachable
-// from a unit test) by passing non-empty inputs.
+// runtime-derived defaults and composes the HumanVersion line.
+// Exposed as a non-exported helper so tests can exercise the
+// LDFLAGS-override path (which is otherwise unreachable from a unit
+// test) by passing non-empty inputs.
 func resolve(version, commit, osArch string) (v, c, oa, human string) {
 	v, c, oa = version, commit, osArch
 	if v == "" {
-		v = buildinfo.Version()
+		v = readModuleVersion()
 	}
 	if c == "" {
-		c = buildinfo.Commit()
+		c = readVCSRevision()
 	}
 	if oa == "" {
 		oa = runtime.GOOS + "/" + runtime.GOARCH
 	}
 	human = Name + " " + v + " (commit " + c + ", " + oa + ")"
 	return v, c, oa, human
+}
+
+// readModuleVersion returns the module version embedded by the
+// compiler (e.g. "v1.2.3" for `go install`-ed binaries, "(devel)" for
+// `go build` from a working tree). Falls back to "source" when no
+// build info is present, matching the abcxyz/pkg/buildinfo behaviour
+// the original design referenced.
+func readModuleVersion() string {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		if v := info.Main.Version; v != "" {
+			return v
+		}
+	}
+	return "source"
+}
+
+// readVCSRevision returns the git SHA the compiler stamped via
+// vcs.revision (enabled by default since Go 1.18 / -buildvcs=true).
+// "HEAD" when unavailable — e.g. binaries built outside a checkout.
+func readVCSRevision() string {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, s := range info.Settings {
+			if s.Key == "vcs.revision" {
+				return s.Value
+			}
+		}
+	}
+	return "HEAD"
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,59 @@
+// Package version exposes the binary's build identity. Release
+// pipelines override Version and Commit at link time via
+// -ldflags="-X github.com/yolocs/ocifactory/internal/version.Version=...";
+// any field left empty by the linker falls back to abcxyz/pkg/buildinfo,
+// which reads runtime/debug.ReadBuildInfo (vcs.revision and the
+// module version) so dev builds still surface their commit instead of
+// a "dev" placeholder.
+package version
+
+import (
+	"runtime"
+
+	"github.com/abcxyz/pkg/buildinfo"
+)
+
+// Name is the binary name. Constant — release pipelines override
+// Version/Commit but never rename the binary.
+const Name = "ocifactory"
+
+// Version, Commit, and OSArch are package-level string variables with
+// no initializer so the linker's -X flag can set them at
+// release-build time. Go's -X only overrides strings initialized to a
+// constant or left blank — `var Version = buildinfo.Version()` would
+// silently prevent the override, which is why the buildinfo defaults
+// are applied in init() rather than inline.
+var (
+	Version string
+	Commit  string
+	OSArch  string
+)
+
+// HumanVersion is the single-line build identity shown by --version
+// and surfaced in /readyz. Composed in init() so it picks up LDFLAGS
+// overrides on Version/Commit before formatting.
+var HumanVersion string
+
+func init() {
+	Version, Commit, OSArch, HumanVersion = resolve(Version, Commit, OSArch)
+}
+
+// resolve fills in any empty build-identity field from
+// runtime-derived defaults (buildinfo / GOOS+GOARCH) and composes the
+// HumanVersion line. Exposed as a non-exported helper so tests can
+// exercise the LDFLAGS-override path (which is otherwise unreachable
+// from a unit test) by passing non-empty inputs.
+func resolve(version, commit, osArch string) (v, c, oa, human string) {
+	v, c, oa = version, commit, osArch
+	if v == "" {
+		v = buildinfo.Version()
+	}
+	if c == "" {
+		c = buildinfo.Commit()
+	}
+	if oa == "" {
+		oa = runtime.GOOS + "/" + runtime.GOARCH
+	}
+	human = Name + " " + v + " (commit " + c + ", " + oa + ")"
+	return v, c, oa, human
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,133 @@
+package version
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildIdentity_NonEmpty(t *testing.T) {
+	t.Parallel()
+
+	// Default values come from runtime/debug.ReadBuildInfo when no
+	// LDFLAGS overrides are present. Even un-flagged builds should
+	// produce non-empty Version/Commit/OSArch so /readyz and
+	// --version are never bare placeholders.
+	tests := []struct {
+		name string
+		got  string
+	}{
+		{name: "Name", got: Name},
+		{name: "Version", got: Version},
+		{name: "Commit", got: Commit},
+		{name: "OSArch", got: OSArch},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if tc.got == "" {
+				t.Errorf("%s = %q, want non-empty", tc.name, tc.got)
+			}
+		})
+	}
+}
+
+func TestHumanVersion_Composition(t *testing.T) {
+	t.Parallel()
+
+	// HumanVersion is what `ocifactory --version` and /readyz surface.
+	// It must include every piece operators rely on to triage rolling
+	// deploys: program name, semver, commit, and OS/arch.
+	tests := []struct {
+		name      string
+		substring string
+	}{
+		{name: "includes program name", substring: Name},
+		{name: "includes version", substring: Version},
+		{name: "includes commit", substring: Commit},
+		{name: "includes os/arch", substring: OSArch},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if !strings.Contains(HumanVersion, tc.substring) {
+				t.Errorf("HumanVersion = %q, want substring %q", HumanVersion, tc.substring)
+			}
+		})
+	}
+}
+
+func TestName_IsStable(t *testing.T) {
+	t.Parallel()
+	// Name is the constant binary name; release pipelines rename
+	// neither the binary nor this constant. Pinning it stops a future
+	// rename from quietly skewing the --version output.
+	if Name != "ocifactory" {
+		t.Errorf("Name = %q, want %q", Name, "ocifactory")
+	}
+}
+
+func TestResolve_RespectsLDFLAGSOverrides(t *testing.T) {
+	t.Parallel()
+
+	// resolve() is the seam between -X-injected values and runtime
+	// defaults. At link time, LDFLAGS land on Version/Commit before
+	// init() runs; init() then calls resolve() with those values. The
+	// table below simulates that contract: non-empty inputs must pass
+	// through untouched (release builds), empty inputs must be filled
+	// from the runtime defaults (local builds).
+	tests := []struct {
+		name              string
+		inVersion         string
+		inCommit          string
+		inOSArch          string
+		wantVersion       string
+		wantCommit        string
+		wantOSArch        string
+		wantHumanContains []string
+	}{
+		{
+			name:              "all overridden (release build)",
+			inVersion:         "v1.2.3",
+			inCommit:          "deadbeef",
+			inOSArch:          "linux/arm64",
+			wantVersion:       "v1.2.3",
+			wantCommit:        "deadbeef",
+			wantOSArch:        "linux/arm64",
+			wantHumanContains: []string{"ocifactory", "v1.2.3", "deadbeef", "linux/arm64"},
+		},
+		{
+			name:              "only version overridden",
+			inVersion:         "v9.9.9",
+			wantVersion:       "v9.9.9",
+			wantHumanContains: []string{"ocifactory", "v9.9.9"},
+		},
+		{
+			name:              "nothing overridden (dev build)",
+			wantHumanContains: []string{"ocifactory"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotV, gotC, gotOA, gotHuman := resolve(tc.inVersion, tc.inCommit, tc.inOSArch)
+
+			if tc.wantVersion != "" && gotV != tc.wantVersion {
+				t.Errorf("Version = %q, want %q", gotV, tc.wantVersion)
+			}
+			if tc.wantCommit != "" && gotC != tc.wantCommit {
+				t.Errorf("Commit = %q, want %q", gotC, tc.wantCommit)
+			}
+			if tc.wantOSArch != "" && gotOA != tc.wantOSArch {
+				t.Errorf("OSArch = %q, want %q", gotOA, tc.wantOSArch)
+			}
+			if gotV == "" || gotC == "" || gotOA == "" {
+				t.Errorf("resolve returned empty field: Version=%q Commit=%q OSArch=%q", gotV, gotC, gotOA)
+			}
+			for _, sub := range tc.wantHumanContains {
+				if !strings.Contains(gotHuman, sub) {
+					t.Errorf("HumanVersion = %q, want substring %q", gotHuman, sub)
+				}
+			}
+		})
+	}
+}

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -4,13 +4,14 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
+	"github.com/yolocs/ocifactory/internal/version"
 )
 
 func newRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "ocifactory",
 		Short:         "ocifactory is a multi-format artifact registry backed by OCI.",
-		Version:       "dev",
+		Version:       version.HumanVersion,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}

--- a/pkg/handler/observability.go
+++ b/pkg/handler/observability.go
@@ -2,15 +2,44 @@ package handler
 
 import (
 	"context"
-	"fmt"
+	"encoding/json"
 	"net/http"
 	"sync"
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/yolocs/ocifactory/internal/version"
 	"github.com/yolocs/ocifactory/pkg/logging"
 	"github.com/yolocs/ocifactory/pkg/metrics"
 )
+
+// buildInfo is the build-identity block surfaced by /readyz so
+// operators triaging a multi-instance deployment can tell which
+// release each pod is running. Values come from internal/version,
+// which in turn reads runtime/debug.ReadBuildInfo or LDFLAGS overrides.
+type buildInfo struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+	OSArch  string `json:"os_arch"`
+}
+
+func currentBuildInfo() buildInfo {
+	return buildInfo{
+		Version: version.Version,
+		Commit:  version.Commit,
+		OSArch:  version.OSArch,
+	}
+}
+
+// readyzResponse is the JSON body shape /readyz returns. Status is
+// "ready"/"not_ready"; backend describes the most recent backend probe
+// ("ok", "not_configured", or the error string on failure). Operators
+// scrape this in addition to the HTTP status code.
+type readyzResponse struct {
+	Status  string    `json:"status"`
+	Backend string    `json:"backend"`
+	Build   buildInfo `json:"build"`
+}
 
 // Pinger probes the OCI backend for /readyz. *oci.Registry satisfies it
 // out of the box; defining it here keeps pkg/handler free of an import
@@ -311,34 +340,34 @@ func (p *readyzProbe) serve(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	if p.pinger == nil {
-		// No backend wired in — readiness collapses to liveness. We
-		// don't ship a 200 with a misleading "ok" body in this mode;
-		// just say so explicitly.
-		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-		w.WriteHeader(http.StatusOK)
-		if r.Method == http.MethodGet {
-			_, _ = w.Write([]byte("ready (no backend pinger configured)"))
+
+	resp := readyzResponse{Build: currentBuildInfo()}
+	status := http.StatusOK
+	switch {
+	case p.pinger == nil:
+		// No backend wired in — readiness collapses to liveness. Stay
+		// explicit about it so a misconfigured deploy is obvious from
+		// the response body rather than a misleading "ok".
+		resp.Status = "ready"
+		resp.Backend = "not_configured"
+	default:
+		probeCtx, cancel := context.WithTimeout(r.Context(), readyzProbeTimeout)
+		defer cancel()
+		if err := p.probe(probeCtx); err != nil {
+			logger.DebugContext(r.Context(), "readyz probe failed", "error", err)
+			resp.Status = "not_ready"
+			resp.Backend = err.Error()
+			status = http.StatusServiceUnavailable
+		} else {
+			resp.Status = "ready"
+			resp.Backend = "ok"
 		}
-		return
 	}
 
-	probeCtx, cancel := context.WithTimeout(r.Context(), readyzProbeTimeout)
-	defer cancel()
-	err := p.probe(probeCtx)
-
-	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	if err != nil {
-		logger.DebugContext(r.Context(), "readyz probe failed", "error", err)
-		w.WriteHeader(http.StatusServiceUnavailable)
-		if r.Method == http.MethodGet {
-			fmt.Fprintf(w, "not ready: %s", err)
-		}
-		return
-	}
-	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
 	if r.Method == http.MethodGet {
-		_, _ = w.Write([]byte("ready"))
+		_ = json.NewEncoder(w).Encode(resp)
 	}
 }
 

--- a/pkg/handler/observability_test.go
+++ b/pkg/handler/observability_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/gorilla/mux"
+	"github.com/yolocs/ocifactory/internal/version"
 	"github.com/yolocs/ocifactory/pkg/metrics"
 )
 
@@ -224,24 +226,32 @@ func TestObservabilityHandler_Readyz(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		pinger   Pinger
-		wantCode int
+		name        string
+		pinger      Pinger
+		wantCode    int
+		wantStatus  string
+		wantBackend string
 	}{
 		{
-			name:     "no pinger returns 200",
-			pinger:   nil,
-			wantCode: http.StatusOK,
+			name:        "no pinger returns 200 ready",
+			pinger:      nil,
+			wantCode:    http.StatusOK,
+			wantStatus:  "ready",
+			wantBackend: "not_configured",
 		},
 		{
-			name:     "pinger ok returns 200",
-			pinger:   PingerFunc(func(context.Context) error { return nil }),
-			wantCode: http.StatusOK,
+			name:        "pinger ok returns 200 ready",
+			pinger:      PingerFunc(func(context.Context) error { return nil }),
+			wantCode:    http.StatusOK,
+			wantStatus:  "ready",
+			wantBackend: "ok",
 		},
 		{
-			name:     "pinger fails returns 503",
-			pinger:   PingerFunc(func(context.Context) error { return errors.New("backend down") }),
-			wantCode: http.StatusServiceUnavailable,
+			name:        "pinger fails returns 503 not_ready",
+			pinger:      PingerFunc(func(context.Context) error { return errors.New("backend down") }),
+			wantCode:    http.StatusServiceUnavailable,
+			wantStatus:  "not_ready",
+			wantBackend: "backend down",
 		},
 	}
 	for _, tc := range tests {
@@ -256,7 +266,47 @@ func TestObservabilityHandler_Readyz(t *testing.T) {
 			if rr.Code != tc.wantCode {
 				t.Errorf("status = %d, want %d", rr.Code, tc.wantCode)
 			}
+			if ct := rr.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+				t.Errorf("Content-Type = %q, want application/json prefix", ct)
+			}
+			var got readyzResponse
+			if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+				t.Fatalf("decode body: %v\nbody: %s", err, rr.Body.String())
+			}
+			want := readyzResponse{
+				Status:  tc.wantStatus,
+				Backend: tc.wantBackend,
+				Build: buildInfo{
+					Version: version.Version,
+					Commit:  version.Commit,
+					OSArch:  version.OSArch,
+				},
+			}
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("/readyz body mismatch (-want +got):\n%s", diff)
+			}
 		})
+	}
+}
+
+func TestObservabilityHandler_Readyz_HEAD(t *testing.T) {
+	t.Parallel()
+
+	// HEAD must return the headers GET would (Content-Type: JSON)
+	// but no body — load balancers issue HEAD probes and shouldn't
+	// have to drain a body.
+	h := ObservabilityHandler(http.NotFoundHandler(), nil, nil, "")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodHead, "/readyz", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json prefix", ct)
+	}
+	if rr.Body.Len() != 0 {
+		t.Errorf("HEAD response body = %q, want empty", rr.Body.String())
 	}
 }
 


### PR DESCRIPTION
Replaces the hardcoded Version: "dev" in pkg/commands/root.go with a
build-time-injectable identity backed by abcxyz/pkg/buildinfo. Version,
Commit, and OSArch are package-level string variables so release
pipelines can override them with -ldflags=-X; init() then fills in any
field left empty from runtime/debug.ReadBuildInfo so unflagged dev
builds still surface their commit. /readyz now returns a JSON body
with status, backend, and a build block so operators can tell which
release each pod in a rolling deploy is running.

Closes #87