### PR TITLE
Refresh storage-model docs to reflect the OCI 1.1 referrers layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,12 +72,19 @@ HTTP request ──►     │  cmd/ocifactory  (CLI entrypoint)    │
                      └─────────────────────────────────────┘
 ```
 
+The on-OCI shape `pkg/oci` writes — version anchors, file manifests,
+alias manifests, the deterministic `_f_*` file tag, and why it's not a
+fat per-version manifest — is documented in
+[`docs/architecture/storage-model.md`](docs/architecture/storage-model.md).
+Read that doc before touching the `pkg/oci` write paths.
+
 ### Key types
 
 - `oci.RepoFile{OwningRepo, OwningTag, RefTag, Name, MediaType, Digest}` — addresses one file inside the OCI-backed virtual store.
   - `OwningRepo` is the OCI repository name (e.g. `packages/requests`, `com/foo/bar`).
-  - `OwningTag` is the canonical version tag (e.g. `2.31.0`). One OCI manifest per `OwningTag`; layers are the files in that version.
-  - `RefTag` is an alias tag like `latest`. Stored prefixed with `ref_` in the backend so `ListTags` can filter them out (callers see clean tag names).
+  - `OwningTag` is the canonical version tag (e.g. `2.31.0`). It identifies the **version manifest** — a constant-size anchor in the [OCI 1.1 referrers layout](docs/architecture/storage-model.md). Files for that version are *not* layers on this manifest; each file is its own **file manifest** with `subject = versionDesc`, addressed via the referrers API and tagged with a deterministic `_f_<sha256>` tag so reads resolve in one round-trip.
+  - `RefTag` is an alias tag like `latest`. It identifies an **alias manifest** with `subject = versionDesc` and the canonical version recorded in the `ocifactory.alias.target` annotation.
+  - The three manifest kinds are distinguished by `artifactType` suffix — `.version`, `.file`, `.alias` — appended to the operator-configured base type (e.g. `application/vnd.ocifactory.python.version`).
 - `handler.Registry` — the interface every per-format handler depends on. Keep it minimal; do not push format-specific concepts into it.
 - `cred.Cred` — credentials carried in the request `context.Context`. Today only `Basic`. When adding OAuth/OIDC/JWT, add a new field rather than overloading `Basic`.
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,14 @@ client ──► handler/<format> ──► pkg/oci.Registry ──► OCI regis
 
 One Go binary. One process. Storage offloaded entirely to your OCI registry.
 Each artifact format gets its own `pkg/handler/<format>` package implementing
-the relevant protocol. See [`AGENTS.md`](AGENTS.md) for the full design notes
-and [`docs/ROADMAP.md`](docs/ROADMAP.md) for what's coming.
+the relevant protocol.
+
+For the on-OCI shape — version anchors, file manifests, alias manifests, and
+why ocifactory uses the OCI 1.1 referrers layout instead of one fat manifest
+per version — see
+[`docs/architecture/storage-model.md`](docs/architecture/storage-model.md).
+See [`AGENTS.md`](AGENTS.md) for the full design notes and
+[`docs/ROADMAP.md`](docs/ROADMAP.md) for what's coming.
 
 ## Contributing
 

--- a/docs/architecture/storage-model.md
+++ b/docs/architecture/storage-model.md
@@ -1,0 +1,258 @@
+# Storage model
+
+This doc describes what ocifactory writes to its OCI backend for a
+single published version. It's the canonical reference for the
+on-registry shape — the per-format docs under [`../repos/`](../repos/)
+link here from their "How it's stored" sections.
+
+The implementation lives in [`pkg/oci/registry.go`](../../pkg/oci/registry.go);
+the deterministic file-tag helper lives in
+[`pkg/oci/filetag.go`](../../pkg/oci/filetag.go).
+
+## TL;DR
+
+For one published version of a package, the OCI backend holds:
+
+- **One version manifest** — a constant-size anchor with no real layers,
+  tagged with the canonical version string (e.g. `2.31.0`). This is the
+  thing aliases and file manifests `subject`-link to.
+- **One file manifest per file** — single layer is the file blob,
+  `subject` is the version manifest, addressed via the
+  [OCI 1.1 referrers API](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers).
+  Each file manifest also gets a deterministic `_f_<sha256>` tag so
+  reads resolve in a single round-trip.
+- **One alias manifest per ref tag** (`latest`, `stable`, an npm
+  dist-tag, …) — empty layers, `subject` is the version manifest, the
+  canonical version recorded in the
+  `ocifactory.alias.target` annotation. Tagged with the alias name.
+
+Three distinct `artifactType` suffixes — `.version`, `.file`,
+`.alias` — let an operator inspecting the registry tell the manifest
+kinds apart at a glance.
+
+## Manifest graph
+
+```
+                  alias manifest (tag: latest)               alias manifest (tag: stable)
+                  artifactType: ...alias                     artifactType: ...alias
+                  ann: ocifactory.alias.target=2.31.0        ann: ocifactory.alias.target=2.31.0
+                              │                                          │
+                              │ subject                                  │ subject
+                              ▼                                          ▼
+                     ┌─────────────────────────────────────────────────────┐
+                     │  version manifest      (tag: 2.31.0)                │
+                     │  artifactType: application/vnd.ocifactory.<fmt>.version │
+                     │  layers: [empty.json sentinel]                      │
+                     └────▲──────────────▲──────────────▲─────────────────┘
+                          │ subject      │ subject      │ subject
+              ┌───────────┘              │              └───────────┐
+              │                          │                          │
+   file manifest                 file manifest                 file manifest
+   (tag: _f_<sha256>)            (tag: _f_<sha256>)            (tag: _f_<sha256>)
+   artifactType: ...file         artifactType: ...file         artifactType: ...file
+   ann.title = sdist             ann.title = wheel-cp310       ann.title = wheel-cp311
+   ann.digest = sha256:…         ann.digest = sha256:…         ann.digest = sha256:…
+   layer: <sdist blob>           layer: <wheel blob>           layer: <wheel blob>
+```
+
+Tags exposed to callers via `ListTags` are filtered to just the
+canonical version tag and any alias tags; the deterministic `_f_*`
+file tags are stripped on the way out so callers see the same
+"versions + aliases" view they'd expect from any registry.
+
+## Annotations and artifactType constants
+
+From [`pkg/oci/registry.go`](../../pkg/oci/registry.go):
+
+| Constant | Value | Where it lives |
+|---|---|---|
+| `FileNameAnnotation` | `ocifactory.file.title` | File manifests, mirrored onto the layer descriptor. Lets the referrers index surface the filename without fetching each manifest body. |
+| `FileDigestAnnotation` | `ocifactory.file.digest` | File manifests. Lets `ListFiles` learn the blob digest from the referrer entry without fetching each manifest. |
+| `AliasTargetAnnotation` | `ocifactory.alias.target` | Alias manifests. Records the canonical version tag the alias points at, in human-readable form. |
+| `versionArtifactSuffix` | `.version` | Appended to the operator-configured base type (e.g. `application/vnd.ocifactory.python.version`). |
+| `fileArtifactSuffix` | `.file` | Same shape (`...python.file`). |
+| `aliasArtifactSuffix` | `.alias` | Same shape (`...python.alias`). |
+
+Operators set the base type via `WithArtifactType(...)`; the per-format
+handlers pass `application/vnd.ocifactory.python`,
+`application/vnd.ocifactory.maven`, `application/vnd.ocifactory.npm`,
+etc. The three subtypes are derived in `NewRegistry`.
+
+## Worked example — Python release (`twine upload dist/*`)
+
+A user runs:
+
+```bash
+twine upload dist/*
+```
+
+with `dist/` containing:
+
+```
+requests-2.31.0.tar.gz
+requests-2.31.0-py3-none-any.whl
+requests-2.31.0-cp311-cp311-manylinux_2_17_x86_64.whl
+```
+
+`twine` issues **three independent POSTs** to ocifactory's `/` endpoint
+— one per file. They may arrive in any order and may overlap if `twine`
+is parallelised across CI workers.
+
+Each POST translates to one `Registry.AddFile` call. For the first one
+to land (say the sdist):
+
+1. **Probe** for an existing `requests-2.31.0.tar.gz` referrer under
+   the `2.31.0` tag. There isn't one (the version tag doesn't exist
+   yet) — proceed.
+2. **Push the blob.** Either monolithic (small bodies) or chunked PATCH
+   (bodies above `uploadMemThreshold`). The blob is content-addressed,
+   so concurrent uploads of the same bytes deduplicate.
+3. **Ensure the version manifest.** `Resolve("2.31.0")` returns
+   `ErrNotFound`, so we pack the constant-size version manifest
+   (artifactType `application/vnd.ocifactory.python.version`, no real
+   layers) and tag it `2.31.0`. The version manifest digest is
+   deterministic — concurrent first-writers race the `Tag` call but
+   both push the same content, so the loser is a no-op.
+4. **Push the file manifest.** `subject = versionDesc`, single layer is
+   the sdist blob, `artifactType = application/vnd.ocifactory.python.file`,
+   annotations set `ocifactory.file.title = requests-2.31.0.tar.gz` and
+   `ocifactory.file.digest = sha256:…`.
+5. **Tag the file manifest** with `_f_<sha256("2.31.0\0requests-2.31.0.tar.gz")>`
+   so future `ReadFile` calls resolve it in one round-trip.
+
+The next two POSTs (the two wheels) take the same path but
+short-circuit at step 3 — `Resolve("2.31.0")` now returns the version
+manifest from the first call, the artifactType matches
+`...python.version`, so we reuse it. Each wheel writes its own file
+manifest pointing at the same version anchor, gets its own
+deterministic `_f_*` tag, and never touches the version manifest's
+bytes.
+
+**No read-modify-write anywhere on the path.** Three concurrent CI
+workers running `twine upload` against three different files of the
+same release race only on the version-manifest creation, which is
+idempotent (same content, same digest). Nobody loses a file.
+
+## Worked example — Maven release (`mvn deploy`)
+
+A user runs:
+
+```bash
+mvn deploy
+```
+
+for `com.example:foo:1.0.0` with a normal release configuration. `mvn`
+fires roughly 12 PUTs:
+
+```
+PUT /com/example/foo/1.0.0/foo-1.0.0.jar
+PUT /com/example/foo/1.0.0/foo-1.0.0.jar.md5
+PUT /com/example/foo/1.0.0/foo-1.0.0.jar.sha1
+PUT /com/example/foo/1.0.0/foo-1.0.0.pom
+PUT /com/example/foo/1.0.0/foo-1.0.0.pom.md5
+PUT /com/example/foo/1.0.0/foo-1.0.0.pom.sha1
+PUT /com/example/foo/1.0.0/foo-1.0.0-sources.jar
+PUT /com/example/foo/1.0.0/foo-1.0.0-sources.jar.md5
+PUT /com/example/foo/1.0.0/foo-1.0.0-sources.jar.sha1
+PUT /com/example/foo/1.0.0/foo-1.0.0-javadoc.jar
+PUT /com/example/foo/1.0.0/foo-1.0.0-javadoc.jar.md5
+PUT /com/example/foo/1.0.0/foo-1.0.0-javadoc.jar.sha1
+PUT /com/example/foo/maven-metadata.xml
+PUT /com/example/foo/maven-metadata.xml.sha1
+```
+
+Each PUT lands as one `AddFile` call against the `com/example/foo` OCI
+repo. The first one (jar, say) walks the same five steps as the python
+sdist above: probe, push blob, ensure `1.0.0` version manifest, push
+file manifest with `subject = versionDesc`, tag with deterministic
+`_f_*` tag.
+
+The other 13 PUTs short-circuit at step 3 — the version manifest
+already exists — and each one writes its own independent file
+manifest. **None of them rewrite the version manifest, the jar
+manifest, or each other.**
+
+Parallel reactor mode (`mvn deploy -T 4`) interleaves PUTs across
+modules. Because every file manifest is independent, there's no shared
+mutable state to race on. Two workers PUTting two different files
+under the same version manifest both succeed; two workers PUTting the
+same file race on the deterministic `_f_*` tag, and last-writer-wins
+on the tag, with the loser's file manifest left as an unreferenced
+manifest the backend's GC eventually reaps.
+
+The artifact-level `maven-metadata.xml` (the file at
+`com/example/foo/maven-metadata.xml`) lands as a file in a separate
+"metadata" tag — see [`docs/repos/maven.md`](../repos/maven.md) for
+the URL-to-tag mapping.
+
+## Read path
+
+`Registry.ReadFile` resolves a file in **two backend round-trips on
+the hot path**, regardless of how many files exist under the version:
+
+1. **Resolve** `_f_<sha256(canonicalTag\0filename)>` directly. The
+   helper is `fileTagFor` in [`pkg/oci/filetag.go`](../../pkg/oci/filetag.go);
+   it produces the same tag the write path attached. The Resolve
+   returns the file manifest descriptor.
+2. **Fetch the file manifest body**, read its single layer descriptor,
+   and stream the blob.
+
+The naive referrers walk — Resolve version → Referrers list → match
+filename → Fetch file manifest descriptor → Fetch blob — is four
+serial round-trips. At a typical 30ms backend RTT that's ~60ms saved
+per file, which compounds into seconds across a cold
+`mvn dependency:resolve` or `npm install`.
+
+The alias path adds one round-trip on top: `Resolve(refTag)` followed
+by a fetch of the alias manifest body to read
+`ocifactory.alias.target` and recover the canonical version string,
+which is then fed into `fileTagFor` exactly as above. The alias path
+still skips the Referrers list.
+
+## Why not a fat version manifest?
+
+Earlier iterations of the storage layout used a single fat version
+manifest per `(OwningRepo, OwningTag)` whose layers were the files. It
+was switched out for the OCI 1.1 referrers layout for one concrete
+reason: **per-file PUTs from real client tools force a read-modify-write
+cycle on every file, and the OCI distribution spec has no compare-and-set
+primitive on manifest writes.**
+
+A fat-manifest write looks like:
+
+1. GET the current version manifest.
+2. Append the new layer descriptor.
+3. PUT the new manifest.
+4. Re-tag.
+
+Two writers running steps 1–4 concurrently against the same version
+both read the same manifest in step 1, both compute different
+"correct" successor manifests in step 2, both PUT in step 3, and the
+later writer's PUT overwrites the earlier one's tag — silently losing
+the earlier writer's file. Per-file delete and per-file overwrite have
+the same RMW shape and the same race.
+
+The two real-world client behaviours that hit this:
+
+- **Twine.** Each wheel / sdist is a separate POST. A release with one
+  sdist plus three platform wheels is four independent HTTP requests,
+  arriving in arbitrary order, possibly from parallel CI workers.
+- **`mvn deploy`.** Roughly a dozen PUTs per release (artifact + POM +
+  sources + javadoc, each with two or three checksum companions, plus
+  `maven-metadata.xml`). Reactor mode (`mvn deploy -T <n>`) interleaves
+  PUTs from multiple modules concurrently.
+
+The OCI 1.1 referrers layout sidesteps the race entirely: each file
+gets its own immutable manifest with `subject = versionDesc`. Concurrent
+writers race only on the version-manifest creation, which is
+content-addressable and idempotent.
+
+A second motivation: the referrers layout matches how cosign / SBOM /
+attestation tooling already attaches signatures to artifacts. Each
+file manifest has its own digest you can sign independently. A future
+"sign every wheel on publish" feature drops in without any storage-side
+plumbing.
+
+The deterministic `_f_*` file tag exists so the read path stays cheap
+despite the extra indirection — same RTT count as the old fat-manifest
+shape would have given on the hot path.

--- a/docs/repos/maven.md
+++ b/docs/repos/maven.md
@@ -1,10 +1,17 @@
 # Maven
 
 ocifactory speaks the [Maven 2 repository layout](https://maven.apache.org/repository/layout.html)
-that `mvn`, `gradle`, `sbt`, and friends already know. Each
-`(groupId, artifactId, version)` becomes one OCI manifest, and the files
-inside that version (jar, pom, sources, javadoc, checksum companions)
-become its layers.
+that `mvn`, `gradle`, `sbt`, and friends already know. Each uploaded
+file (jar, pom, sources, javadoc, checksum companion, `maven-metadata.xml`)
+becomes its own file manifest attached via `subject` to a per-version
+anchor manifest, so the dozen-plus PUTs `mvn deploy` fires for one
+release land independently and never read-modify-write each other.
+
+> **How it's stored on OCI:** see
+> [`docs/architecture/storage-model.md`](../architecture/storage-model.md).
+> That doc walks `mvn deploy` step-by-step through the manifests and
+> tags ocifactory writes for one release, including why the layout is
+> race-free under `mvn deploy -T <n>`.
 
 ## 🚨 Operator requirement: `--allow-overwrite=true`
 
@@ -162,10 +169,14 @@ go test -tags=integration ./pkg/handler/maven/...
 
 ## OCI storage layout
 
-ocifactory writes one OCI manifest per `(repo, tag)` tuple, with the
-uploaded files as layers. The mapping from Maven URL to OCI tuple:
+Each `(OCI repo, canonical tag)` tuple holds one version anchor
+manifest tagged with the canonical tag, plus one file manifest per
+uploaded file (subject-linked to the anchor, addressable via the
+OCI 1.1 referrers API, and individually tagged with a deterministic
+`_f_<sha256>` for fast reads). The mapping from Maven URL to the tuple
+the file lands under:
 
-| Maven URL | OCI repo | OCI tag | Layer name |
+| Maven URL | OCI repo | Canonical tag | File name on the file manifest |
 |---|---|---|---|
 | `/{groupId}/{artifactId}/{version}/{filename}` | `{groupId}/{artifactId}` | `{version}` | `{filename}` |
 | `/{groupId}/{artifactId}/{version}-SNAPSHOT/maven-metadata.xml` | `{groupId}/{artifactId}` | `{version}-SNAPSHOT-metadata` | `maven-metadata.xml` |
@@ -174,9 +185,15 @@ uploaded files as layers. The mapping from Maven URL to OCI tuple:
 
 `{groupId}` keeps its slash form (`com/example/foo`), matching the URL.
 
-The OCI manifest `artifactType` is `application/vnd.ocifactory.maven`
-so a backend with multiple ocifactory tenants (or formats) can tell
-them apart.
+The base `artifactType` is `application/vnd.ocifactory.maven` and
+ocifactory appends `.version`, `.file`, and `.alias` suffixes to
+distinguish the three manifest kinds — operators inspecting the
+registry see e.g. `application/vnd.ocifactory.maven.file` on the JAR.
+
+For the manifest graph and a worked example walking `mvn deploy`'s
+~12 PUTs through to the per-file `AddFile` calls (and why parallel
+reactor mode `-T <n>` doesn't lose files), see
+[`docs/architecture/storage-model.md`](../architecture/storage-model.md).
 
 ## Checksum verification
 

--- a/docs/repos/npm.md
+++ b/docs/repos/npm.md
@@ -2,9 +2,17 @@
 
 ocifactory speaks the [npm registry HTTP protocol](https://github.com/npm/registry/blob/main/docs/REGISTRY-API.md)
 that `npm`, `yarn`, and `pnpm` already know. Storage is your OCI
-registry — one OCI manifest per `(package, version)` carrying the
-tarball and the version metadata as layers, plus a parallel `index`
-repo whose tags enumerate the packages you've published.
+registry — every published `(package, version)` writes a per-version
+anchor manifest plus two file manifests (the tarball and
+`package.json` metadata blob) attached via `subject`, with dist-tags
+landing as alias manifests on the same OCI repo. A parallel `index`
+repo's tags enumerate the packages you've published.
+
+> **How it's stored on OCI:** see
+> [`docs/architecture/storage-model.md`](../architecture/storage-model.md).
+> That doc walks the manifest graph (version anchor / file manifests /
+> alias manifests) end-to-end; the worked examples are for python and
+> maven, but npm uses the exact same shape.
 
 ## Quickstart
 
@@ -100,18 +108,29 @@ go test -tags=integration ./pkg/handler/npm/...
 
 Two OCI repositories per namespace under `--backend-registry`:
 
-| OCI repo | Tag | Layers |
+| OCI repo | Canonical tags | What's stored |
 |---|---|---|
-| `packages/u/<name>` | `<version>` | `<name>-<version>.tgz` (the tarball) and `package.json` (the version metadata). Used for unscoped packages. |
-| `packages/s/<scope>/<name>` | `<version>` | Same two layers; used for scoped (`@scope/name`) packages. |
-| `index` | `<encoded-name>` | A single sentinel layer (`name=present`, body=`"1"`). `ListTags("index")` is the package list. |
+| `packages/u/<name>` | `<version>` per release | A version anchor manifest tagged with `<version>`, plus two file manifests (tarball `<name>-<version>.tgz` and `package.json`) subject-linked to the anchor and addressable via the OCI 1.1 referrers API. Used for unscoped packages. |
+| `packages/s/<scope>/<name>` | `<version>` per release | Same shape; used for scoped (`@scope/name`) packages. |
+| `index` | `<encoded-name>` per package | A single sentinel layer (`name=present`, body=`"1"`). `ListTags("index")` is the package list. |
 
-Dist-tag aliases land as OCI alias tags on the same `packages/...`
-repo: `npm dist-tag add foo@1.0.0 latest` creates a `latest` alias
-pointing at the `1.0.0` version manifest, exactly the same shape
-python's `latest`/`stable` aliases use.
+Each file manifest also carries a deterministic `_f_<sha256>` tag so
+tarball downloads resolve in one round-trip.
 
-`artifactType` = `application/vnd.ocifactory.npm`.
+Dist-tag aliases land as alias manifests on the same `packages/...`
+repo, tagged with the dist-tag name: `npm dist-tag add foo@1.0.0 latest`
+creates a `latest` alias subject-linked to the `1.0.0` version anchor,
+with `ocifactory.alias.target = "1.0.0"` recorded as an annotation —
+exactly the same shape python's `latest`/`stable` aliases use.
+
+The base `artifactType` is `application/vnd.ocifactory.npm` and
+ocifactory appends `.version`, `.file`, and `.alias` suffixes to
+distinguish the three manifest kinds — operators inspecting the
+registry see e.g. `application/vnd.ocifactory.npm.alias` on the
+`latest` dist-tag.
+
+For the full manifest graph and worked examples, see
+[`docs/architecture/storage-model.md`](../architecture/storage-model.md).
 
 ### Name encoding
 

--- a/docs/repos/python.md
+++ b/docs/repos/python.md
@@ -2,9 +2,15 @@
 
 ocifactory speaks the [PEP 503](https://peps.python.org/pep-0503/) /
 [PEP 691](https://peps.python.org/pep-0691/) "simple repository" protocol
-clients like `pip` and `twine` already know. Storage is your OCI registry —
-one OCI manifest per `(package, version)` and a parallel `index` repo whose
-tags enumerate the packages you've published.
+clients like `pip` and `twine` already know. Storage is your OCI
+registry — every uploaded wheel / sdist becomes its own file manifest
+attached via `subject` to a per-version anchor manifest, with a parallel
+`index` repo whose tags enumerate the packages you've published.
+
+> **How it's stored on OCI:** see
+> [`docs/architecture/storage-model.md`](../architecture/storage-model.md).
+> That doc walks `twine upload dist/*` step-by-step through the
+> manifests and tags ocifactory writes for one release.
 
 ## Quickstart
 
@@ -83,14 +89,22 @@ go test -tags=integration ./pkg/handler/python/...
 
 Two OCI repositories under `--backend-registry`:
 
-| OCI repo | Tag | Layers |
+| OCI repo | Canonical tags | What's stored |
 |---|---|---|
-| `packages/<pkg>` | `<version>` | The wheel / sdist files uploaded for that version (one layer per file). |
-| `index` | `<pkg>` | A single sentinel layer (`name=present`, body=`"1"`). The body is unused; `ListTags("index")` is the package list. |
+| `packages/<pkg>` | `<version>` per release | A version anchor manifest tagged with `<version>`, plus one file manifest per uploaded wheel / sdist (subject-linked to the version anchor and addressable via the OCI 1.1 referrers API). Each file manifest also carries a deterministic `_f_<sha256>` tag so reads resolve in one round-trip. |
+| `index` | `<pkg>` per package | A single sentinel layer (`name=present`, body=`"1"`). The body is unused; `ListTags("index")` is the package list. |
 
-`<pkg>` is always the PEP 503 normalised name. The OCI manifest
-`artifactType` is `application/vnd.ocifactory.python` so a backend with
-multiple ocifactory tenants (or formats) can tell them apart at a glance.
+`<pkg>` is always the PEP 503 normalised name. The base
+`artifactType` is `application/vnd.ocifactory.python` and ocifactory
+appends `.version`, `.file`, and `.alias` suffixes to distinguish the
+three manifest kinds — operators inspecting the registry see e.g.
+`application/vnd.ocifactory.python.file` and can tell at a glance.
+
+For the manifest graph (version anchor / file manifests / alias
+manifests), the read path that turns a file lookup into a single tag
+resolve, and a worked example tracing `twine upload dist/*` through to
+the per-file `AddFile` calls it produces, see
+[`docs/architecture/storage-model.md`](../architecture/storage-model.md).
 
 The `index` repo write is one sentinel **per package**, not per version.
 The first upload of a given package writes the sentinel; later uploads


### PR DESCRIPTION
AGENTS.md still described the legacy fat-version-manifest shape ("one
OCI manifest per OwningTag; layers are the files in that version"),
which hasn't matched the code since the switch to the OCI 1.1
referrers layout. New contributors reading it to orient themselves
were getting the wrong picture.

This adds docs/architecture/storage-model.md as the canonical
reference for the on-OCI shape — version anchors, file manifests,
alias manifests, the deterministic _f_* file tag, the annotations and
artifactType suffixes ocifactory writes, and worked examples for both
twine upload and mvn deploy showing why the layout is race-free under
per-file PUTs from parallel CI workers.

AGENTS.md's Architecture section now points at the new doc and the
Key types paragraph correctly describes the three manifest kinds.
The python / maven / npm operator docs each get a "How it's stored"
pointer near the top and have their OCI storage layout tables
updated to match reality. README's architecture section gets the
same pointer.

Closes #100