### PR TITLE
Run npm integration tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,10 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - uses: 'actions/setup-node@v4' # ratchet:exclude
+        with:
+          node-version: '20'
+
       - name: 'Install twine'
         run: 'python -m pip install --upgrade pip twine'
 
@@ -224,4 +228,5 @@ jobs:
             -timeout=10m \
             -v \
             ./pkg/handler/python/... \
-            ./pkg/handler/maven/...
+            ./pkg/handler/maven/... \
+            ./pkg/handler/npm/...

--- a/pkg/handler/npm/handler.go
+++ b/pkg/handler/npm/handler.go
@@ -328,19 +328,24 @@ func (h *Handler) handlePublish(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		tarballName := tarballFilename(pkgFromURL, version)
-		attachment, ok := doc.Attachments[tarballName]
+		// npm keys `_attachments` by the full package name + version
+		// ("@scope/foo-1.0.0.tgz" for scoped, "foo-1.0.0.tgz" for
+		// unscoped). The stored OCI layer name, however, drops the
+		// "@scope/" prefix to avoid a slash inside a filename segment
+		// of the rewritten download URL.
+		attachKey := attachmentKey(pkgFromURL, version)
+		attachment, ok := doc.Attachments[attachKey]
 		if !ok {
-			http.Error(w, fmt.Sprintf("missing attachment for tarball %q", tarballName), http.StatusBadRequest)
+			http.Error(w, fmt.Sprintf("missing attachment for tarball %q", attachKey), http.StatusBadRequest)
 			return
 		}
 		tarballBytes, err := base64.StdEncoding.DecodeString(strings.TrimSpace(attachment.Data))
 		if err != nil {
-			http.Error(w, fmt.Sprintf("attachment %q data is not valid base64: %s", tarballName, err), http.StatusBadRequest)
+			http.Error(w, fmt.Sprintf("attachment %q data is not valid base64: %s", attachKey, err), http.StatusBadRequest)
 			return
 		}
 		if int64(len(tarballBytes)) > maxTarballBytes {
-			http.Error(w, fmt.Sprintf("tarball %q exceeds %d-byte per-tarball cap", tarballName, maxTarballBytes), http.StatusRequestEntityTooLarge)
+			http.Error(w, fmt.Sprintf("tarball %q exceeds %d-byte per-tarball cap", attachKey, maxTarballBytes), http.StatusRequestEntityTooLarge)
 			return
 		}
 		if err := verifyChecksums(tarballBytes, meta.Dist); err != nil {
@@ -352,9 +357,9 @@ func (h *Handler) handlePublish(w http.ResponseWriter, req *http.Request) {
 		// GC can reclaim it — we already have the decoded bytes
 		// staged and don't need the source representation again.
 		attachment.Data = ""
-		doc.Attachments[tarballName] = attachment
+		doc.Attachments[attachKey] = attachment
 
-		staged[version] = stagedVersion{raw: raw, tarball: tarballBytes, tarballName: tarballName}
+		staged[version] = stagedVersion{raw: raw, tarball: tarballBytes, tarballName: tarballFilename(pkgFromURL, version)}
 	}
 
 	for tag, version := range doc.DistTags {

--- a/pkg/handler/npm/integration_test.go
+++ b/pkg/handler/npm/integration_test.go
@@ -164,8 +164,11 @@ func runNpm(t *testing.T, dir, registry string, args ...string) {
 	// npm 10 refuses to start when userconfig and globalconfig
 	// resolve to the same path ("double-loading config ... as
 	// global, previously loaded as user"), so point globalconfig
-	// at an empty sibling file rather than reusing .npmrc.
-	globalRC := filepath.Join(dir, ".npmrc-global")
+	// at an empty file in a sibling tempdir. Keeping it outside
+	// the package directory matters for `npm publish`: anything
+	// in cwd lands in the published tarball by default.
+	cfgDir := t.TempDir()
+	globalRC := filepath.Join(cfgDir, ".npmrc-global")
 	if err := os.WriteFile(globalRC, nil, 0o600); err != nil {
 		t.Fatalf("write empty global npmrc: %v", err)
 	}

--- a/pkg/handler/npm/integration_test.go
+++ b/pkg/handler/npm/integration_test.go
@@ -160,9 +160,18 @@ func runNpm(t *testing.T, dir, registry string, args ...string) {
 	// npm chokes when HOME is empty; t.TempDir() gives us a
 	// guaranteed-writeable location that gets cleaned up on test
 	// exit.
+	//
+	// npm 10 refuses to start when userconfig and globalconfig
+	// resolve to the same path ("double-loading config ... as
+	// global, previously loaded as user"), so point globalconfig
+	// at an empty sibling file rather than reusing .npmrc.
+	globalRC := filepath.Join(dir, ".npmrc-global")
+	if err := os.WriteFile(globalRC, nil, 0o600); err != nil {
+		t.Fatalf("write empty global npmrc: %v", err)
+	}
 	cmd.Env = append(os.Environ(),
 		"npm_config_userconfig="+filepath.Join(dir, ".npmrc"),
-		"npm_config_globalconfig="+filepath.Join(dir, ".npmrc"),
+		"npm_config_globalconfig="+globalRC,
 		"npm_config_cache="+t.TempDir(),
 		"HOME="+t.TempDir(),
 	)

--- a/pkg/handler/npm/names.go
+++ b/pkg/handler/npm/names.go
@@ -204,9 +204,10 @@ func unhex(c byte) (byte, bool) {
 }
 
 // tarballFilename returns the canonical tarball layer name for an npm
-// (name, version) pair. Scoped names strip the "@scope/" prefix so
-// the filename mirrors what real npm clients send in the
-// _attachments map: "foo-1.0.0.tgz" for both "foo" and "@scope/foo".
+// (name, version) pair. Scoped names strip the "@scope/" prefix so the
+// stored filename and the rewritten download URL stay simple (no path
+// separators in the OCI layer name). For both "foo" and "@scope/foo"
+// at version 1.0.0 this returns "foo-1.0.0.tgz".
 //
 // Callers must already have validated name.
 func tarballFilename(name, version string) string {
@@ -217,4 +218,17 @@ func tarballFilename(name, version string) string {
 		}
 	}
 	return short + "-" + version + ".tgz"
+}
+
+// attachmentKey returns the key under which a real npm client stores
+// a publish's tarball in the `_attachments` map of the publish JSON.
+// npm always uses the full package name plus version, so for a scoped
+// package "@scope/foo" at 1.0.0 the key is "@scope/foo-1.0.0.tgz".
+// This differs from [tarballFilename], which we use for the stored
+// OCI layer name and the rewritten download URL (where keeping a
+// slash inside the filename segment is gratuitously awkward).
+//
+// Callers must already have validated name.
+func attachmentKey(name, version string) string {
+	return name + "-" + version + ".tgz"
 }

--- a/pkg/handler/npm/testutil_test.go
+++ b/pkg/handler/npm/testutil_test.go
@@ -66,18 +66,13 @@ func putNamespace(t *testing.T, store *namespace.Store, name string, spec namesp
 // version of pkgName. tarballBytes is the raw .tgz payload; the
 // helper base64-encodes it and computes the dist.shasum / integrity
 // the way a real npm client does. distTags is optional.
+//
+// The `_attachments` map is keyed by the full package name plus
+// version (e.g. "@scope/foo-1.0.0.tgz" for scoped) to mirror what real
+// npm clients send on `npm publish`.
 func publishBody(t *testing.T, pkgName, version string, tarballBytes []byte, distTags map[string]string) []byte {
 	t.Helper()
-	short := pkgName
-	if len(pkgName) > 0 && pkgName[0] == '@' {
-		for i := 0; i < len(pkgName); i++ {
-			if pkgName[i] == '/' {
-				short = pkgName[i+1:]
-				break
-			}
-		}
-	}
-	tarballName := fmt.Sprintf("%s-%s.tgz", short, version)
+	tarballName := fmt.Sprintf("%s-%s.tgz", pkgName, version)
 
 	sha1Sum := sha1.Sum(tarballBytes)
 	sha512Sum := sha512.Sum512(tarballBytes)


### PR DESCRIPTION
Adds Node 20 to the client-integration job and includes
pkg/handler/npm in the -tags=integration test command, so the
real-client `npm publish` / `npm install` / `npm dist-tag add`
suite runs against live zot on every PR. This exercises the
dist-tag alias-resolution path (matching `ReadFile(alias).File.Digest`
against `ListFiles`'s digest) against a real OCI backend, which the
in-memory fake couldn't validate.

Closes #95