### PR TITLE
Add deterministic file-tag lookup for direct file downloads

### DIFF
--- a/pkg/oci/filetag.go
+++ b/pkg/oci/filetag.go
@@ -1,0 +1,40 @@
+package oci
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// fileTagPrefix marks deterministic file-manifest tags so they can be
+// filtered out of the "versions + aliases" view exposed via ListTags.
+// The OCI tag grammar ([A-Za-z0-9_][A-Za-z0-9._-]{0,127}) admits the
+// prefix, and "_f_" is short enough that the full tag stays well under
+// the 128-character limit even with a 64-char sha256 hex suffix (66
+// chars total).
+const fileTagPrefix = "_f_"
+
+// fileTagFor maps (owningTag, filename) onto the deterministic OCI tag
+// that AddFile attaches to the file manifest. ReadFile and
+// BlobRedirectURL resolve this tag directly, replacing the
+// version-manifest → Referrers → file-manifest descriptor triple with a
+// single Resolve. The 0x00 separator prevents "1.0" + "0foo" colliding
+// with "1.00" + "foo".
+//
+// The handler is responsible for any normalization it wants on the
+// inputs (lowercasing, percent-decoding, etc.) before hashing — this
+// helper is just a deterministic mapper, not a normalizer.
+func fileTagFor(owningTag, filename string) string {
+	h := sha256.New()
+	h.Write([]byte(owningTag))
+	h.Write([]byte{0x00})
+	h.Write([]byte(filename))
+	return fileTagPrefix + hex.EncodeToString(h.Sum(nil))
+}
+
+// isFileTag reports whether tag was produced by fileTagFor. Used to
+// keep deterministic file tags out of the "versions + aliases" view in
+// ListTags and to skip them in ListFiles' per-tag iteration.
+func isFileTag(tag string) bool {
+	return strings.HasPrefix(tag, fileTagPrefix)
+}

--- a/pkg/oci/filetag_test.go
+++ b/pkg/oci/filetag_test.go
@@ -1,0 +1,120 @@
+package oci
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+// TestFileTagFor pins the deterministic mapping from
+// (owningTag, filename) onto the on-wire tag string. The output is part
+// of the registry's persistence format — any change here is a
+// migration. The cases also lock in the 0x00-separator collision guard
+// the issue called out (("1.0","0foo") must not equal ("1.00","foo")).
+func TestFileTagFor(t *testing.T) {
+	t.Parallel()
+
+	pair := func(owningTag, name string) string {
+		h := sha256.New()
+		h.Write([]byte(owningTag))
+		h.Write([]byte{0x00})
+		h.Write([]byte(name))
+		return fileTagPrefix + hex.EncodeToString(h.Sum(nil))
+	}
+
+	tests := []struct {
+		name       string
+		owningTag  string
+		filename   string
+		wantPrefix string
+		wantSame   *struct {
+			owningTag string
+			filename  string
+		}
+		wantDiffer *struct {
+			owningTag string
+			filename  string
+		}
+	}{
+		{
+			name:       "simple version + filename",
+			owningTag:  "1.0.0",
+			filename:   "react-1.0.0.tgz",
+			wantPrefix: fileTagPrefix,
+		},
+		{
+			name:       "different owning tag differs",
+			owningTag:  "1.0.1",
+			filename:   "react-1.0.0.tgz",
+			wantPrefix: fileTagPrefix,
+			wantDiffer: &struct {
+				owningTag string
+				filename  string
+			}{owningTag: "1.0.0", filename: "react-1.0.0.tgz"},
+		},
+		{
+			name:       "collision-resistant separator",
+			owningTag:  "1.0",
+			filename:   "0foo",
+			wantPrefix: fileTagPrefix,
+			wantDiffer: &struct {
+				owningTag string
+				filename  string
+			}{owningTag: "1.00", filename: "foo"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := fileTagFor(tc.owningTag, tc.filename)
+			if !strings.HasPrefix(got, tc.wantPrefix) {
+				t.Errorf("fileTagFor(%q, %q) = %q, want prefix %q", tc.owningTag, tc.filename, got, tc.wantPrefix)
+			}
+			// Length: prefix (3) + sha256 hex (64) = 67. OCI tags
+			// allow up to 128; we want some headroom but the size
+			// should be stable.
+			if want := len(fileTagPrefix) + 64; len(got) != want {
+				t.Errorf("len(fileTagFor) = %d, want %d", len(got), want)
+			}
+			// Reference computation must match (locks in the hash
+			// scheme — change here is a wire-format break).
+			if want := pair(tc.owningTag, tc.filename); got != want {
+				t.Errorf("fileTagFor mismatch:\ngot:  %q\nwant: %q", got, want)
+			}
+			if tc.wantDiffer != nil {
+				other := fileTagFor(tc.wantDiffer.owningTag, tc.wantDiffer.filename)
+				if got == other {
+					t.Errorf("fileTagFor produced same tag for (%q,%q) and (%q,%q): %q",
+						tc.owningTag, tc.filename, tc.wantDiffer.owningTag, tc.wantDiffer.filename, got)
+				}
+			}
+		})
+	}
+}
+
+func TestIsFileTag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		tag  string
+		want bool
+	}{
+		{tag: fileTagFor("v1", "a.txt"), want: true},
+		{tag: "_f_anything", want: true},
+		{tag: "v1.0.0", want: false},
+		{tag: "latest", want: false},
+		{tag: "", want: false},
+		{tag: "_factory", want: false}, // missing trailing underscore
+	}
+	for _, tc := range tests {
+		t.Run(tc.tag, func(t *testing.T) {
+			t.Parallel()
+			if got := isFileTag(tc.tag); got != tc.want {
+				t.Errorf("isFileTag(%q) = %v, want %v", tc.tag, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/oci/instrumented.go
+++ b/pkg/oci/instrumented.go
@@ -24,6 +24,7 @@ const (
 	opResolve        = "resolve"
 	opTag            = "tag"
 	opDelete         = "delete"
+	opDeleteTag      = "delete_tag"
 	opListTags       = "list_tags"
 	opListReferrers  = "list_referrers"
 	opPredecessors   = "predecessors"
@@ -98,6 +99,13 @@ func (r *instrumentedRepo) Delete(ctx context.Context, target ocispec.Descriptor
 	start := time.Now()
 	err := r.destRepo.Delete(ctx, target)
 	r.rec.OCIBackendCall(opDelete, statusFromErr(err), time.Since(start))
+	return err
+}
+
+func (r *instrumentedRepo) DeleteTag(ctx context.Context, tag string) error {
+	start := time.Now()
+	err := r.destRepo.DeleteTag(ctx, tag)
+	r.rec.OCIBackendCall(opDeleteTag, statusFromErr(err), time.Since(start))
 	return err
 }
 

--- a/pkg/oci/instrumented_test.go
+++ b/pkg/oci/instrumented_test.go
@@ -76,14 +76,15 @@ func (f *fakeRecorder) backendOpStatuses() []string {
 // exercise the wrapper's classification logic against synthetic
 // successes and failures.
 type stubRepo struct {
-	pushErr    error
-	fetchErr   error
-	existsErr  error
-	resolveErr error
-	tagErr     error
-	deleteErr  error
-	tagsErr    error
-	predErr    error
+	pushErr      error
+	fetchErr     error
+	existsErr    error
+	resolveErr   error
+	tagErr       error
+	deleteErr    error
+	deleteTagErr error
+	tagsErr      error
+	predErr      error
 }
 
 func (s *stubRepo) Push(ctx context.Context, expected ocispec.Descriptor, content io.Reader) error {
@@ -109,6 +110,9 @@ func (s *stubRepo) Tag(ctx context.Context, desc ocispec.Descriptor, reference s
 }
 func (s *stubRepo) Delete(ctx context.Context, target ocispec.Descriptor) error {
 	return s.deleteErr
+}
+func (s *stubRepo) DeleteTag(ctx context.Context, tag string) error {
+	return s.deleteTagErr
 }
 func (s *stubRepo) Tags(ctx context.Context, last string, fn func(tags []string) error) error {
 	return s.tagsErr
@@ -154,12 +158,13 @@ func TestInstrumentedRepo_LabelsByMediaTypeAndError(t *testing.T) {
 			want: []string{"fetch_blob:ok"},
 		},
 		{
-			name: "exists, resolve, tag, delete, list_tags, list_referrers",
+			name: "exists, resolve, tag, delete, delete_tag, list_tags, list_referrers",
 			exercise: func(repo destRepo) {
 				_, _ = repo.Exists(t.Context(), ocispec.Descriptor{})
 				_, _ = repo.Resolve(t.Context(), "tag")
 				_ = repo.Tag(t.Context(), ocispec.Descriptor{}, "tag")
 				_ = repo.Delete(t.Context(), ocispec.Descriptor{})
+				_ = repo.DeleteTag(t.Context(), "tag")
 				_ = repo.(interface {
 					Tags(ctx context.Context, last string, fn func(tags []string) error) error
 				}).Tags(t.Context(), "", func([]string) error { return nil })
@@ -172,6 +177,7 @@ func TestInstrumentedRepo_LabelsByMediaTypeAndError(t *testing.T) {
 				"resolve:ok",
 				"tag:ok",
 				"delete:ok",
+				"delete_tag:ok",
 				"list_tags:ok",
 				"list_referrers:ok",
 			},

--- a/pkg/oci/redirect.go
+++ b/pkg/oci/redirect.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -56,28 +57,23 @@ func (r *Registry) blobRedirectURL(ctx context.Context, f *RepoFile) (string, er
 		return "", err
 	}
 
-	versionDesc, err := r.resolveVersionDescriptor(ctx, backend, f)
+	canonicalTag, err := r.resolveCanonicalTag(ctx, backend, f)
 	if err != nil {
 		return "", err
 	}
 
-	refs, err := registry.Referrers(ctx, backend, versionDesc, r.fileArtifactType)
+	fileManifestDesc, err := backend.Resolve(ctx, fileTagFor(canonicalTag, f.Name))
 	if err != nil {
-		return "", fmt.Errorf("failed to list file referrers: %w", err)
-	}
-
-	for i := range refs {
-		if refs[i].Annotations[FileNameAnnotation] != f.Name {
-			continue
+		if errors.Is(err, errdef.ErrNotFound) {
+			return "", fmt.Errorf("file %q not found in version %q: %w", f.Name, canonicalTag, errdef.ErrNotFound)
 		}
-		blobDesc, err := fetchBlobDescriptor(ctx, backend, refs[i])
-		if err != nil {
-			return "", err
-		}
-		return r.probeBlobRedirect(ctx, f, blobDesc)
+		return "", fmt.Errorf("failed to resolve file manifest tag: %w", err)
 	}
-
-	return "", fmt.Errorf("file %q not found in version: %w", f.Name, errdef.ErrNotFound)
+	blobDesc, err := fetchBlobDescriptor(ctx, backend, fileManifestDesc)
+	if err != nil {
+		return "", err
+	}
+	return r.probeBlobRedirect(ctx, f, blobDesc)
 }
 
 // probeBlobRedirect issues a HEAD against the backend's

--- a/pkg/oci/registry.go
+++ b/pkg/oci/registry.go
@@ -92,6 +92,16 @@ type destRepo interface {
 	content.Tagger
 	content.Deleter
 	content.PredecessorFinder
+
+	// DeleteTag removes a single tag reference without otherwise
+	// touching the manifest it points to. Used by the deterministic
+	// file-tag cleanup paths so a deleted file manifest doesn't leave
+	// behind a dangling _f_* tag entry that ListTags would have to
+	// filter on every call. oras-go's public surface exposes manifest
+	// deletion by digest only, so the destRepo abstraction grows this
+	// one method and remoteRepo implements it via a direct HTTP
+	// DELETE against /v2/<repo>/manifests/<tag>.
+	DeleteTag(ctx context.Context, tag string) error
 }
 
 type Registry struct {
@@ -442,7 +452,7 @@ func (r *Registry) AddFile(ctx context.Context, f *RepoFile, ro io.Reader) (*Fil
 		return nil, err
 	}
 
-	fileManifestDesc, err := r.pushFileManifest(ctx, backend, blobDesc, f.Name, versionDesc)
+	fileManifestDesc, err := r.pushFileManifest(ctx, backend, blobDesc, f.OwningTag, f.Name, versionDesc)
 	if err != nil {
 		return nil, err
 	}
@@ -455,6 +465,12 @@ func (r *Registry) AddFile(ctx context.Context, f *RepoFile, ro io.Reader) (*Fil
 	// referrers list until backend GC reaps it, but the live referrer
 	// scan in ReadFile may then return either manifest. That
 	// uncertainty is exactly what overwrite-mode opts into.
+	//
+	// The deterministic file tag was already retagged onto the new
+	// manifest by pushFileManifest (Tag is an overwrite, not a
+	// create), so there's no separate tag to untag here — the old
+	// manifest is reachable only via Referrers until the Delete below
+	// detaches it.
 	if oldFileManifest != nil && oldFileManifest.Digest != fileManifestDesc.Digest {
 		_ = backend.Delete(ctx, *oldFileManifest)
 	}
@@ -666,7 +682,15 @@ func (r *Registry) ensureVersionManifest(ctx context.Context, backend destRepo, 
 // pushFileManifest packs a file manifest with subject = versionDesc, single
 // layer = blobDesc, and the file's name + blob digest mirrored into manifest
 // annotations so the referrers index reflects them without an extra fetch.
-func (r *Registry) pushFileManifest(ctx context.Context, backend destRepo, blobDesc ocispec.Descriptor, fileName string, versionDesc ocispec.Descriptor) (ocispec.Descriptor, error) {
+//
+// After the manifest is pushed, the deterministic file tag derived from
+// (owningTag, fileName) is set on it so ReadFile and BlobRedirectURL can
+// resolve the file manifest in one round-trip instead of paying for the
+// version-manifest → Referrers → file-manifest descriptor walk on every
+// download. Tag is an overwrite (PUT /v2/<repo>/manifests/<tag>), so an
+// AddFile that replaces an existing file simply moves the tag onto the
+// new manifest atomically.
+func (r *Registry) pushFileManifest(ctx context.Context, backend destRepo, blobDesc ocispec.Descriptor, owningTag, fileName string, versionDesc ocispec.Descriptor) (ocispec.Descriptor, error) {
 	annotations := map[string]string{
 		FileNameAnnotation:      fileName,
 		ocispec.AnnotationTitle: fileName,
@@ -676,14 +700,28 @@ func (r *Registry) pushFileManifest(ctx context.Context, backend destRepo, blobD
 	if err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("failed to push file manifest for %q: %w", fileName, err)
 	}
+	if err := backend.Tag(ctx, desc, fileTagFor(owningTag, fileName)); err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to tag file manifest for %q: %w", fileName, err)
+	}
 	return desc, nil
 }
 
-// ReadFile reads a file by either OwningTag or RefTag. With OwningTag, the
-// version manifest is resolved directly and its file referrers are scanned
-// for a name match. With RefTag, the alias manifest is resolved first, its
-// subject followed to the canonical version manifest, and the same scan
-// runs from there.
+// ReadFile reads a file by either OwningTag or RefTag.
+//
+// With OwningTag, the file manifest is resolved directly via the
+// deterministic _f_<sha256(OwningTag\0Name)> tag that AddFile attaches.
+// That's two backend round-trips on the hot path (Resolve + Fetch
+// manifest) before the blob fetch, instead of the four serial RTTs the
+// old Resolve-version → Referrers → fetchBlobDescriptor → Fetch path
+// paid. At a 30ms backend RTT that's ~60ms saved per file, which
+// compounds into seconds across a cold `mvn dependency:resolve` or
+// `npm install`.
+//
+// With RefTag, the alias manifest is resolved first, the canonical
+// version tag is read out of its AliasTargetAnnotation, and the
+// deterministic file tag is computed against the canonical name. The
+// alias path keeps the extra round-trip to fetch the alias manifest
+// body but still skips the Referrers walk.
 func (r *Registry) ReadFile(ctx context.Context, f *RepoFile) (*FileDescriptor, io.ReadCloser, error) {
 	if f.OwningTag == "" && f.RefTag == "" {
 		return nil, nil, fmt.Errorf("either OwningTag or RefTag must be set")
@@ -694,73 +732,70 @@ func (r *Registry) ReadFile(ctx context.Context, f *RepoFile) (*FileDescriptor, 
 		return nil, nil, err
 	}
 
-	versionDesc, err := r.resolveVersionDescriptor(ctx, backend, f)
+	canonicalTag, err := r.resolveCanonicalTag(ctx, backend, f)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	refs, err := registry.Referrers(ctx, backend, versionDesc, r.fileArtifactType)
+	fileManifestDesc, err := backend.Resolve(ctx, fileTagFor(canonicalTag, f.Name))
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to list file referrers: %w", err)
+		if errors.Is(err, errdef.ErrNotFound) {
+			return nil, nil, fmt.Errorf("file %q not found in version %q: %w", f.Name, canonicalTag, errdef.ErrNotFound)
+		}
+		return nil, nil, fmt.Errorf("failed to resolve file manifest tag: %w", err)
 	}
-
-	for i := range refs {
-		if refs[i].Annotations[FileNameAnnotation] != f.Name {
-			continue
-		}
-		fileManifestDesc := refs[i]
-		blobDesc, err := fetchBlobDescriptor(ctx, backend, fileManifestDesc)
-		if err != nil {
-			return nil, nil, err
-		}
-		if f.Digest != "" && string(blobDesc.Digest) != f.Digest {
-			return nil, nil, fmt.Errorf("file digest mismatch: %q != %q", blobDesc.Digest, f.Digest)
-		}
-		rc, err := backend.Fetch(ctx, blobDesc)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to fetch file blob: %w", err)
-		}
-		return &FileDescriptor{Manifest: fileManifestDesc, File: blobDesc}, rc, nil
+	blobDesc, err := fetchBlobDescriptor(ctx, backend, fileManifestDesc)
+	if err != nil {
+		return nil, nil, err
 	}
-
-	return nil, nil, fmt.Errorf("file %q not found in version: %w", f.Name, errdef.ErrNotFound)
+	if f.Digest != "" && string(blobDesc.Digest) != f.Digest {
+		return nil, nil, fmt.Errorf("file digest mismatch: %q != %q", blobDesc.Digest, f.Digest)
+	}
+	rc, err := backend.Fetch(ctx, blobDesc)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to fetch file blob: %w", err)
+	}
+	return &FileDescriptor{Manifest: fileManifestDesc, File: blobDesc}, rc, nil
 }
 
-// resolveVersionDescriptor turns a RepoFile (which may identify the version
-// directly via OwningTag or indirectly via RefTag) into the descriptor of
-// the canonical version manifest. The RefTag path follows the alias
-// manifest's subject field.
-func (r *Registry) resolveVersionDescriptor(ctx context.Context, backend destRepo, f *RepoFile) (ocispec.Descriptor, error) {
+// resolveCanonicalTag turns a RepoFile that identifies a version either
+// directly (OwningTag) or via an alias (RefTag) into the canonical
+// version tag string. The string is what fileTagFor hashes; we don't
+// need the version manifest descriptor on the per-file read path because
+// the deterministic file tag short-circuits the Referrers walk.
+//
+// The alias path still pays one Resolve + one Fetch (to inspect the
+// alias manifest's AliasTargetAnnotation), but skips the Referrers list
+// that used to walk every file under the canonical version.
+func (r *Registry) resolveCanonicalTag(ctx context.Context, backend destRepo, f *RepoFile) (string, error) {
 	if f.OwningTag != "" {
-		desc, err := backend.Resolve(ctx, f.OwningTag)
-		if err != nil {
-			return ocispec.Descriptor{}, fmt.Errorf("failed to resolve version tag %q: %w", f.OwningTag, err)
-		}
-		return desc, nil
+		return f.OwningTag, nil
 	}
 
 	aliasDesc, err := backend.Resolve(ctx, f.RefTag)
 	if err != nil {
-		return ocispec.Descriptor{}, fmt.Errorf("failed to resolve alias tag %q: %w", f.RefTag, err)
+		return "", fmt.Errorf("failed to resolve alias tag %q: %w", f.RefTag, err)
 	}
 	var aliasManifest ocispec.Manifest
 	if err := fetchManifestJSON(ctx, backend, aliasDesc, &aliasManifest); err != nil {
-		return ocispec.Descriptor{}, fmt.Errorf("failed to fetch alias manifest %q: %w", f.RefTag, err)
+		return "", fmt.Errorf("failed to fetch alias manifest %q: %w", f.RefTag, err)
 	}
 	if aliasManifest.ArtifactType != r.aliasArtifactType {
-		return ocispec.Descriptor{}, fmt.Errorf("%w: tag %q has artifactType %q (expected %q)", ErrAliasCollision, f.RefTag, aliasManifest.ArtifactType, r.aliasArtifactType)
+		return "", fmt.Errorf("%w: tag %q has artifactType %q (expected %q)", ErrAliasCollision, f.RefTag, aliasManifest.ArtifactType, r.aliasArtifactType)
 	}
-	if aliasManifest.Subject == nil {
-		return ocispec.Descriptor{}, fmt.Errorf("alias manifest %q has no subject", f.RefTag)
+	canonical := aliasManifest.Annotations[AliasTargetAnnotation]
+	if canonical == "" {
+		return "", fmt.Errorf("alias manifest %q is missing %s annotation", f.RefTag, AliasTargetAnnotation)
 	}
-	return *aliasManifest.Subject, nil
+	return canonical, nil
 }
 
-// ListTags lists the tags for a repository. Both canonical version tags
-// and alias tags are returned in the same flat list — the legacy ref_
-// prefix filter is gone. Callers that need version-vs-alias discrimination
-// should use a sibling helper (added when first needed; the current
-// in-tree caller is python's "index" repo, which has no aliases).
+// ListTags lists the tags for a repository. Canonical version tags and
+// alias tags are returned in the same flat list; deterministic file
+// tags (the _f_<sha256> entries AddFile attaches to each file manifest
+// so ReadFile can resolve a file in one round-trip) are filtered out
+// so callers see the same "versions + aliases" view they did before
+// the deterministic-tag fast path landed.
 //
 // 404 NAME_UNKNOWN responses (zot returns this for repositories that
 // have never been pushed to) are normalized to errdef.ErrNotFound so
@@ -772,7 +807,17 @@ func (r *Registry) ListTags(ctx context.Context, repo string) ([]string, error) 
 		return nil, err
 	}
 	tags, err := registry.Tags(ctx, backend)
-	return tags, normalizeNotFound(err)
+	if err != nil {
+		return nil, normalizeNotFound(err)
+	}
+	out := tags[:0]
+	for _, t := range tags {
+		if isFileTag(t) {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out, nil
 }
 
 // ListFiles enumerates all files across all canonical versions in repo.
@@ -793,6 +838,13 @@ func (r *Registry) ListFiles(ctx context.Context, repo string) ([]*RepoFile, err
 
 	var files []*RepoFile
 	for _, tag := range tags {
+		// Deterministic file tags (_f_<sha256>) point at file manifests
+		// directly; iterating over them would re-enter the file
+		// manifest scan and double-count every file. Skip them up
+		// front rather than relying on the artifactType filter below.
+		if isFileTag(tag) {
+			continue
+		}
 		versionDesc, err := backend.Resolve(ctx, tag)
 		if err != nil {
 			if errors.Is(err, errdef.ErrNotFound) {
@@ -932,6 +984,17 @@ func (r *Registry) deleteTagFiles(ctx context.Context, backend destRepo, tag str
 			return fmt.Errorf("failed to list referrers for tag %q: %w", tag, err)
 		}
 		for _, ref := range refs {
+			// Untag the deterministic file tag first so an in-flight
+			// reader that already resolved the tag is the only race
+			// window — without this, ListTags would keep returning
+			// _f_* entries that point at a soon-deleted digest. Only
+			// file manifests carry one; alias manifests don't, and
+			// the call is a no-op against a missing tag.
+			if name := ref.Annotations[FileNameAnnotation]; name != "" {
+				if err := backend.DeleteTag(ctx, fileTagFor(tag, name)); err != nil && !errors.Is(err, errdef.ErrNotFound) {
+					return fmt.Errorf("failed to untag file %q: %w", name, err)
+				}
+			}
 			if err := backend.Delete(ctx, ref); err != nil && !errors.Is(err, errdef.ErrNotFound) {
 				return fmt.Errorf("failed to delete referrer %s: %w", ref.Digest, err)
 			}
@@ -1227,11 +1290,50 @@ func (r *Registry) newBackend(ctx context.Context, f *RepoFile) (destRepo, error
 }
 
 // remoteRepo adapts oras-go's *remote.Repository to our destRepo
-// interface. The wrapper exists only so the package compiles when oras-go
-// adds further methods that conflict with destRepo's surface; today it is
-// a thin pass-through.
+// interface. The wrapper exists so we can attach DeleteTag — oras-go's
+// public surface only exposes manifest deletion by digest, but the OCI
+// distribution spec allows DELETE /v2/<repo>/manifests/<tag> to remove
+// the tag reference (leaving the underlying manifest alone if other
+// tags or referrers still pin it).
 type remoteRepo struct {
 	*remote.Repository
+}
+
+// DeleteTag issues a direct HTTP DELETE against
+// /v2/<repo>/manifests/<tag>. Used by the deterministic file-tag
+// cleanup paths so removed file manifests don't leave dangling _f_*
+// tags behind. A 404 from the backend is translated to
+// errdef.ErrNotFound so callers can use errors.Is to swallow
+// already-gone tags.
+func (r remoteRepo) DeleteTag(ctx context.Context, tag string) error {
+	ref := r.Repository.Reference
+	ref.Reference = tag
+	scheme := "https"
+	if r.Repository.PlainHTTP {
+		scheme = "http"
+	}
+	deleteURL := fmt.Sprintf("%s://%s/v2/%s/manifests/%s", scheme, ref.Host(), ref.Repository, tag)
+
+	delCtx := auth.AppendRepositoryScope(ctx, ref, auth.ActionDelete)
+	req, err := http.NewRequestWithContext(delCtx, http.MethodDelete, deleteURL, nil)
+	if err != nil {
+		return fmt.Errorf("build delete-tag request: %w", err)
+	}
+	resp, err := r.Repository.Client.Do(req)
+	if err != nil {
+		return fmt.Errorf("delete tag %q: %w", tag, err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusAccepted, http.StatusNoContent:
+		return nil
+	case http.StatusNotFound:
+		return errdef.ErrNotFound
+	default:
+		return fmt.Errorf("delete tag %q: backend returned %s", tag, resp.Status)
+	}
 }
 
 // newStreamPusher constructs a streamPusher that talks directly to the

--- a/pkg/oci/registry_test.go
+++ b/pkg/oci/registry_test.go
@@ -229,6 +229,22 @@ func (r *inMemoryRepo) Predecessors(ctx context.Context, node ocispec.Descriptor
 	return kept, nil
 }
 
+// DeleteTag mirrors a real OCI registry's
+// `DELETE /v2/<repo>/manifests/<tag>` semantics: just the tag mapping
+// is removed; the underlying manifest stays addressable by digest (and
+// reachable via Predecessors) until something deletes it. Used by the
+// deterministic file-tag cleanup path in pkg/oci so the dangling _f_*
+// tag is reaped before the file manifest itself.
+func (r *inMemoryRepo) DeleteTag(_ context.Context, tag string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.allTags[tag]; !ok {
+		return errdef.ErrNotFound
+	}
+	delete(r.allTags, tag)
+	return nil
+}
+
 // Intercept the Resolve call to return ErrNotFound if the target has been deleted.
 func (r *inMemoryRepo) Resolve(ctx context.Context, reference string) (ocispec.Descriptor, error) {
 	target, err := r.Store.Resolve(ctx, reference)
@@ -1315,4 +1331,244 @@ type readCounter struct {
 func (r *readCounter) Read(p []byte) (int, error) {
 	r.calls++
 	return r.src.Read(p)
+}
+
+// TestAddFile_TagsDeterministicFileTag verifies the contract added in
+// #97: every AddFile attaches a deterministic _f_<sha256(owningTag\0name)>
+// tag to its file manifest so ReadFile / BlobRedirectURL can resolve in
+// one round-trip. The tag must point at the file manifest (not the
+// blob, not the version), and the canonical version tag must still be
+// the version manifest — the two namespaces must not collide.
+func TestAddFile_TagsDeterministicFileTag(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	r, memRepo := newTestRegistry(t)
+
+	f := &RepoFile{
+		OwningRepo: "pkg",
+		OwningTag:  "v1",
+		Name:       "a.txt",
+	}
+	desc, err := r.AddFile(ctx, f, strings.NewReader("hello"))
+	if err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+
+	memRepo.mu.Lock()
+	fileTagDigest := memRepo.allTags[fileTagFor("v1", "a.txt")]
+	versionTagDigest := memRepo.allTags["v1"]
+	memRepo.mu.Unlock()
+
+	if fileTagDigest == "" {
+		t.Fatalf("expected _f_* tag for (v1, a.txt) but none present in allTags")
+	}
+	if fileTagDigest == versionTagDigest {
+		t.Errorf("deterministic file tag and version tag point at the same manifest digest %q; they must address different manifests", fileTagDigest)
+	}
+	if fileTagDigest == desc.File.Digest.String() {
+		t.Errorf("deterministic file tag points at the blob digest %q instead of the file manifest", fileTagDigest)
+	}
+	if fileTagDigest != desc.Manifest.Digest.String() {
+		t.Errorf("deterministic file tag digest = %q, want file manifest digest %q", fileTagDigest, desc.Manifest.Digest.String())
+	}
+}
+
+// TestReadFile_UsesDeterministicTag locks in the actual perf win the
+// issue is after: ReadFile must NOT walk the version's referrers when
+// the deterministic file tag exists. We exercise this by replacing
+// Predecessors (which backs registry.Referrers fallback) with a stub
+// that fails — if ReadFile ever asks for referrers on the hot path
+// this test fails. Resolve and Fetch are the only backend calls
+// allowed.
+func TestReadFile_UsesDeterministicTag(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	r, memRepo := newTestRegistry(t)
+	f := &RepoFile{
+		OwningRepo: "pkg",
+		OwningTag:  "v1",
+		Name:       "a.txt",
+	}
+	if _, err := r.AddFile(ctx, f, strings.NewReader("hello")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+
+	// Wrap the backend so any Predecessors / Referrers call surfaces
+	// as an error. Resolve+Fetch are the only backend calls
+	// ReadFile-via-deterministic-tag is permitted to make.
+	r.newBackendFunc = func(ctx context.Context, _ *RepoFile) (destRepo, error) {
+		return &referrerForbiddenRepo{inMemoryRepo: memRepo, t: t}, nil
+	}
+
+	_, body, err := r.ReadFile(ctx, f)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	defer body.Close()
+	got, _ := io.ReadAll(body)
+	if string(got) != "hello" {
+		t.Errorf("ReadFile() content = %q, want %q", got, "hello")
+	}
+}
+
+// referrerForbiddenRepo fails any call that walks the referrers graph,
+// so a test can assert that the fast-path ReadFile never touches it.
+type referrerForbiddenRepo struct {
+	*inMemoryRepo
+	t *testing.T
+}
+
+func (r *referrerForbiddenRepo) Predecessors(_ context.Context, _ ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+	r.t.Errorf("Predecessors called on the read fast path; deterministic file tag should have short-circuited the referrers walk")
+	return nil, errors.New("referrer walk forbidden")
+}
+
+// TestListTags_FiltersDeterministicFileTags verifies the user-visible
+// view of ListTags: it must hide _f_* tags so handlers that enumerate
+// "versions + aliases" don't see implementation-detail entries. The
+// raw backend tag list confirms a _f_* entry is actually present —
+// otherwise the test would pass trivially even if filtering were a
+// no-op against an empty input.
+func TestListTags_FiltersDeterministicFileTags(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	r, memRepo := newTestRegistry(t)
+
+	if _, err := r.AddFile(ctx, &RepoFile{
+		OwningRepo: "pkg",
+		OwningTag:  "v1",
+		Name:       "a.txt",
+	}, strings.NewReader("a")); err != nil {
+		t.Fatalf("AddFile(v1) error = %v", err)
+	}
+	if err := r.AppendRefs(ctx, "pkg", "v1", "latest"); err != nil {
+		t.Fatalf("AppendRefs() error = %v", err)
+	}
+
+	// Sanity-check the backend actually carries the deterministic
+	// tag — otherwise the ListTags filter assertion would pass even
+	// if filtering were broken against an empty input.
+	memRepo.mu.Lock()
+	hasFileTag := false
+	for k := range memRepo.allTags {
+		if isFileTag(k) {
+			hasFileTag = true
+			break
+		}
+	}
+	memRepo.mu.Unlock()
+	if !hasFileTag {
+		t.Fatalf("precondition: backend must hold at least one _f_* tag after AddFile")
+	}
+
+	gotTags, err := r.ListTags(ctx, "pkg")
+	if err != nil {
+		t.Fatalf("ListTags() error = %v", err)
+	}
+	slices.Sort(gotTags)
+	if diff := cmp.Diff([]string{"latest", "v1"}, gotTags); diff != "" {
+		t.Errorf("ListTags() leaked _f_* tags or missed versions/aliases (-want +got):\n%s", diff)
+	}
+}
+
+// TestDeleteTagFiles_UntagsDeterministicTag locks in the cleanup
+// contract: after DeleteTagFiles, the deterministic _f_* tag must be
+// gone so Resolve(_f_*) returns ErrNotFound and ListTags-after-filter
+// surfaces a clean view of remaining versions.
+func TestDeleteTagFiles_UntagsDeterministicTag(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	r, memRepo := newTestRegistry(t)
+
+	f := &RepoFile{
+		OwningRepo: "pkg",
+		OwningTag:  "v1",
+		Name:       "a.txt",
+	}
+	if _, err := r.AddFile(ctx, f, strings.NewReader("a")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	tag := fileTagFor("v1", "a.txt")
+	memRepo.mu.Lock()
+	_, present := memRepo.allTags[tag]
+	memRepo.mu.Unlock()
+	if !present {
+		t.Fatalf("precondition: deterministic file tag %q must be set after AddFile", tag)
+	}
+
+	if err := r.DeleteTagFiles(ctx, "pkg", "v1"); err != nil {
+		t.Fatalf("DeleteTagFiles() error = %v", err)
+	}
+
+	memRepo.mu.Lock()
+	_, stillPresent := memRepo.allTags[tag]
+	memRepo.mu.Unlock()
+	if stillPresent {
+		t.Errorf("DeleteTagFiles() left deterministic tag %q behind", tag)
+	}
+
+	if _, _, err := r.ReadFile(ctx, f); !errors.Is(err, errdef.ErrNotFound) {
+		t.Errorf("ReadFile() after DeleteTagFiles = %v, want errors.Is ErrNotFound", err)
+	}
+}
+
+// TestAddFile_OverwriteMovesDeterministicTag verifies the
+// allow-overwrite path keeps the deterministic tag pointing at the new
+// file manifest (and not stranded on the deleted old one). Without
+// this, the second ReadFile would resolve the dangling tag and
+// either 404 or surface the previous content.
+func TestAddFile_OverwriteMovesDeterministicTag(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	r, err := NewRegistry(
+		&url.URL{Scheme: "https", Host: "example.com"},
+		WithAllowOverwrite(true),
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	memRepo := &inMemoryRepo{Store: memory.New(), allTags: map[string]string{}}
+	r.newBackendFunc = func(_ context.Context, _ *RepoFile) (destRepo, error) {
+		return memRepo, nil
+	}
+
+	f := &RepoFile{
+		OwningRepo: "pkg",
+		OwningTag:  "v1",
+		Name:       "a.txt",
+	}
+	first, err := r.AddFile(ctx, f, strings.NewReader("first"))
+	if err != nil {
+		t.Fatalf("AddFile() first error = %v", err)
+	}
+	second, err := r.AddFile(ctx, f, strings.NewReader("second"))
+	if err != nil {
+		t.Fatalf("AddFile() second error = %v", err)
+	}
+	if first.Manifest.Digest == second.Manifest.Digest {
+		t.Fatalf("overwrite produced identical manifest digest; expected different content to yield different manifest")
+	}
+
+	tag := fileTagFor("v1", "a.txt")
+	memRepo.mu.Lock()
+	pointsAt := memRepo.allTags[tag]
+	memRepo.mu.Unlock()
+	if pointsAt != second.Manifest.Digest.String() {
+		t.Errorf("deterministic tag %q points at %q, want new manifest digest %q", tag, pointsAt, second.Manifest.Digest)
+	}
+
+	_, body, err := r.ReadFile(ctx, f)
+	if err != nil {
+		t.Fatalf("ReadFile() after overwrite error = %v", err)
+	}
+	gotBody, _ := io.ReadAll(body)
+	body.Close()
+	if string(gotBody) != "second" {
+		t.Errorf("ReadFile() after overwrite = %q, want %q", gotBody, "second")
+	}
 }


### PR DESCRIPTION
ReadFile and BlobRedirectURL used to walk the version manifest's
referrer index on every per-file lookup: Resolve(version) -> Referrers
-> fetchBlobDescriptor -> Fetch was 4 serial RTTs, with the Referrers
response body sized to fan-in O(files-per-version). Most artifact
clients address files by name, not digest, so this happened on every
`npm install` tarball and `mvn dependency:resolve` jar fetch.

Each AddFile now attaches a deterministic _f_<sha256(OwningTag\0Name)>
tag to the file manifest, and the read path becomes Resolve(tag) ->
Fetch -> blob fetch — 2 RTTs of metadata, O(1) response body, before
bytes start flowing. Existing Referrers-based listing (ListFiles, format
index generation) stays unchanged.

ListTags filters _f_* entries so handlers that enumerate "versions +
aliases" don't see the implementation detail; ListFiles skips them up
front. DeleteTagFiles untags each file manifest before deleting it via
a new DeleteTag method on destRepo (real backends via direct DELETE
/v2/<repo>/manifests/<tag>, in-memory fake via map deletion).

Closes #97