### PR TITLE
Always allow overwrite on Maven snapshot versions

### DIFF
--- a/docs/repos/maven.md
+++ b/docs/repos/maven.md
@@ -6,46 +6,49 @@ that `mvn`, `gradle`, `sbt`, and friends already know. Each
 inside that version (jar, pom, sources, javadoc, checksum companions)
 become its layers.
 
-## 🚨 Operator requirement: `--allow-overwrite=true`
+## Snapshots vs releases: overwrite semantics
 
-**You must run `--allow-overwrite=true` for any production Maven
-deployment.** The default `--allow-overwrite=false` rejects every
-re-upload with `409 Conflict`, which sounds reasonable but breaks
-`mvn deploy` on the second invocation of *any* artifact:
+ocifactory matches Maven's own immutability rules:
 
-`mvn` rewrites the artifact-level `maven-metadata.xml` (the file at
-`<groupId>/<artifactId>/maven-metadata.xml` that lists known versions)
-on every deploy as part of the standard release/snapshot workflow.
-With overwrite disabled the second push of that file 409s and the
-deploy fails. The same is true for the version-level metadata of
-snapshots.
+- **Snapshot versions** (any version ending in `-SNAPSHOT`,
+  case-insensitive) are **always overwritable**, regardless of the
+  registry's `--allow-overwrite` flag. The second `mvn deploy` of a
+  `1.0-SNAPSHOT` succeeds against the default
+  `--allow-overwrite=false`. This covers both the artifact files
+  themselves (jars, poms, sources, javadoc, checksums) and the
+  per-version `maven-metadata.xml` that tracks the latest timestamped
+  build under a unique-snapshot setup.
+- **Release versions** are **immutable by default**. A second deploy
+  of `1.0` returns `409 Conflict` unless you started ocifactory with
+  `--allow-overwrite=true`. Pass `--allow-overwrite=true` when you
+  need lax behaviour for releases too (e.g. fix-the-CI-job retries,
+  ephemeral staging) and add a CI gate of your own if you also want
+  immutable fixed-version releases.
 
-Concretely, run:
+The artifact-level `maven-metadata.xml`
+(`<groupId>/<artifactId>/maven-metadata.xml`) follows the same
+release-immutability rule. With the default `--allow-overwrite=false`
+the second rewrite of the artifact-level metadata 409s — workflows
+that rewrite it on every deploy (some `mvn deploy:deploy-file`
+invocations, custom uploaders) need `--allow-overwrite=true`.
+Snapshot CI workflows are unaffected because everything under a
+`-SNAPSHOT` version is always overwritable.
+
+A typical Maven server config:
 
 ```bash
 ocifactory serve \
   --repo-type=maven \
   --backend-registry=zot.local:5000/ocifactory \
-  --allow-overwrite=true \
   --authn-kind=oidc \
   --authn-oidc-issuers=https://accounts.google.com \
   --authn-oidc-audience=https://ocifactory.your-domain \
   --port=8080
 ```
 
-This loosens immutability for **every** Maven file type, not just
-metadata — operators who require immutable releases (production
-binaries that should never be silently re-published) should add a CI
-gate that refuses re-deploys of fixed-version artifacts. A future
-code-side fix that special-cases `maven-metadata.xml` for overwrite
-without affecting other files is tracked separately; until that lands,
-`--allow-overwrite=true` is the only way to run a working Maven
-ocifactory.
-
 ## Quickstart
 
-After starting the server with `--allow-overwrite=true` (above),
-configure `~/.m2/settings.xml`:
+After starting the server (above), configure `~/.m2/settings.xml`:
 
 ```xml
 <settings>
@@ -103,8 +106,8 @@ for resolve.
 |---|---|
 | `/{groupId}/{artifactId}/{version}/{filename}` | Regular artifact (jar, pom, sources, javadoc). |
 | `/{groupId}/{artifactId}/{version}/{filename}.{sha1,md5,sha256,sha512}` | Checksum companion. **Must arrive after the artifact it covers.** |
-| `/{groupId}/{artifactId}/{version}-SNAPSHOT/maven-metadata.xml` | Version-level snapshot metadata. |
-| `/{groupId}/{artifactId}/maven-metadata.xml` | Artifact-level metadata (mvn rewrites this on every deploy — see overwrite warning above). |
+| `/{groupId}/{artifactId}/{version}-SNAPSHOT/maven-metadata.xml` | Version-level snapshot metadata. Always overwritable (snapshot-mutable). |
+| `/{groupId}/{artifactId}/maven-metadata.xml` | Artifact-level metadata. Follows release-immutability semantics — see the [Snapshots vs releases](#snapshots-vs-releases-overwrite-semantics) section above. |
 | `/archetype-catalog.xml` | Global archetype catalog. |
 
 `{groupId}` is the dotted Java group with `.` rewritten to `/`
@@ -228,7 +231,7 @@ artifact. Tracked by [#49](https://github.com/yolocs/ocifactory/issues/49).
 
 | Flag | Default | Purpose |
 |---|---|---|
-| `--allow-overwrite` | `false` | **REQUIRED to set to `true` for any working Maven deployment** — see the warning at the top. |
+| `--allow-overwrite` | `false` | Whether to allow re-uploading release-version files. Snapshot versions (`-SNAPSHOT`) are *always* overwritable regardless of this flag — see [Snapshots vs releases](#snapshots-vs-releases-overwrite-semantics). Flip to `true` if your workflow also re-publishes the artifact-level `maven-metadata.xml` on every deploy. |
 | `--maven-max-upload-bytes` | `1073741824` (1 GiB) | Caps the total request body the upload endpoint accepts. Defends against an authenticated client streaming arbitrary bytes to burn instance hours / egress before the OCI backend rejects the layer. Set to `0` to disable; tighten for cost-sensitive deployments. Oversize requests are rejected with `413 Payload Too Large` before they touch the OCI backend. |
 | `--disable-streaming-push` | `false` | Force buffered+monolithic uploads through the OCI backend instead of chunked PATCH. Set only if your backend has broken chunked-PATCH support. |
 | `--disable-blob-redirect` | `false` | Disable `307` redirects to backend-issued presigned URLs on blob downloads. Set when exposing backend URLs to clients is unacceptable (egress restrictions, DLP, audit). |
@@ -257,7 +260,11 @@ are documented in [`docs/auth.md`](../auth.md) and
   no "stage to a sandbox repo, then promote to releases" feature.
 - **No pull-through caching of Maven Central.** Tracked under Phase 4
   of [`docs/ROADMAP.md`](../ROADMAP.md).
-- **`--allow-overwrite=true` loosens immutability for every file type.**
-  Operators who want immutable release jars should add a CI gate that
-  refuses re-deploys of fixed-version artifacts; ocifactory itself
-  does not distinguish "metadata" from "jar" once overwrite is on.
+- **`--allow-overwrite=true` loosens immutability for every release
+  file type.** Snapshot versions are always overwritable by design,
+  independent of the flag. Operators who want immutable release jars
+  but also need to re-publish the artifact-level `maven-metadata.xml`
+  should leave the flag at its default (`false`) and use a Maven
+  workflow that publishes only snapshots, or accept that toggling the
+  flag will let release artifacts be overwritten too and add a CI
+  gate that refuses re-deploys of fixed-version artifacts.

--- a/pkg/handler/maven/handler.go
+++ b/pkg/handler/maven/handler.go
@@ -181,6 +181,11 @@ func (h *Handler) handleSnapshotMetadata(w http.ResponseWriter, req *http.Reques
 		OwningTag:  versionSnapshot + "-metadata", // e.g., 1.0-SNAPSHOT-metadata
 		Name:       "maven-metadata.xml",
 		MediaType:  "text/xml",
+		// Per-version snapshot metadata is rewritten on every deploy
+		// (unique snapshots track the latest timestamped build).
+		// Always allow overwrite here so the second `mvn deploy` of a
+		// snapshot doesn't 409 on the metadata write.
+		AllowOverwrite: true,
 	}
 	if req.Method == http.MethodPut || req.Method == http.MethodPost {
 		h.handlePut(w, req, scoped, f)
@@ -231,6 +236,13 @@ func (h *Handler) handleRegularArtifact(w http.ResponseWriter, req *http.Request
 		OwningTag:  version,
 		Name:       filename,
 		MediaType:  detectMediaType(filename),
+		// Maven snapshot versions are mutable by design: non-unique
+		// snapshots overwrite the same artifact path on every deploy,
+		// and unique snapshots leave behind a per-version
+		// maven-metadata.xml that the snapshot-metadata route also
+		// rewrites. Release versions stay immutable and respect the
+		// registry-level --allow-overwrite default.
+		AllowOverwrite: isSnapshotVersion(version),
 	}
 	if req.Method == http.MethodPut || req.Method == http.MethodPost {
 		h.handlePut(w, req, scoped, f)

--- a/pkg/handler/maven/handler_test.go
+++ b/pkg/handler/maven/handler_test.go
@@ -536,6 +536,82 @@ func TestHandlePut_DefaultMaxUploadBytes(t *testing.T) {
 	}
 }
 
+// TestHandlePut_SnapshotOverwrite locks the snapshot-vs-release
+// overwrite contract: snapshot versions and per-version snapshot
+// metadata are always overwritable regardless of the registry's
+// --allow-overwrite default, while release versions still 409 by
+// default. This is the load-bearing contract for `mvn deploy` of a
+// snapshot version twice in a row against ocifactory's default
+// strict-overwrite config.
+func TestHandlePut_SnapshotOverwrite(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		registryOverwrite bool
+		path              string
+		wantSecondStatus  int
+	}{
+		{
+			name:              "snapshot jar overwrites under strict registry",
+			registryOverwrite: false,
+			path:              nsPath("/com/example/project/1.0-SNAPSHOT/project-1.0-SNAPSHOT.jar"),
+			wantSecondStatus:  http.StatusCreated,
+		},
+		{
+			name:              "snapshot jar with lowercase suffix overwrites under strict registry",
+			registryOverwrite: false,
+			path:              nsPath("/com/example/project/1.0-snapshot/project-1.0-snapshot.jar"),
+			wantSecondStatus:  http.StatusCreated,
+		},
+		{
+			name:              "release jar 409s under strict registry",
+			registryOverwrite: false,
+			path:              nsPath("/com/example/project/1.0/project-1.0.jar"),
+			wantSecondStatus:  http.StatusConflict,
+		},
+		{
+			name:              "release jar overwrites under permissive registry",
+			registryOverwrite: true,
+			path:              nsPath("/com/example/project/1.0/project-1.0.jar"),
+			wantSecondStatus:  http.StatusCreated,
+		},
+		{
+			name:              "per-version snapshot metadata overwrites under strict registry",
+			registryOverwrite: false,
+			path:              nsPath("/com/example/project/1.0-SNAPSHOT/maven-metadata.xml"),
+			wantSecondStatus:  http.StatusCreated,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			reg := oci.NewFakeRegistry()
+			reg.AllowOverwrite = tc.registryOverwrite
+			h, _ := newTestHandler(t, reg)
+			m := h.Mux()
+
+			send := func(body string) *httptest.ResponseRecorder {
+				req := httptest.NewRequest(http.MethodPut, tc.path, strings.NewReader(body))
+				rec := httptest.NewRecorder()
+				m.ServeHTTP(rec, req)
+				return rec
+			}
+
+			if rec := send("first"); rec.Code != http.StatusCreated {
+				t.Fatalf("first PUT status=%d, want 201 (body=%s)", rec.Code, rec.Body.String())
+			}
+
+			rec := send("second")
+			if got, want := rec.Code, tc.wantSecondStatus; got != want {
+				t.Fatalf("second PUT status=%d, want %d (body=%s)", got, want, rec.Body.String())
+			}
+		})
+	}
+}
+
 // TestHandlePut_ReuploadConflict locks the wire-level shape of the
 // re-upload contract for Maven uploads.
 func TestHandlePut_ReuploadConflict(t *testing.T) {

--- a/pkg/handler/maven/paths.go
+++ b/pkg/handler/maven/paths.go
@@ -5,6 +5,26 @@ import (
 	"strings"
 )
 
+// snapshotSuffix is Maven's case-insensitive sentinel that marks a
+// mutable version. We compare against the lower-case form because
+// `strings.EqualFold` allocates and Maven coordinates are ASCII.
+const snapshotSuffix = "-snapshot"
+
+// isSnapshotVersion reports whether version is a Maven snapshot
+// version. Maven's spec is unambiguous: a version is a snapshot iff it
+// ends with `-SNAPSHOT` (case-insensitive). Snapshot versions are
+// mutable by design — every `mvn deploy` either rewrites bytes (non-
+// unique snapshots) or updates the per-version maven-metadata.xml
+// (unique snapshots, Maven 3+ default) — so the handler opts into
+// per-call AllowOverwrite for them regardless of the registry's
+// default.
+func isSnapshotVersion(version string) bool {
+	if len(version) < len(snapshotSuffix) {
+		return false
+	}
+	return strings.EqualFold(version[len(version)-len(snapshotSuffix):], snapshotSuffix)
+}
+
 // validatePath rejects path components that contain traversal segments
 // (".", ".."), empty segments, or characters outside the conservative
 // Maven coordinate grammar [A-Za-z0-9._-] (with "/" only allowed inside

--- a/pkg/handler/maven/paths_test.go
+++ b/pkg/handler/maven/paths_test.go
@@ -153,3 +153,33 @@ func TestValidatePath(t *testing.T) {
 		})
 	}
 }
+
+func TestIsSnapshotVersion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		{name: "canonical snapshot", version: "1.0-SNAPSHOT", want: true},
+		{name: "lowercase snapshot", version: "1.0-snapshot", want: true},
+		{name: "mixed case snapshot", version: "1.0-SnApShOt", want: true},
+		{name: "multi segment snapshot", version: "1.0.0-RC1-SNAPSHOT", want: true},
+		{name: "release version", version: "1.0.0", want: false},
+		{name: "release with -RC1 qualifier", version: "1.0.0-RC1", want: false},
+		{name: "release with embedded SNAPSHOT not at end", version: "1.0-SNAPSHOT-final", want: false},
+		{name: "empty string", version: "", want: false},
+		{name: "shorter than suffix", version: "1.0", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isSnapshotVersion(tc.version); got != tc.want {
+				t.Errorf("isSnapshotVersion(%q) = %v, want %v", tc.version, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/oci/fake.go
+++ b/pkg/oci/fake.go
@@ -43,9 +43,12 @@ type FakeRegistry struct {
 	// AllowOverwrite mirrors WithAllowOverwrite on the real Registry.
 	// When false (the default), AddFile returns ErrAlreadyExists for a
 	// re-upload of an existing (OwningRepo, OwningTag, Name); when
-	// true the existing entry is replaced. Tests that exercise the
-	// 409-on-re-upload branch leave it false; tests for overwrite
-	// flip it on per-test.
+	// true the existing entry is replaced. A per-call
+	// RepoFile.AllowOverwrite=true forces the same loosening for a
+	// single call even when this is false — matches the real Registry
+	// "force on, not force off" semantics. Tests that exercise the
+	// 409-on-re-upload branch leave both off; tests for overwrite flip
+	// either on per-test.
 	AllowOverwrite bool
 }
 
@@ -88,7 +91,7 @@ func (r *FakeRegistry) AddFile(ctx context.Context, f *RepoFile, ro io.Reader) (
 		r.mu.Unlock()
 		return nil, fmt.Errorf("%w: tag %q in repo %q is an alias", ErrAliasCollision, f.OwningTag, f.OwningRepo)
 	}
-	if _, exists := r.Files[key]; exists && !r.AllowOverwrite {
+	if _, exists := r.Files[key]; exists && !r.AllowOverwrite && !f.AllowOverwrite {
 		r.mu.Unlock()
 		return nil, fmt.Errorf("%w: %s", ErrAlreadyExists, key)
 	}

--- a/pkg/oci/registry.go
+++ b/pkg/oci/registry.go
@@ -293,6 +293,18 @@ type RepoFile struct {
 	// "unknown" sentinel of -1) means unknown and AddFile falls back to
 	// peeking up to uploadMemThreshold+1 bytes.
 	Size int64
+
+	// AllowOverwrite, when true, forces this single AddFile call to
+	// behave as if the registry was constructed with
+	// WithAllowOverwrite(true). The semantics are "force on, not force
+	// off": the effective policy is registry.allowOverwrite ||
+	// RepoFile.AllowOverwrite, so a per-call true cannot tighten a
+	// permissive registry, only loosen a strict one. Handlers that
+	// need format-specific overwrite (e.g. Maven snapshot versions)
+	// set this on the snapshot path and leave it false everywhere
+	// else, so release immutability stays intact under the registry's
+	// default.
+	AllowOverwrite bool
 }
 
 // FileDescriptor identifies a file within the OCI-backed registry. Manifest
@@ -420,13 +432,15 @@ func NewRegistry(baseURL *url.URL, opt ...RegistryOption) (*Registry, error) {
 //     (artifactType ≠ versionArtifactType), AddFile returns
 //     ErrAliasCollision rather than silently overwriting the alias.
 //   - If a file with the same (OwningRepo, OwningTag, Name) already
-//     exists and the registry was constructed without
-//     WithAllowOverwrite(true), AddFile returns ErrAlreadyExists
-//     before the body is read so a rejected re-upload doesn't pay for
-//     a wasted upload. With WithAllowOverwrite(true), the previous
-//     file manifest is unlinked from the version's referrer set after
-//     the new one is pushed; readers only ever see one match per
-//     filename, even across overwrites.
+//     exists and neither the registry was constructed with
+//     WithAllowOverwrite(true) nor RepoFile.AllowOverwrite is set,
+//     AddFile returns ErrAlreadyExists before the body is read so a
+//     rejected re-upload doesn't pay for a wasted upload. When either
+//     the registry-level or per-call flag is on, the previous file
+//     manifest is unlinked from the version's referrer set after the
+//     new one is pushed; readers only ever see one match per
+//     filename, even across overwrites. The per-call flag only
+//     loosens — it cannot tighten an already-permissive registry.
 func (r *Registry) AddFile(ctx context.Context, f *RepoFile, ro io.Reader) (*FileDescriptor, error) {
 	if f.OwningTag == "" {
 		return nil, fmt.Errorf("OwningTag must be set")
@@ -521,11 +535,12 @@ func (r *Registry) probeExistingFile(ctx context.Context, f *RepoFile) (*ocispec
 	if err != nil {
 		return nil, fmt.Errorf("failed to list file referrers for %q: %w", f.OwningTag, err)
 	}
+	allowOverwrite := r.allowOverwrite || f.AllowOverwrite
 	for i := range refs {
 		if refs[i].Annotations[FileNameAnnotation] != f.Name {
 			continue
 		}
-		if !r.allowOverwrite {
+		if !allowOverwrite {
 			return nil, fmt.Errorf("%w: %s/%s/%s", ErrAlreadyExists, f.OwningRepo, f.OwningTag, f.Name)
 		}
 		return &refs[i], nil

--- a/pkg/oci/registry_test.go
+++ b/pkg/oci/registry_test.go
@@ -1281,6 +1281,110 @@ func TestAddFile_ReuploadAllowedWithOverwrite(t *testing.T) {
 	}
 }
 
+// TestAddFile_ReuploadPerCallOverwrite locks the per-call
+// RepoFile.AllowOverwrite contract: a true on the RepoFile loosens a
+// strict-default registry for that one call, a false on the RepoFile
+// cannot tighten a permissive registry, and the strict-default both-
+// false case still 409s. This is the load-bearing knob Maven uses to
+// flip overwrite on for snapshot versions while leaving release
+// immutability intact.
+func TestAddFile_ReuploadPerCallOverwrite(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	tests := []struct {
+		name              string
+		registryOverwrite bool
+		repoFileOverwrite bool
+		wantSecondErr     error
+	}{
+		{
+			name:              "strict registry, per-call true overwrites",
+			registryOverwrite: false,
+			repoFileOverwrite: true,
+			wantSecondErr:     nil,
+		},
+		{
+			name:              "strict registry, per-call false still 409s",
+			registryOverwrite: false,
+			repoFileOverwrite: false,
+			wantSecondErr:     ErrAlreadyExists,
+		},
+		{
+			name:              "permissive registry, per-call false still overwrites",
+			registryOverwrite: true,
+			repoFileOverwrite: false,
+			wantSecondErr:     nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var opts []RegistryOption
+			if tc.registryOverwrite {
+				opts = append(opts, WithAllowOverwrite(true))
+			}
+			r, err := NewRegistry(&url.URL{Scheme: "https", Host: "example.com"}, opts...)
+			if err != nil {
+				t.Fatalf("NewRegistry() error = %v", err)
+			}
+			memRepo := &inMemoryRepo{Store: memory.New(), allTags: map[string]string{}}
+			r.newBackendFunc = func(_ context.Context, _ *RepoFile) (destRepo, error) {
+				return memRepo, nil
+			}
+
+			f := &RepoFile{
+				OwningRepo:     "pkg",
+				OwningTag:      "1.0-SNAPSHOT",
+				Name:           "a.txt",
+				AllowOverwrite: tc.repoFileOverwrite,
+			}
+			if _, err := r.AddFile(ctx, f, strings.NewReader("first")); err != nil {
+				t.Fatalf("AddFile() first call error = %v", err)
+			}
+
+			second, err := r.AddFile(ctx, f, strings.NewReader("second"))
+			if tc.wantSecondErr != nil {
+				if !errors.Is(err, tc.wantSecondErr) {
+					t.Fatalf("AddFile() second call error = %v, want errors.Is %v", err, tc.wantSecondErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("AddFile() second call error = %v, want nil", err)
+			}
+
+			files, err := r.ListFiles(ctx, "pkg")
+			if err != nil {
+				t.Fatalf("ListFiles() error = %v", err)
+			}
+			if got, want := len(files), 1; got != want {
+				t.Fatalf("ListFiles() = %d files, want %d (got: %+v)", got, want, files)
+			}
+
+			_, body, err := r.ReadFile(ctx, f)
+			if err != nil {
+				t.Fatalf("ReadFile() error = %v", err)
+			}
+			got, _ := io.ReadAll(body)
+			body.Close()
+			if string(got) != "second" {
+				t.Errorf("ReadFile() after overwrite = %q, want %q", got, "second")
+			}
+
+			tag := fileTagFor(f.OwningTag, f.Name)
+			memRepo.mu.Lock()
+			pointsAt := memRepo.allTags[tag]
+			memRepo.mu.Unlock()
+			if pointsAt != second.Manifest.Digest.String() {
+				t.Errorf("deterministic tag %q points at %q, want new manifest digest %q", tag, pointsAt, second.Manifest.Digest)
+			}
+		})
+	}
+}
+
 // TestAddFile_ReuploadDistinctNamesNotAffected proves the existence
 // probe scopes its match by Name: a second AddFile with a different
 // filename under the same OwningTag is the normal multi-file case


### PR DESCRIPTION
Maven snapshot versions are mutable by design: non-unique snapshots
overwrite the same artifact path on every deploy, and the per-version
maven-metadata.xml under a unique-snapshot setup is rewritten to
track the latest timestamped build. Treating snapshot uploads under
ocifactory's default --allow-overwrite=false broke every Maven
snapshot CI workflow on the second deploy.

Add an AllowOverwrite field to oci.RepoFile so a single AddFile call
can force overwrite-on without loosening the registry-level default
for unrelated calls. The effective policy is registry.allowOverwrite
|| repoFile.AllowOverwrite — per-call true can loosen a strict
registry but a per-call false cannot tighten a permissive one. The
maven handler sets the flag on regular-artifact PUTs whose version
ends in -SNAPSHOT (case-insensitive) and unconditionally on
per-version snapshot maven-metadata.xml PUTs. Release versions and
the artifact-level maven-metadata.xml keep release-immutability
semantics under the registry default.

Closes #101