### PR TITLE
Refresh docs to match the shipped namespace + authz + release pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,58 +18,82 @@ Design pillars (in priority order):
 
 | Area | State |
 |---|---|
-| `pkg/oci` — OCI-backed registry primitives (Add/Read/List/Delete/AppendRefs) | Done, tested with in-memory fake |
-| `pkg/handler/python` — PEP 503 simple index, twine upload, pip download | Done, tested. Operator docs: [`docs/repos/python.md`](docs/repos/python.md). |
-| `pkg/handler/maven` — Maven 2 layout (releases, snapshots, metadata, archetype catalog) | Done, tested. Operator docs: [`docs/repos/maven.md`](docs/repos/maven.md). |
-| `pkg/handler/npm` — npm registry HTTP protocol (`npm publish`, `npm install`, `npm dist-tag add\|ls`) | Done, tested. Operator docs: [`docs/repos/npm.md`](docs/repos/npm.md). |
-| `pkg/handler` — `Server`, `PassThroughAuth`, `Logger`, `MetricsMiddleware` | Done |
+| `pkg/oci` — OCI-backed registry primitives (Add/Read/List/Delete/AppendRefs), streaming-push integration test against a real zot | Done, tested with in-memory fake + live-zot |
+| `pkg/oci` — deterministic `_f_<sha256>` file tags so file reads are one round-trip | Done |
+| `pkg/oci` — blob-download redirect to backend presigned URLs (GAR/ECR/ACR/GHCR/Docker Hub) | Done |
+| `pkg/handler/python` — PEP 503 simple index, twine upload, pip download, per-package simple-index cache | Done, tested (incl. real-client integration tests). Operator docs: [`docs/repos/python.md`](docs/repos/python.md). |
+| `pkg/handler/maven` — Maven 2 layout (releases, snapshots, metadata, archetype catalog), checksum verification, snapshot-always-overwrite | Done, tested (incl. real-client integration tests). Operator docs: [`docs/repos/maven.md`](docs/repos/maven.md). |
+| `pkg/handler/npm` — npm registry HTTP protocol (`npm publish`, `npm install`, `npm dist-tag add\|ls`), scoped + unscoped packages | Done, tested (incl. real-client integration tests). Operator docs: [`docs/repos/npm.md`](docs/repos/npm.md). |
+| `pkg/handler` — `Server`, `Logger`, `MetricsMiddleware`, `ObservabilityHandler` (intercepts `/healthz` / `/readyz` / `/metrics` before format mux) | Done |
 | `pkg/metrics` — pluggable Recorder (Prometheus default, no-op for tests) | Done |
-| `/healthz`, `/readyz`, `/metrics` endpoints (registered at server level) | Done |
 | `pkg/auth` — Pluggable frontend authentication (Authenticator, AuthContext, Chain, OIDC) | Done, tested. OIDC-only — static passwords are out-of-tree by design. Configured via `OCIFACTORY_AUTHN_*` flags / env vars. |
+| `pkg/auth` — Pluggable `Authorizer` interface with `OpRead` / `OpWrite` ops; `AllowAll` / `DenyAll` built-ins for tests / fallbacks | Done |
 | `pkg/auth/backend` — Pluggable backend credential `Provider` interface and in-tree adapters (`anonymous`, `gcpadc`, `staticenv`, `dockerconfig`) | Done, tested. Wired into `oci.Registry` via `WithBackendAuth`. Configured via `OCIFACTORY_BACKEND_AUTH_*` flags / env vars. |
-| `ocifactory admin serve` — control-plane namespace CRUD API | Done, tested. Operator docs: [`docs/admin.md`](docs/admin.md). |
+| `pkg/namespace` — Namespace data model, OCI-backed `Store`, JSON `Spec` with `SchemaVersion` | Done, tested. Operator docs: [`docs/admin.md`](docs/admin.md). |
+| `pkg/namespace` — Per-namespace `Policy` (readers/writers `SubjectMatcher`s on issuer / sub regex / email / claims), `PolicyAuthorizer`, data-plane `Registry` wrapper with policy cache + per-namespace package index | Done, tested. Authorizer is pluggable via `AuthzFactory`. |
+| `ocifactory admin serve` — control-plane namespace CRUD API (`PUT/GET/DELETE /admin/v1/namespaces/{name}`, list, soft-delete) | Done, tested. Operator docs: [`docs/admin.md`](docs/admin.md). |
 | `pkg/handler/echo` — No-op auth target for the GitHub OIDC CI job | Done. Not a real artifact format; no OCI backend, no `handler.Registry`. Exists to give CI a concrete request to make against a real OIDC issuer. |
-| `cmd/ocifactory serve` | Works for `--repo-type=python|maven|npm|echo` (echo runs without `--backend-registry`) |
+| `cmd/ocifactory serve` | Works for `--repo-type=python\|maven\|npm\|echo` (echo runs without `--backend-registry`). Every URL is namespace-prefixed: `/{namespace}/...` for python and npm; `/{namespace}/maven2/...` for maven. |
+| `cmd/ocifactory admin serve` | Works against any OCI backend; runs on a separate listener (`--port`, default `8081`). |
+| Dockerfile + multi-arch image publishing | Done. `Dockerfile.goreleaser` is distroless/nonroot; images at `ghcr.io/yolocs/ocifactory:vX.Y.Z` (+ `:vX.Y` / `:latest` for stable). Built via Goreleaser; release procedure in [`RELEASING.md`](RELEASING.md). |
+| Release pipeline | Done. Goreleaser builds binaries (linux/darwin × amd64/arm64), archives, sha256 sums, CycloneDX SBOMs (syft), cosign keyless signatures on every archive + image. |
+| `internal/version` — build-time version stamping via `-ldflags="-X .../internal/version.Version=..."`, fallbacks to `runtime/debug.ReadBuildInfo()` for dev builds | Done. `--version` surfaces it; `/readyz` includes it in the JSON body. |
 | Go module proxy support | Not started |
 | Debian/apt support | Not started |
 | Pull-through proxy / caching | Not started |
 | Vulnerability scanning | Not started |
-| Authorization (per-repo, per-op policy) | Not started |
-| Dockerfile / deployment | Not started |
-| CI: lint, test, build, image publish | `go-test` from `abcxyz/pkg`; `oidc-e2e` job mints a real GitHub OIDC token and exercises the auth chain against `--repo-type=echo`. |
+| Authorization extensibility — multiple backends (OPA / Cedar / Casbin) | Pluggable via `namespace.AuthzFactory`; only the matcher-based built-in ships in-tree. |
+| Cloud Run / Cloudflare deployment guides | Not started |
+| Structured request logging | Not started (debug-level request log via `pkg/handler.Loggeer` is present) |
+| Rate limiting | Not started |
+| CI: lint, test, build, image publish | `go-test` from `abcxyz/pkg`; `oidc-e2e` job mints a real GitHub OIDC token and exercises the auth chain against `--repo-type=echo`; `client-integration` job runs the `-tags=integration` real-client tests (`twine`, `mvn`, `npm`). Image publish runs on the release workflow, not per-PR. |
 
 ## Architecture (read this before changing things)
 
 ```
-                     ┌─────────────────────────────────────┐
-HTTP request ──►     │  cmd/ocifactory  (CLI entrypoint)    │
-                     └────────────┬────────────────────────┘
-                                  │
-                     ┌────────────▼────────────────────────┐
-                     │  pkg/handler                         │
-                     │  • Server (port + middleware chain)  │
-                     │  • Logger, MetricsMiddleware         │
-                     │  • auth.Middleware (pkg/auth)        │
-                     │  • /healthz, /readyz, /metrics       │
-                     └────────────┬────────────────────────┘
-                                  │ http.Handler
-                     ┌────────────▼────────────────────────┐
-                     │  pkg/handler/{python,maven,npm,...}  │
-                     │  Each speaks one client protocol     │
-                     │  (pip, mvn, npm, go mod, apt, ...)   │
-                     └────────────┬────────────────────────┘
-                                  │ Registry interface (handler.Registry)
-                     ┌────────────▼────────────────────────┐
-                     │  pkg/oci.Registry                    │
-                     │  AddFile / ReadFile / ListTags /     │
-                     │  ListFiles / DeleteRepoFiles /       │
-                     │  AppendRefs                          │
-                     └────────────┬────────────────────────┘
-                                  │ ORAS (oras-go/v2)
-                     ┌────────────▼────────────────────────┐
-                     │  Any OCI registry                    │
-                     │  (GAR, ECR, GHCR, Harbor, zot, ...)  │
-                     └─────────────────────────────────────┘
+                     ┌──────────────────────────────────────────┐
+HTTP request ──►     │  cmd/ocifactory  (CLI entrypoint)         │
+                     │  Subcommands: serve / admin serve         │
+                     └───────────────┬──────────────────────────┘
+                                     │
+                     ┌───────────────▼──────────────────────────┐
+                     │  pkg/handler                              │
+                     │  • Server (port + middleware chain)       │
+                     │  • Logger, MetricsMiddleware              │
+                     │  • ObservabilityHandler                   │
+                     │    (/healthz, /readyz, /metrics)          │
+                     └───────────────┬──────────────────────────┘
+                                     │ http.Handler
+                     ┌───────────────▼──────────────────────────┐
+                     │  pkg/handler/{python,maven,npm,...}       │
+                     │  Each speaks one client protocol          │
+                     │  (pip, mvn, npm, go mod, apt, ...)        │
+                     │  Routes mounted under /{namespace}/...    │
+                     │  auth.Middleware (pkg/auth) chained on    │
+                     │    the format's root or sub-router        │
+                     └───────────────┬──────────────────────────┘
+                                     │ handler.Registry interface
+                     ┌───────────────▼──────────────────────────┐
+                     │  pkg/namespace.ScopedRegistry             │
+                     │  • authorizes (read/write) against the    │
+                     │    namespace's compiled Policy            │
+                     │  • prefixes OwningRepo with <namespace>/  │
+                     │  • records writes into the per-namespace  │
+                     │    package index (ocifactory-packages)    │
+                     └───────────────┬──────────────────────────┘
+                                     │ handler.Registry interface
+                     ┌───────────────▼──────────────────────────┐
+                     │  pkg/oci.Registry                         │
+                     │  AddFile / ReadFile / ListTags /          │
+                     │  ListFiles / DeleteRepoFiles /            │
+                     │  DeleteTagFiles / AppendRefs /            │
+                     │  BlobRedirectURL / Ping                   │
+                     └───────────────┬──────────────────────────┘
+                                     │ ORAS (oras-go/v2)
+                     ┌───────────────▼──────────────────────────┐
+                     │  Any OCI registry                         │
+                     │  (GAR, ECR, GHCR, Harbor, zot, ...)       │
+                     └──────────────────────────────────────────┘
 ```
 
 The on-OCI shape `pkg/oci` writes — version anchors, file manifests,
@@ -80,28 +104,51 @@ Read that doc before touching the `pkg/oci` write paths.
 
 ### Key types
 
-- `oci.RepoFile{OwningRepo, OwningTag, RefTag, Name, MediaType, Digest}` — addresses one file inside the OCI-backed virtual store.
-  - `OwningRepo` is the OCI repository name (e.g. `packages/requests`, `com/foo/bar`).
+- `oci.RepoFile{OwningRepo, OwningTag, RefTag, Name, MediaType, Digest, Size, AllowOverwrite}` — addresses one file inside the OCI-backed virtual store.
+  - `OwningRepo` is the OCI repository name **relative to the namespace** at the handler boundary (e.g. `packages/requests`, `com/foo/bar`). The `namespace.ScopedRegistry` wrapper prefixes it with `<namespace>/` before forwarding to `pkg/oci`, so on the real backend the repo is `<namespace>/packages/requests`.
   - `OwningTag` is the canonical version tag (e.g. `2.31.0`). It identifies the **version manifest** — a constant-size anchor in the [OCI 1.1 referrers layout](docs/architecture/storage-model.md). Files for that version are *not* layers on this manifest; each file is its own **file manifest** with `subject = versionDesc`, addressed via the referrers API and tagged with a deterministic `_f_<sha256>` tag so reads resolve in one round-trip.
   - `RefTag` is an alias tag like `latest`. It identifies an **alias manifest** with `subject = versionDesc` and the canonical version recorded in the `ocifactory.alias.target` annotation.
+  - `AllowOverwrite` is a per-file flag handlers set when the file is intentionally mutable (Maven snapshot artifacts, snapshot `maven-metadata.xml`). It overrides the registry-level `--allow-overwrite` default for that one call.
   - The three manifest kinds are distinguished by `artifactType` suffix — `.version`, `.file`, `.alias` — appended to the operator-configured base type (e.g. `application/vnd.ocifactory.python.version`).
-- `handler.Registry` — the interface every per-format handler depends on. Keep it minimal; do not push format-specific concepts into it.
-- `cred.Cred` — credentials carried in the request `context.Context`. Today only `Basic`. When adding OAuth/OIDC/JWT, add a new field rather than overloading `Basic`.
+- `handler.Registry` — the interface every per-format handler depends on. Keep it minimal; do not push format-specific concepts into it. Implementations are `*oci.Registry` (raw) and `*namespace.ScopedRegistry` (namespaced + authorized, used in production).
+- `namespace.Registry` / `namespace.ScopedRegistry` — the data-plane namespace wrapper. `Registry.For(ns)` returns a cheap per-request `ScopedRegistry` that handlers use as their `handler.Registry`. Authorizer instances are cached per namespace (`DefaultPolicyCacheTTL = 60s`) and invalidated automatically when admin-side `Store.Put` / `Store.Delete` fires the mutation hook.
+- `namespace.Policy` — the JSON-serialised authz block on a namespace `Spec`. Empty Policy is deny-all. `Readers` and `Writers` are independent `SubjectMatcher` lists; matchers ANDed across fields (`issuer`, `sub_match` regex, `email`, `claims_match`, `kind`).
+- `auth.AuthContext{Issuer, ID, Email, Claims}` — the verified caller identity the OIDC authenticator installs into the request context. The `namespace.PolicyAuthorizer` consumes it; out-of-tree authorizers (OPA / Cedar / Casbin) plug in via `namespace.WithAuthzFactory`.
+- `auth.Authorizer` / `auth.Op` (`OpRead`, `OpWrite`) — the coarse pluggable authz surface every namespace policy compiles to.
 
 ### How a per-format handler is structured
 
 Each `pkg/handler/<format>` package owns:
 - `RepoType` constant (`"npm"`, `"python"`, …) — used by `serve` to dispatch.
-- `ArtifactType` constant — the OCI manifest `artifactType` (e.g. `application/vnd.ocifactory.npm`). Unique per format so users can tell formats apart in their OCI registry.
-- `NewHandler(handler.Registry) (*Handler, error)`
-- `Mux() http.Handler` — gorilla/mux router for that format's URL scheme.
-- Translation logic mapping client protocol calls ↔ `RepoFile` operations.
+- `ArtifactType` constant — the OCI manifest `artifactType` base (e.g. `application/vnd.ocifactory.npm`). `pkg/oci` appends `.version` / `.file` / `.alias` to it so the three manifest kinds are distinguishable in the OCI backend.
+- `NewHandler(*namespace.Registry, opts ...Option) (*Handler, error)` — takes the namespace wrapper, not a raw `*oci.Registry`, so every request goes through the authorizer.
+- `Mux() http.Handler` — gorilla/mux router for that format's URL scheme. Mount every route on a `router.PathPrefix("/{namespace}").Subrouter()` (or `"/{namespace}/<format-prefix>"`) so the handler can read the namespace from `mux.Vars(req)` and call `r.For(ns)` to get a per-request `*namespace.ScopedRegistry`.
+- Translation logic mapping client protocol calls ↔ `RepoFile` operations through the scoped registry.
 
-When adding a new format, copy the structure from `pkg/handler/python` (it's the most complete reference, including the embedded simple index template and the dual-write trick that maintains an `index` repo for fast `list packages`).
+When adding a new format, copy the structure from `pkg/handler/python` (it's the most complete reference, including the embedded simple index template, the per-package simple-index cache, and the dual-write trick that maintains an `index` repo for fast "list packages").
+
+### Namespace URL layout
+
+Every format mounts under `/{namespace}/...`. Some formats add a fixed
+sub-prefix after the namespace to make the URL self-describing when a
+single hostname serves multiple formats per namespace:
+
+| Format | URL shape |
+|---|---|
+| python | `/{namespace}/simple/<pkg>/`, `/{namespace}/packages/<pkg>/<version>/<filename>`, `/{namespace}/` for twine upload |
+| maven  | `/{namespace}/maven2/<groupId>/<artifactId>/<version>/<filename>` (and the `maven-metadata.xml` / `archetype-catalog.xml` routes) |
+| npm    | `/{namespace}/<pkg>`, `/{namespace}/{@scope/name}`, `/{namespace}/-/package/<pkg>/dist-tags/<tag>`, `/{namespace}/-/ping` |
+
+Namespaces have to be created via the [admin API](docs/admin.md) before any
+request can land on them — there is no auto-vivification. `ScopedRegistry`
+returns `namespace.ErrNotFound` (mapped to 404 by `handler.WriteNamespaceError`)
+when the namespace's metadata document is missing.
 
 ### Index repos pattern
 
-For formats where you need "list all packages I have" (PyPI simple index, npm registry root, etc.), `python` handler maintains a parallel OCI repo named `index` whose tags are package names. This avoids needing a sidecar database — `ListTags("index")` is the package list. Reuse the pattern when implementing npm/Go/apt.
+For formats where you need "list all packages I have" (PyPI simple index, npm registry root, etc.), `python` handler maintains a parallel OCI repo named `index` (relative to the namespace, so `<namespace>/index` on the backend) whose tags are package names. This avoids needing a sidecar database — `ListTags("index")` is the package list. Reuse the pattern when implementing npm/Go/apt.
+
+Separately, `namespace.Registry` itself maintains a per-namespace **package index repo** at `<namespace>/ocifactory-packages` (configurable via `WithPackageIndexSuffix`). It's an in-process LRU-deduped record of every owning-repo the wrapper has written to, used by `admin serve`'s soft-delete to refuse deleting a non-empty namespace. Format handlers don't write to it directly — every `ScopedRegistry.AddFile` call updates it best-effort.
 
 ## Build, run, test
 
@@ -127,11 +174,20 @@ go vet ./...
 gofmt -s -w .
 go mod tidy
 
-# Run locally against a real OCI registry (e.g. local zot or GAR)
+# Run locally against a real OCI registry (e.g. local zot or GAR).
+# --disable-authn is required for the dev path — Validate refuses to
+# start with neither --authn-kind nor --disable-authn set.
 go run ./cmd/ocifactory serve \
   --repo-type=python \
   --backend-registry=zot.local:5000/ocifactory \
+  --disable-authn \
   --port=8080
+
+# Then create a namespace via the admin service so the data plane has
+# something to serve under.
+go run ./cmd/ocifactory admin serve \
+  --backend-registry=zot.local:5000/ocifactory \
+  --port=8081
 ```
 
 ## Code conventions
@@ -139,7 +195,7 @@ go run ./cmd/ocifactory serve \
 - **Languages:** Go is the only implementation language. Avoid pulling in shell scripts when a Go test will do.
 - **Style:** Write idiomatic Go. Follow [Effective Go](https://go.dev/doc/effective_go) and the Google Go style guide — [overview](https://google.github.io/styleguide/go/), [style decisions](https://google.github.io/styleguide/go/decisions), [best practices](https://google.github.io/styleguide/go/best-practices). Prefer explicit and boring over clever. `gofmt -s` and `go vet` must be clean before every commit.
 - **Errors:** wrap with `fmt.Errorf("...: %w", err)`. Use `errors.Is` / `errors.As` to check. The `pkg/oci` package already exposes `oci.HasCode(err, statusCode)` for translating ORAS HTTP errors — use it in handlers rather than re-deriving status codes.
-- **Logging:** `github.com/abcxyz/pkg/logging`. Read with `logging.FromContext(ctx)`; configure via `OCIFACTORY_LOG_LEVEL`, `OCIFACTORY_LOG_FORMAT`, `OCIFACTORY_LOG_DEBUG`.
+- **Logging:** `github.com/yolocs/ocifactory/pkg/logging`. Read with `logging.FromContext(ctx)`; configure via `OCIFACTORY_LOG_LEVEL`, `OCIFACTORY_LOG_FORMAT`, `OCIFACTORY_LOG_DEBUG`.
 - **Routing:** gorilla/mux (already adopted, see commit `26f36de`). Don't reach for stdlib `http.ServeMux` for new format handlers.
 - **Public API surface:** anything in `pkg/` is public. Don't expose internals you wouldn't want to support — when in doubt, lowercase it.
 - **Configuration:** Operator-tunable knobs (timeouts, thresholds, feature toggles, backend URLs) go through a CLI flag on `cmd/ocifactory serve`, not `os.Getenv` reads scattered inside library code. Library types (e.g. `oci.Registry`) accept the value through a typed option (`WithStreamingPushDisabled(bool)`, `WithArtifactType(string)`, …) so tests can override it without touching the environment and there's exactly one place — the flag definition — that enumerates every knob ocifactory exposes. Environment variables are reserved for what the runtime / harness sets (`OCIFACTORY_LOG_LEVEL`, secret material, GCP `GOOGLE_APPLICATION_CREDENTIALS` and friends), not product behaviour.
@@ -177,20 +233,22 @@ These are non-negotiable. Apply them to every test in the repo:
 
 1. Create `pkg/handler/<format>/` with `handler.go`, the `Mux()`, and translation logic.
 2. Define `RepoType` and `ArtifactType` constants.
-3. **Accept `WithAuthMiddleware(func(http.Handler) http.Handler)` as an Option** and chain the middleware on whichever routes need authentication. The convention today (python, maven) is `router.Use(mux.MiddlewareFunc(h.authMW))` on the root router so every route is gated. Public-by-default formats (npm registry root, Go module proxy listings) chain on a sub-router and leave reads ungated; outlier endpoints with their own auth contract (npm login bootstrap, Docker token server) sit on a sub-router that doesn't chain it at all. **Do not add an open default**: in `pkg/commands/serve.go`, always pass `WithAuthMiddleware(authMW)` when constructing the handler. The handler-side option is permissive (omitting it leaves routes ungated, which is what tests want), so the gate against silent-no-auth lives in serve.go — verify it's wired before merging.
-4. Plumb it into `pkg/commands/serve.go`'s `supportedRepoTypes` and the `switch` in `Run`. Pass `WithAuthMiddleware(authMW)` (built earlier in `runServe`) to the handler constructor.
-5. Add handler tests using the `oci.fake` backend (cover happy path + 404 + auth errors at minimum). Add a `pkg/handler/<format>/auth_test.go` that mirrors `pkg/handler/python/auth_test.go`: a deny-all middleware reaches every route, omitting the option leaves routes ungated, and the middleware chains before the route handler runs.
-6. Add an integration test or a documented manual test against a real client (`pip`, `mvn`, `npm install`, `go mod download`, `apt-get`).
-7. Document the format under `docs/repos/<format>.md`: URL layout, supported client commands, known limitations. Copy [`docs/repos/_template.md`](docs/repos/_template.md) — it has the headings and depth `python.md` / `maven.md` use, plus inline notes on what to call out front-and-center (e.g. operator footguns that break the second invocation of the most common client command).
-8. Update the status table in this file.
+3. **Mount every route under a `/{namespace}` sub-router** so the handler can read the namespace from `mux.Vars(req)` and call `registry.For(ns)` to get a per-request `*namespace.ScopedRegistry`. Optionally prefix routes with a per-format segment (`/{namespace}/maven2/...`, `/{namespace}/simple/...`) when the URL would otherwise be ambiguous against another format on the same hostname.
+4. **Accept `WithAuthMiddleware(func(http.Handler) http.Handler)` as an Option** and chain the middleware on whichever routes need authentication. The convention today (python, maven, npm) is `router.Use(mux.MiddlewareFunc(h.authMW))` on the root router (python, maven) or on the `/{namespace}` sub-router (npm) so every route is gated. Public-by-default formats (Go module proxy listings, future read-without-token endpoints) would chain on a sub-router and leave reads ungated; outlier endpoints with their own auth contract sit on a sub-router that doesn't chain it at all. **Do not add an open default**: in `pkg/commands/serve.go`, always pass `WithAuthMiddleware(authMW)` when constructing the handler. The handler-side option is permissive (omitting it leaves routes ungated, which is what tests want), so the gate against silent-no-auth lives in serve.go — verify it's wired before merging.
+5. **Take a `*namespace.Registry` in `NewHandler`**, not a `*oci.Registry`. Every backend op flows through the scoped view so the namespace's compiled `Policy` runs on every read and write. Map `namespace.ErrNotFound`, `namespace.ErrInvalidName`, `namespace.ErrInvalidOwningRepo`, and `auth.ErrUnauthorized` to HTTP via `handler.WriteNamespaceError` — there's a shared helper because every format needs the same translation.
+6. Plumb it into `pkg/commands/serve.go`'s `supportedRepoTypes` and the `switch` in `Run`. Build the `*namespace.Registry` next to the format-specific `*oci.Registry`, pass it to the handler constructor along with `WithAuthMiddleware(authMW)`.
+7. Add handler tests using the `oci.fake` backend (cover happy path + 404 + auth errors at minimum). Add a `pkg/handler/<format>/auth_test.go` that mirrors `pkg/handler/python/auth_test.go`: a deny-all middleware reaches every route, omitting the option leaves routes ungated, and the middleware chains before the route handler runs. Add a `pkg/handler/<format>/namespace_test.go` mirroring `pkg/handler/python/namespace_test.go`: unknown namespace → 404, deny-all policy → 403, cross-namespace request can't reach another namespace's data.
+8. Add an integration test or a documented manual test against a real client (`pip`, `mvn`, `npm install`, `go mod download`, `apt-get`). The harness in `pkg/handler/integrationtest/` seeds a `default` namespace via `Store.Put` before the subprocess starts; copy that pattern.
+9. Document the format under `docs/repos/<format>.md`: URL layout (including the `/{namespace}/` prefix), supported client commands, known limitations. Copy [`docs/repos/_template.md`](docs/repos/_template.md) — it has the headings and depth `python.md` / `maven.md` / `npm.md` use, plus inline notes on what to call out front-and-center (e.g. operator footguns that break the second invocation of the most common client command).
+10. Update the status table in this file.
 
 ## Roadmap (one step at a time)
 
 The intent is to ship each phase production-ready before starting the next. See `docs/ROADMAP.md` for the long form.
 
-1. **Phase 1 — Core formats:** npm → Go module proxy → Debian/apt. (Maven and PyPI already done.)
-2. **Phase 2 — Deployability:** Dockerfile, container image publishing in CI, Cloud Run / Cloudflare Workers deployment guide, basic Prometheus metrics.
-3. **Phase 3 — Auth/Authz extensibility:** OIDC + JWT verification, scoped tokens, pluggable authorizer interface (allow/deny per repo/operation).
+1. **Phase 1 — Core formats:** Go module proxy → Debian/apt. (Python, Maven, npm done.)
+2. **Phase 2 — Deployability:** Cloud Run + Cloudflare deployment guides, structured request logging, rate limiting. (Distroless image, multi-arch publishing, Goreleaser pipeline, Prometheus metrics, signed releases + SBOMs done.)
+3. **Phase 3 — Auth/Authz extensibility:** pluggable authn (OIDC) and per-namespace authz are shipped. Remaining: more authorizer plugins (OPA / Cedar / Casbin examples) and scoped token issuance.
 4. **Phase 4 — Pull-through proxy:** read-through caching from upstream npm/PyPI/Maven Central/proxy.golang.org/Debian mirrors. Cache TTLs, negative caching, immutable-version pinning.
 5. **Phase 5 — Add-ons:** vulnerability scanning (Grype/Trivy integration), retention policies, web UI.
 
@@ -240,8 +298,9 @@ The human is the product owner / reviewer; the agent does most of the implementa
 
 - Adding a new top-level dependency (especially anything implying state outside the OCI backend).
 - Changing the `handler.Registry` interface — every format handler depends on it.
-- Adding a new auth mechanism — discuss the interface shape first.
-- Anything that breaks backward compatibility of existing `--repo-type=python|maven` users (assume there's at least one in the wild).
+- Changing the `namespace.Spec` / `namespace.Policy` JSON shape — bump `CurrentSchemaVersion` and add a read-side migration so older bodies stay loadable; never silently drop fields.
+- Adding a new auth mechanism or `Op` value — discuss the interface shape first. Authenticator implementations must return one of the sentinel errors (`ErrNoCredential`, `ErrInvalidToken`, `ErrIssuerUnavailable`) so the middleware maps to the right HTTP status; authorizers must wrap `auth.ErrUnauthorized` on deny.
+- Anything that breaks backward compatibility of existing `--repo-type=python|maven|npm` users — incl. the URL shape, the on-OCI layout, or the admin API.
 
 ## Out of scope
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A lightweight, multi-format artifact registry that uses any OCI registry as its
 sole storage backend. Think of it as a small, open-source drop-in for
 Artifactory or Nexus — for users who can't or don't want to run them.
 
-> **Status:** experimental / pre-1.0. Maven and PyPI are functional; npm is in
-> progress; Go module proxy and apt are planned. See [`AGENTS.md`](AGENTS.md)
-> for the full status table.
+> **Status:** experimental / pre-1.0. Python, Maven, and npm are functional and
+> covered by real-client integration tests; Go module proxy and apt are
+> planned. See [`AGENTS.md`](AGENTS.md) for the full status table.
 
 ## Why
 
@@ -18,24 +18,44 @@ service.
 
 - **Single stateless binary.** No Postgres, no S3, no separate metadata DB.
 - **Storage is your OCI registry.** Bring your own. We only need v2 API.
-- **Lean ops.** Designed to deploy on Cloud Run or Cloudflare in minutes.
-- **Pluggable auth.** Pass-through basic auth today; OIDC/JWT and a custom
-  authorizer interface on the roadmap.
+- **Lean ops.** Single Go binary, distroless container image, deployable to
+  Cloud Run or Cloudflare in minutes. Signed releases + SBOMs.
+- **Pluggable auth.** OIDC-only frontend authentication (Google, GitHub
+  Actions, dex, keycloak, …) and a pluggable per-namespace authorizer for
+  read/write policy.
 
 ## Supported formats
 
 | Format | Client | Status | Docs |
 |---|---|---|---|
-| Maven | `mvn`, `gradle` | ✅ Functional | [`docs/repos/maven.md`](docs/repos/maven.md) |
-| PyPI  | `pip`, `twine`  | ✅ Functional | [`docs/repos/python.md`](docs/repos/python.md) |
-| npm   | `npm`, `yarn`, `pnpm` | 🚧 In progress (routes wired, handlers pending) | — |
-| Go module proxy | `go mod`        | ⏳ Planned | — |
-| Debian / apt    | `apt-get`       | ⏳ Planned | — |
+| Python (PyPI) | `pip`, `twine` | ✅ Functional | [`docs/repos/python.md`](docs/repos/python.md) |
+| Maven         | `mvn`, `gradle` | ✅ Functional | [`docs/repos/maven.md`](docs/repos/maven.md) |
+| npm           | `npm`, `yarn`, `pnpm` | ✅ Functional | [`docs/repos/npm.md`](docs/repos/npm.md) |
+| Go module proxy | `go mod`     | ⏳ Planned | — |
+| Debian / apt    | `apt-get`    | ⏳ Planned | — |
 | Pull-through caching of upstreams | — | ⏳ Phase 4 | — |
 
 Per-format operator guides live under [`docs/repos/`](docs/repos/) — URL
 layouts, supported client commands, OCI storage shape, knobs, and known
 limitations.
+
+## Namespaces
+
+Every URL ocifactory serves lives under a namespace prefix that an operator
+creates ahead of time via the [admin API](docs/admin.md):
+
+```
+https://ocifactory.your-domain/{namespace}/simple/...        # python
+https://ocifactory.your-domain/{namespace}/maven2/...        # maven
+https://ocifactory.your-domain/{namespace}/<pkg>             # npm
+```
+
+Each namespace carries its own authorization policy
+(`readers` / `writers` matchers against the OIDC `iss` + `sub` + claims) and
+its own slice of OCI repos, so the same ocifactory instance can host disjoint
+teams without leaking artifacts between them. See
+[`docs/admin.md`](docs/admin.md) for the API, [`docs/auth.md`](docs/auth.md) for
+the policy model.
 
 ## Quickstart
 
@@ -43,13 +63,28 @@ limitations.
 go build ./...
 
 # Point at any OCI registry — local zot, GAR, ECR, GHCR, ...
-go run ./cmd/ocifactory serve \
+ocifactory serve \
   --repo-type=python \
   --backend-registry=zot.local:5000/ocifactory \
+  --disable-authn \
   --port=8080
+```
 
-# In another shell
-pip install --index-url http://localhost:8080/simple/ requests
+Then, in another shell, create a namespace via the admin service and use it:
+
+```bash
+# Start the admin service (separate listener, no internal auth — see docs/admin.md).
+ocifactory admin serve \
+  --backend-registry=zot.local:5000/ocifactory \
+  --port=8081 &
+
+# Create a namespace with a permissive policy (dev-only).
+curl -X PUT http://localhost:8081/admin/v1/namespaces/team-a \
+  -H 'content-type: application/json' \
+  -d '{"policy":{"readers":[{"issuer":"anonymous"}],"writers":[{"issuer":"anonymous"}]}}'
+
+# Install through the namespace.
+pip install --index-url http://localhost:8080/team-a/simple/ requests
 ```
 
 Every runtime knob is a CLI flag with a matching env var — no config files.
@@ -61,12 +96,14 @@ options and [`docs/repos/`](docs/repos/) for per-format guides.
 ## Architecture
 
 ```
-client ──► handler/<format> ──► pkg/oci.Registry ──► OCI registry (ORAS)
+client ──► handler/<format> ──► namespace.Registry ──► pkg/oci.Registry ──► OCI registry (ORAS)
 ```
 
 One Go binary. One process. Storage offloaded entirely to your OCI registry.
 Each artifact format gets its own `pkg/handler/<format>` package implementing
-the relevant protocol.
+the relevant protocol; every request resolves its `{namespace}` URL segment
+into a per-namespace `ScopedRegistry` view that authorizes the operation
+against the namespace's policy and prefixes OCI repos with the namespace.
 
 For the on-OCI shape — version anchors, file manifests, alias manifests, and
 why ocifactory uses the OCI 1.1 referrers layout instead of one fat manifest
@@ -74,6 +111,21 @@ per version — see
 [`docs/architecture/storage-model.md`](docs/architecture/storage-model.md).
 See [`AGENTS.md`](AGENTS.md) for the full design notes and
 [`docs/ROADMAP.md`](docs/ROADMAP.md) for what's coming.
+
+## Running
+
+### Container image
+
+Signed multi-arch images live at `ghcr.io/yolocs/ocifactory:vX.Y.Z` (and
+rolling `:vX.Y` / `:latest` for stable releases). Verify the signature with
+cosign — see [`RELEASING.md`](RELEASING.md) for the exact command and identity
+regex.
+
+### Binary
+
+Release archives (`linux/amd64`, `linux/arm64`, `darwin/amd64`,
+`darwin/arm64`) are published on each GitHub Release with sha256 checksums,
+CycloneDX SBOMs, and cosign keyless signatures.
 
 ## Contributing
 
@@ -98,6 +150,13 @@ go test -race -short ./...
 
 # Race detector + coverage, same flags CI uses (sans -short):
 go test -count=1 -race -shuffle=on -coverprofile=coverage.out ./...
+```
+
+Per-format real-client integration tests (`twine`, `mvn`, `npm`) live behind
+the `integration` build tag and run in the `client-integration` CI job:
+
+```bash
+go test -tags=integration ./pkg/handler/...
 ```
 
 ## License

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,10 +9,11 @@ least one real end-to-end run documented in the PR.
 
 Round out the format coverage that motivates the project.
 
-- [ ] **npm** — finish the stub handlers in `pkg/handler/npm/`. PEP-equivalent
-  endpoints: package metadata, version metadata, tarball download, publish,
-  unpublish, dist-tags. Use the `index` repo pattern from `python` for
-  package listing. Validate against `npm`, `yarn`, and `pnpm`.
+- [x] **npm** — `npm publish` (scoped + unscoped), `npm install` (with
+  dist-tag and version specifiers), `npm dist-tag add` / `ls`. Tarball
+  URLs rewritten per request so the `dist.tarball` field always points
+  at ocifactory. Validated against `npm`, `yarn`, and `pnpm`. Operator
+  docs: [`repos/npm.md`](repos/npm.md).
 - [ ] **Go module proxy** — implement the `GOPROXY` protocol
   (`/<module>/@v/list`, `/<module>/@v/<version>.info|.mod|.zip`,
   `/<module>/@latest`). Use immutable version tags (`v1.2.3` → OCI tag).
@@ -24,30 +25,76 @@ Round out the format coverage that motivates the project.
 
 Make it trivial to run. Without this, nobody adopts it.
 
-- [ ] Dockerfile (distroless or alpine, < 30 MB image)
-- [ ] CI pipeline: lint (`golangci-lint`), unit tests, integration tests, image
-  build + push (GHCR) on tag.
+- [x] **Dockerfile and multi-arch container image.** Distroless `nonroot`
+  base, < 30 MB image. Published to `ghcr.io/yolocs/ocifactory:vX.Y.Z`
+  (+ `:vX.Y` / `:latest` for stable releases). See
+  [`../Dockerfile.goreleaser`](../Dockerfile.goreleaser).
+- [x] **Release pipeline.** Manually-dispatched GitHub Actions workflow
+  drives Goreleaser. Per release: binaries for `linux/amd64`,
+  `linux/arm64`, `darwin/amd64`, `darwin/arm64`; CycloneDX SBOMs;
+  cosign keyless signatures on every archive and image. See
+  [`../RELEASING.md`](../RELEASING.md).
+- [x] **CI pipeline.** `go-test` (full suite incl. live-zot integration
+  test) on every PR; `oidc-e2e` job mints a real GitHub Actions OIDC
+  token and exercises the auth chain; `client-integration` job runs
+  the `-tags=integration` real-client tests for python, maven, and
+  npm.
+- [x] **Health check, readiness, metrics.** `/healthz`, `/readyz`
+  (caches a 1s backend probe; returns build info), `/metrics`
+  (Prometheus exposition with HTTP- and OCI-backend-layer
+  instrumentation). See [`observability.md`](observability.md).
+- [x] **Build-time version stamping.** `--version` surfaces
+  `ocifactory vX.Y.Z (commit <sha>, <os>/<arch>)`; same info appears
+  in the `/readyz` JSON body so multi-instance deployments are
+  diagnosable per-pod. See `internal/version`.
 - [ ] Cloud Run deployment guide + sample Terraform.
 - [ ] Cloudflare Workers/Containers deployment guide.
-- [x] Health check endpoint (`/healthz`, `/readyz`), Prometheus metrics
-  (`/metrics`), HTTP- and OCI-backend-layer instrumentation.
-- [ ] Structured request logs.
+- [ ] Structured request logs (debug-level request log via
+  `pkg/handler.Loggeer` exists; structured-with-fields request log
+  doesn't).
 - [ ] Rate limiting hooks (interface, default no-op).
 
 ## Phase 3 — Auth/Authz extensibility
 
-The pass-through basic auth model gets us off the ground but won't survive a
-real deployment. This phase makes auth pluggable.
+The pluggable auth model is partially landed and powers production
+deployments today. Remaining work is more authorizer backends and
+scoped-token issuance.
 
-- [ ] Define `Authenticator` and `Authorizer` interfaces in `pkg/auth/`.
-- [ ] Built-in implementations:
-  - Pass-through basic auth (today, kept for back-compat).
-  - OIDC / JWT verifier (issuer + JWKS URL config).
-  - Static token list (env var or file).
-- [ ] Authorization model: scope = `(repo, format, op)` where `op ∈ {read, write, delete}`.
-- [ ] Middleware in `pkg/handler` consumes the interfaces; concrete
-  implementations register at startup.
-- [ ] Documented "how to plug in your own authorizer" recipe.
+- [x] **`Authenticator` interface in `pkg/auth/`.** OIDC implementation
+  in `pkg/auth/oidc/`. `pkg/auth/chain/` composes multiple authenticators
+  so an instance can accept tokens from several issuers (Google service
+  accounts + GitHub Actions + …).
+- [x] **`Authorizer` interface in `pkg/auth/`.** `OpRead` / `OpWrite`
+  ops. Default in-tree implementation is `namespace.PolicyAuthorizer`
+  — a matcher-based authorizer compiled from each namespace's `Policy`
+  block (`readers` / `writers` `SubjectMatcher` lists). Out-of-tree
+  authorizers (OPA / Cedar / Casbin) plug in via
+  `namespace.WithAuthzFactory`.
+- [x] **Pluggable backend credential `Provider`.** In-tree adapters:
+  `anonymous`, `gcpadc` (ADC), `staticenv` (env vars, re-read every
+  call), `dockerconfig` (honours credential helpers). See
+  [`auth.md`](auth.md#backend-how-ocifactory-talks-to-the-oci-registry).
+- [x] **Namespace control plane.** `ocifactory admin serve` exposes
+  `PUT/GET/DELETE /admin/v1/namespaces/{name}` against an OCI-backed
+  store. See [`admin.md`](admin.md).
+- [x] **Per-namespace authorization model.** `(namespace, op)` where
+  `op ∈ {read, write}`. Every data-plane request matches against the
+  namespace's compiled `Policy`; authorizer cache invalidates on admin
+  Put/Delete. Documented in [`auth.md`](auth.md#namespace-authorization).
+- [x] **OIDC-only frontend authentication.** Static passwords are
+  intentionally out-of-tree — out-of-tree authenticators implement
+  `auth.Authenticator` and slot in via a custom main. See
+  [`auth.md`](auth.md).
+- [ ] **Scoped tokens.** A token-mint endpoint that takes a verified
+  OIDC token and issues a shorter-lived `aud=ocifactory` token bound
+  to a single namespace and op. Open question on the wire shape.
+- [ ] **Example out-of-tree authorizer.** A small reference for OPA or
+  Cedar so operators who already run one don't need to reverse-engineer
+  the interface.
+- [ ] **Documented "how to plug in your own authorizer" recipe.**
+  Today it's "implement `auth.Authorizer`, pass it via
+  `namespace.WithAuthzFactory`"; the surface is small enough that a
+  recipe in [`auth.md`](auth.md) is sufficient.
 
 ## Phase 4 — Pull-through proxy / cache
 
@@ -77,3 +124,6 @@ Anything we'd bolt on once the core is solid.
 - Feature parity with Artifactory. We aim for an opinionated useful subset.
 - General-purpose blob storage abstraction over non-OCI backends. The OCI
   constraint is a feature, not a limitation to route around.
+- Static passwords / shared HTTP basic auth as a first-class auth mode.
+  An OIDC issuer is reachable from every realistic 2026 deployment;
+  out-of-tree authenticators cover the edge cases.

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -9,6 +9,13 @@ separate hostname behind platform or network access controls.
 > authenticated invoker, an internal load balancer ACL, an identity-aware proxy,
 > or equivalent controls before exposing it to operators.
 
+The admin service owns the **namespace catalogue** — the documents that say
+"a namespace named `myteam` exists, and these are the OIDC subjects allowed
+to read and write its packages". Every data-plane URL ocifactory serves lives
+under a namespace prefix (`/{namespace}/...` for python and npm,
+`/{namespace}/maven2/...` for maven), and the data plane fetches each
+namespace's spec from the same OCI backend the admin service writes to.
+
 ## Start the service
 
 ```bash
@@ -46,6 +53,76 @@ Errors use `{"error":"message"}`. Invalid namespace names and invalid specs
 return `400`; missing namespaces return `404`; soft-delete of a non-empty
 namespace returns `409`.
 
+### Namespace name validation
+
+Names must satisfy:
+
+- 1–64 characters, lowercase ASCII alphanumerics and `-`.
+- No leading or trailing `-`; no leading `_` or `.` (both reserved for
+  internal use).
+- Not one of a small reserved set: `admin`, `healthz`, `readyz`,
+  `metrics`, `simple`, `maven2`, `v2`, `npm`,
+  `ocifactory-namespaces`, plus a few `_`-prefixed historical names.
+  Reservations are conservative on purpose — better to over-reserve in
+  v1 than collide with future routing.
+
+### `Spec` shape
+
+```json
+{
+  "schema_version": 1,
+  "policy": {
+    "readers": [
+      {"issuer": "https://accounts.google.com"}
+    ],
+    "writers": [
+      {"issuer": "https://accounts.google.com",
+       "email": "release-bot@myteam.example"}
+    ]
+  },
+  "format": { /* reserved for future format-specific knobs */ }
+}
+```
+
+- `policy.readers` / `policy.writers` are independent
+  `SubjectMatcher` lists. **An entirely empty policy is deny-all** —
+  a caller is allowed to perform an op only if at least one matcher
+  in the corresponding list matches. Granting `write` does not imply
+  `read`.
+- Every matcher must populate at least one of `issuer`, `sub_match`
+  (RE2 regex), `email`, `claims_match` (map of claim → regex), or
+  `kind`. Regex patterns are anchored at both ends (`^...$`); if
+  your pattern already starts with `^` or ends with `$`, the anchor
+  isn't duplicated. See [`auth.md`](auth.md#subjectmatcher-reference)
+  for the full reference and worked examples.
+- `format` is reserved for future format-specific knobs; ocifactory
+  preserves it across roundtrips so a newer ocifactory's keys aren't
+  silently dropped by an older one.
+
+### Worked example — create a namespace
+
+```bash
+curl -X PUT https://ocifactory-admin.your-domain/admin/v1/namespaces/myteam \
+  -H 'content-type: application/json' \
+  -d '{"policy":{
+        "readers":[{"issuer":"https://token.actions.githubusercontent.com",
+                    "sub_match":"repo:myorg/.+"}],
+        "writers":[{"issuer":"https://token.actions.githubusercontent.com",
+                    "sub_match":"repo:myorg/myapp:ref:refs/heads/main"}]}}'
+```
+
+Response: `201 Created` with the persisted document (including the
+`schema_version: 1` ocifactory stamped on write).
+
+### Policy propagation
+
+Policy changes via this API take effect on the very next data-plane
+request. The admin `Store` fires a mutation hook on `Put` / `Delete`
+that the data plane's `namespace.Registry` consumes to invalidate its
+cached authorizer for the affected namespace. Without that hook,
+changes would only land after the cache TTL (`DefaultPolicyCacheTTL = 60s`)
+expired.
+
 ## Soft delete
 
 `DELETE` is intentionally conservative in this phase. ocifactory checks the
@@ -68,8 +145,21 @@ Namespace metadata is stored with OCI artifact type
 `application/vnd.ocifactory.namespace`, independent of the data-plane format
 served by a process. If you experimented with namespace metadata from the short
 window before this admin service existed, recreate those namespaces through the
-admin API so Python, Maven, and future repo types all read the same control-plane
-documents.
+admin API so Python, Maven, npm, and future repo types all read the same
+control-plane documents.
+
+Concretely, for a namespace named `myteam` with `--namespace-prefix=""`
+(the default):
+
+| OCI repo | Tag | Body |
+|---|---|---|
+| `myteam` | `_metadata` | The JSON-serialised `Spec` written by the admin `PUT`. |
+| `ocifactory-namespaces` | `myteam` | A single sentinel layer — the tag's existence is the catalogue entry. |
+
+A non-empty `--namespace-prefix` (e.g. `control-plane`) shifts both
+repos under that prefix (`control-plane/myteam`, `control-plane/ocifactory-namespaces`).
+Operators sharing one OCI registry between an ocifactory deployment and
+unrelated artifacts use the prefix to keep the namespaces out of the way.
 
 ## `schema_version`
 

--- a/docs/architecture/storage-model.md
+++ b/docs/architecture/storage-model.md
@@ -7,7 +7,12 @@ link here from their "How it's stored" sections.
 
 The implementation lives in [`pkg/oci/registry.go`](../../pkg/oci/registry.go);
 the deterministic file-tag helper lives in
-[`pkg/oci/filetag.go`](../../pkg/oci/filetag.go).
+[`pkg/oci/filetag.go`](../../pkg/oci/filetag.go). The data-plane
+namespace wrapper that prefixes every backend repo with `<namespace>/`
+before reaching `pkg/oci` lives in
+[`pkg/namespace/registry.go`](../../pkg/namespace/registry.go); this
+doc shows the shape `pkg/oci` ends up writing, so every repo path
+below includes the namespace prefix the wrapper adds.
 
 ## TL;DR
 
@@ -83,7 +88,7 @@ etc. The three subtypes are derived in `NewRegistry`.
 A user runs:
 
 ```bash
-twine upload dist/*
+twine upload --repository-url https://ocifactory.your-domain/myteam/ dist/*
 ```
 
 with `dist/` containing:
@@ -94,9 +99,12 @@ requests-2.31.0-py3-none-any.whl
 requests-2.31.0-cp311-cp311-manylinux_2_17_x86_64.whl
 ```
 
-`twine` issues **three independent POSTs** to ocifactory's `/` endpoint
-— one per file. They may arrive in any order and may overlap if `twine`
-is parallelised across CI workers.
+`twine` issues **three independent POSTs** to ocifactory's
+`/{namespace}/` endpoint — one per file. They may arrive in any order
+and may overlap if `twine` is parallelised across CI workers. The
+namespace wrapper resolves each request to the `myteam` namespace's
+authorizer, prefixes the python handler's `packages/requests`
+owning-repo with the namespace segment, and forwards to `pkg/oci`.
 
 Each POST translates to one `Registry.AddFile` call. For the first one
 to land (say the sdist):
@@ -161,11 +169,13 @@ PUT /com/example/foo/maven-metadata.xml
 PUT /com/example/foo/maven-metadata.xml.sha1
 ```
 
-Each PUT lands as one `AddFile` call against the `com/example/foo` OCI
-repo. The first one (jar, say) walks the same five steps as the python
-sdist above: probe, push blob, ensure `1.0.0` version manifest, push
-file manifest with `subject = versionDesc`, tag with deterministic
-`_f_*` tag.
+Each PUT lands as one `AddFile` call against the
+`<namespace>/com/example/foo` OCI repo (the maven handler addresses
+the repo as `com/example/foo`; the namespace wrapper prefixes it
+before forwarding). The first one (jar, say) walks the same five
+steps as the python sdist above: probe, push blob, ensure `1.0.0`
+version manifest, push file manifest with `subject = versionDesc`,
+tag with deterministic `_f_*` tag.
 
 The other 13 PUTs short-circuit at step 3 — the version manifest
 already exists — and each one writes its own independent file
@@ -180,10 +190,12 @@ same file race on the deterministic `_f_*` tag, and last-writer-wins
 on the tag, with the loser's file manifest left as an unreferenced
 manifest the backend's GC eventually reaps.
 
-The artifact-level `maven-metadata.xml` (the file at
-`com/example/foo/maven-metadata.xml`) lands as a file in a separate
-"metadata" tag — see [`docs/repos/maven.md`](../repos/maven.md) for
-the URL-to-tag mapping.
+The artifact-level `maven-metadata.xml` (the URL at
+`/{namespace}/maven2/com/example/foo/maven-metadata.xml`) lands as a
+file in a separate `metadata` tag on the same
+`<namespace>/com/example/foo` repo — see
+[`docs/repos/maven.md`](../repos/maven.md) for the full URL-to-tag
+mapping.
 
 ## Read path
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,17 +1,24 @@
-# Authentication
+# Authentication and authorization
 
-ocifactory has two independent identities:
+ocifactory has three independent identities and policy surfaces:
 
-- **Frontend** — how callers of the ocifactory HTTP API authenticate
-  to ocifactory. OIDC only; configured via `OCIFACTORY_AUTHN_*`.
-- **Backend** — how ocifactory authenticates to the backend OCI
-  registry. Pluggable `backend.Provider` interface with in-tree
-  adapters for ADC, env vars, and docker config; configured via
-  `OCIFACTORY_BACKEND_AUTH_*`.
+- **Frontend authentication** — how callers of the ocifactory HTTP
+  API authenticate _to ocifactory_. OIDC only; configured via
+  `OCIFACTORY_AUTHN_*`.
+- **Per-namespace authorization** — what an authenticated caller is
+  allowed to do on a specific namespace. Defined inside each
+  namespace's `Policy` (set via the admin API) and enforced
+  automatically by the data-plane wrapper.
+- **Backend authentication** — how ocifactory authenticates _to the
+  backend OCI registry_. Pluggable `backend.Provider` interface with
+  in-tree adapters for ADC, env vars, and docker config; configured
+  via `OCIFACTORY_BACKEND_AUTH_*`.
 
 There is no config file. Every knob is a CLI flag or environment
 variable so deployments on Cloud Run / k8s / docker compose stay a
-single deployable unit with no extra mounts.
+single deployable unit with no extra mounts. The only state outside
+the binary is what lives in the OCI backend — including namespace
+metadata.
 
 ## Where auth runs
 
@@ -23,14 +30,22 @@ router, so:
 - Observability endpoints (`/healthz`, `/readyz`, `/metrics`) are
   reachable without auth — they're served before any format
   handler runs.
-- Today both built-in formats (python, maven) gate every route
-  via `router.Use(authMW)` on their root router.
-- Future formats with a public/private route split (npm registry
-  reads, Go module proxy listings) can chain the middleware on a
-  sub-router and leave public routes ungated.
-- Outlier endpoints that need their own auth contract (e.g. an
-  npm login bootstrap that mints a token) sit on a sub-router
-  that doesn't `Use(authMW)`.
+- Today every built-in format (python, maven, npm) gates every
+  route via `router.Use(authMW)` on the root router (python,
+  maven) or on the `/{namespace}` sub-router (npm).
+- Future formats with a public/private route split (Go module
+  proxy listings, anonymous-read mirrors) can chain the middleware
+  on a sub-router and leave public routes ungated.
+- Outlier endpoints that need their own auth contract (e.g. a
+  future npm login bootstrap that mints a token) would sit on a
+  sub-router that doesn't `Use(authMW)`.
+
+Authorization runs one layer deeper, inside the
+`namespace.ScopedRegistry` wrapper: every `AddFile` / `ReadFile` /
+`ListTags` / `ListFiles` call routes through the namespace's
+compiled `Policy` before reaching the OCI backend, so even a
+handler bug that skipped its own pre-check would not let a request
+bypass authz.
 
 ## Frontend: authenticating clients
 
@@ -62,6 +77,134 @@ verification. Mismatched issuers fall through silently to the next
 authenticator, so a multi-issuer chain (Google + GitHub Actions +
 ...) accepts tokens from any of its members without
 short-circuiting on the first one.
+
+## Namespace authorization
+
+Every data-plane URL ocifactory serves lives under a namespace
+prefix (`/{namespace}/...` for python and npm, `/{namespace}/maven2/...`
+for maven). Each namespace carries its own `Policy` — a pair of
+`SubjectMatcher` lists, one for `readers` and one for `writers` —
+that gates every read and write through the namespace.
+
+The control plane is `ocifactory admin serve`; see
+[`admin.md`](admin.md) for the CRUD API. The data plane
+(`ocifactory serve`) reads namespace specs out of the same OCI
+backend, caches the compiled authorizer (default
+`DefaultPolicyCacheTTL = 60s`), and invalidates the cache the moment
+an admin `Put` or `Delete` lands so policy changes take effect on
+the next request.
+
+### Op model
+
+Today there are two ops, deliberately coarse:
+
+| Op | What it covers |
+|---|---|
+| `read` | Every artifact fetch and listing (`pip install`, `mvn dependency:get`, `npm install`, `GET /simple/`, `GET <pkg>`, dist-tag GET, tarball GET, …). |
+| `write` | Every publish (`twine upload`, `mvn deploy`, `npm publish`, `npm dist-tag add`). |
+
+Granularity is per-namespace, not per-package. A caller matched by
+any reader matcher can read every package in the namespace; a caller
+matched by any writer matcher can write to any. Per-coordinate
+granularity is intentionally deferred — operators who need it plug
+in their own `Authorizer` via `namespace.WithAuthzFactory` (OPA,
+Cedar, Casbin) and consume the same `AuthContext`.
+
+### Policy shape
+
+A namespace `Spec` looks like:
+
+```json
+{
+  "schema_version": 1,
+  "policy": {
+    "readers": [
+      {"issuer": "https://accounts.google.com"}
+    ],
+    "writers": [
+      {"issuer": "https://token.actions.githubusercontent.com",
+       "sub_match": "repo:myorg/myapp:ref:refs/heads/main"},
+      {"issuer": "https://accounts.google.com",
+       "email": "release-bot@myteam.example"}
+    ]
+  }
+}
+```
+
+An **empty** policy is **deny-all**: a caller is allowed to perform
+an op only if at least one matcher in the corresponding list
+matches. The `readers` and `writers` lists are independent —
+granting `write` does not implicitly grant `read`.
+
+### `SubjectMatcher` reference
+
+Every populated field on a matcher must match the corresponding
+field on the verified `AuthContext` (fields AND together). An
+entirely-empty matcher is rejected at admin write time.
+
+| Field | Match against | Notes |
+|---|---|---|
+| `issuer` | `AuthContext.Issuer` (OIDC `iss`) | Exact string. |
+| `sub_match` | `AuthContext.ID` (OIDC `sub`) | RE2 regex anchored at both ends (`^...$`). Anchors that already exist on the pattern are honoured. |
+| `email` | `AuthContext.Email` (OIDC `email`, only when `email_verified=true`) | Exact string. |
+| `claims_match` | Other verified claims (`AuthContext.Claims`) | Map from claim name → RE2 regex (anchored). Non-string claim values are JSON-encoded (with sorted object keys) before matching. |
+| `kind` | Credential family | `"oidc"` (default) is the only supported value in v1; `"basictoken"` is reserved and rejected at validation time. |
+
+### Worked example — restrict writes to one GitHub repo's main branch
+
+```json
+{
+  "policy": {
+    "readers": [
+      {"issuer": "https://token.actions.githubusercontent.com",
+       "sub_match": "repo:myorg/.+"}
+    ],
+    "writers": [
+      {"issuer": "https://token.actions.githubusercontent.com",
+       "sub_match": "repo:myorg/myapp:ref:refs/heads/main"}
+    ]
+  }
+}
+```
+
+Any GitHub Actions workflow in any `myorg/*` repository can pull
+artifacts; only a run on `myorg/myapp`'s `main` branch can publish.
+The GitHub Actions `sub` is structured (see [Worked example: GitHub
+Actions OIDC](#worked-example-github-actions-oidc)) so policies can
+match on environment, ref, or workflow file precisely.
+
+### Failure modes
+
+| Case | Status |
+|---|---|
+| Unknown namespace | `404 Not Found` (`namespace not found`). |
+| Authenticated caller, no matching reader/writer matcher | `403 Forbidden`. |
+| Spec JSON has an unknown `schema_version` | Admin `PUT` returns `400`; data-plane `Get` returns `500` (operator must upgrade ocifactory). |
+| Owning-repo with `..` / absolute / reserved-prefix path | `400 Bad Request` — defends against cross-namespace escape via crafted URL parameters. |
+
+### Plugging in an alternative authorizer
+
+`namespace.AuthzFactory` is `func(Policy) (auth.Authorizer, error)`.
+A custom main can replace the built-in factory:
+
+```go
+import (
+    "github.com/yolocs/ocifactory/pkg/auth"
+    "github.com/yolocs/ocifactory/pkg/namespace"
+)
+
+reg := namespace.NewRegistry(ociReg, store,
+    namespace.WithAuthzFactory(func(p namespace.Policy) (auth.Authorizer, error) {
+        // compile p (or fetch a richer policy keyed by namespace name) into
+        // an authorizer that consumes auth.AuthContext.
+        return myOPAAuthorizer(p)
+    }),
+)
+```
+
+Out-of-tree authorizers slot in the same way as out-of-tree
+authenticators — implement `auth.Authorizer`, wire it into your own
+main, and the rest of the wiring is unchanged.
 
 ## Backend: how ocifactory talks to the OCI registry
 
@@ -303,9 +446,14 @@ OCI backend, no real artifacts. See `pkg/handler/echo`.
 
 ## What's out of scope (for now)
 
-- **Authorization** — what a verified caller is allowed to do.
-  Tracked separately; today every authenticated caller can
-  read/write everything.
+- **Per-coordinate authorization** — every reader in a namespace
+  can read every package in it, every writer can write to any.
+  Operators who need finer control plug in their own `Authorizer`
+  via `namespace.WithAuthzFactory` (OPA, Cedar, Casbin).
+- **Scoped-token issuance.** A planned `POST /admin/v1/tokens`
+  endpoint would take a verified OIDC token and mint a shorter-lived
+  ocifactory-audience token bound to a namespace and op; the wire
+  shape is open. Tracked in [`ROADMAP.md`](ROADMAP.md#phase-3--authauthz-extensibility).
 - **GitHub PATs / App tokens** — opaque, not OIDC. A future
   authenticator could validate them via `api.github.com/user`,
   but it has different perf characteristics; meanwhile the

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,14 +1,17 @@
 # Observability
 
 ocifactory exposes three operational endpoints and a Prometheus metrics
-surface so you can run it like a normal service.
+surface so you can run it like a normal service. Both `ocifactory serve`
+and `ocifactory admin serve` expose the same endpoints — they use the
+same wrapper (`handler.ObservabilityHandler`) so probes look identical
+across the two processes.
 
 ## Endpoints
 
 | Path | Purpose | Notes |
 |---|---|---|
 | `GET /healthz` | Liveness probe | Returns `200 ok` if the process is up. No backend call. |
-| `GET /readyz` | Readiness probe | Issues `HEAD /v2/` against the configured backend with a 2-second timeout. `200` if the backend answers `200` or `401` (challenge proves reachability); `503` otherwise. Result is cached for 1 second so probe storms don't fan out. |
+| `GET /readyz` | Readiness probe | Data plane (`serve`): issues `HEAD /v2/` against the configured backend with a 2-second timeout. Admin (`admin serve`): issues a namespace `Store.List` against the same 2-second timeout. `200` on success (backends answering `200` or `401` count — a challenge proves reachability); `503` otherwise. Result is cached for 1 second so probe storms don't fan out. The response body is JSON with `status`, `backend`, and the binary's `build` block (`version`, `commit`, `os_arch`) so multi-instance deployments are diagnosable per-pod. |
 | `GET /metrics` | Prometheus exposition | Path is configurable via `--metrics-path`. Disabled when `--enable-metrics=false`. |
 
 The endpoints live on the **same listener** as the rest of the service.
@@ -38,10 +41,13 @@ control on `/metrics`, front it with your reverse proxy.
 | `ocifactory_http_request_bytes_in_total` | counter | `format`, `op` |
 | `ocifactory_http_response_bytes_out_total` | counter | `format`, `op` |
 
-- `format` — the active `--repo-type` (`python`, `maven`, …). `unknown`
-  for the observability endpoints themselves.
+- `format` — the active `--repo-type` (`python`, `maven`, `npm`, …)
+  or `admin` for the control-plane service. `unknown` for the
+  observability endpoints themselves.
 - `op` — coarse verb. Either a per-route name set by the format
-  handler (`read`, `write`, `list` for python today) or a
+  handler (`read`, `write`, `list`; or `admin_namespaces_put` /
+  `admin_namespaces_get` / `admin_namespaces_delete` /
+  `admin_namespaces_list` on the admin service) or a
   method-derived fallback (`read` for GET/HEAD, `write` for
   PUT/POST/PATCH, `delete` for DELETE).
 - `status` — HTTP status code as a string.

--- a/docs/operations/partial-uploads.md
+++ b/docs/operations/partial-uploads.md
@@ -71,12 +71,13 @@ requests-2.31.0-cp310-cp310-manylinux_2_17_x86_64.whl
 requests-2.31.0-cp311-cp311-manylinux_2_17_x86_64.whl
 ```
 
-`twine` fires four independent POSTs against `/`. Suppose POST #3 fails
-mid-stream (say a TCP reset during the upload of the cp310 wheel).
-State on the backend:
+`twine` fires four independent POSTs against `/{namespace}/`. Suppose
+POST #3 fails mid-stream (say a TCP reset during the upload of the
+cp310 wheel). State on the backend (with `<ns>` standing for the
+namespace the URL targeted):
 
 ```
-packages/requests
+<ns>/packages/requests
 ├── 2.31.0                                (version anchor manifest)
 ├── _f_<sha256("2.31.0\0requests-2.31.0.tar.gz")>   ← file manifest, present
 ├── _f_<sha256("2.31.0\0…py3-none-any.whl")>        ← file manifest, present
@@ -96,13 +97,15 @@ state.
 
 ### Maven — partial `mvn deploy`
 
-A single release deploy fires roughly 12 PUTs (JAR + POM + sources +
-javadoc, each with two or three checksum companions, plus the
-artifact-level `maven-metadata.xml`). Say PUT #7 fails — network drop
-between sources upload and javadoc upload. State on the backend:
+A single release deploy fires roughly 12 PUTs against
+`/{namespace}/maven2/...` (JAR + POM + sources + javadoc, each with
+two or three checksum companions, plus the artifact-level
+`maven-metadata.xml`). Say PUT #7 fails — network drop between
+sources upload and javadoc upload. State on the backend (with `<ns>`
+standing for the namespace the URL targeted):
 
 ```
-com/example/foo
+<ns>/com/example/foo
 ├── 1.0.0                                (version anchor manifest)
 ├── _f_<…foo-1.0.0.jar>                  ← present
 ├── _f_<…foo-1.0.0.jar.sha1>             ← present

--- a/docs/repos/README.md
+++ b/docs/repos/README.md
@@ -16,10 +16,20 @@ using only the page.
 
 Cross-cutting concerns live elsewhere:
 
-- [`../auth.md`](../auth.md) — frontend (caller-to-ocifactory) and
-  backend (ocifactory-to-OCI) authentication.
+- [`../auth.md`](../auth.md) — frontend (caller-to-ocifactory)
+  authentication, per-namespace authorization model, and backend
+  (ocifactory-to-OCI) credentials.
+- [`../admin.md`](../admin.md) — control-plane namespace CRUD API
+  (the prerequisite for serving any data-plane URL).
 - [`../observability.md`](../observability.md) — `/healthz`,
   `/readyz`, `/metrics`, Prometheus metrics surface.
+- [`../operations/partial-uploads.md`](../operations/partial-uploads.md)
+  — what partially-failed `twine upload` / `mvn deploy` runs look
+  like on the backend and the right retry idiom per format.
+- [`../architecture/storage-model.md`](../architecture/storage-model.md)
+  — the on-OCI shape of a single published version: version
+  anchors, file manifests, alias manifests, the deterministic
+  `_f_*` file tag.
 - [`../ROADMAP.md`](../ROADMAP.md) — phased plan: Phase 1 core
   formats, Phase 2 deployability, Phase 3 authz, Phase 4 pull-through
   caching, Phase 5 add-ons.

--- a/docs/repos/_template.md
+++ b/docs/repos/_template.md
@@ -27,11 +27,24 @@ ocifactory serve \
   --port=8080
 ```
 
+Namespace creation via the admin service (every URL lives under a
+namespace — see [`../admin.md`](../admin.md)):
+
+```bash
+curl -X PUT https://ocifactory-admin.your-domain/admin/v1/namespaces/myteam \
+  -H 'content-type: application/json' \
+  -d '{"policy":{
+        "readers":[{"issuer":"https://accounts.google.com"}],
+        "writers":[{"issuer":"https://accounts.google.com",
+                    "email":"release-bot@myteam.example"}]}}'
+```
+
 Client configuration (`pip.conf`, `~/.m2/settings.xml`, `~/.npmrc`,
-`go env GOPROXY`, etc. — show the exact snippet operators paste):
+`go env GOPROXY`, etc. — show the exact snippet operators paste, with
+the namespace prefix in the URL):
 
 ```text
-# ... client config ...
+# ... client config pointing at https://ocifactory.your-domain/myteam/... ...
 ```
 
 > **Template note:** if there's a single operator gotcha that breaks
@@ -42,7 +55,13 @@ Client configuration (`pip.conf`, `~/.m2/settings.xml`, `~/.npmrc`,
 
 ## URL layout
 
-| Method | Path | Purpose |
+Every route lives under `/{namespace}/...` (and optionally a fixed
+format prefix after the namespace — e.g. `/{namespace}/maven2/...` —
+when needed for disambiguation). Document the per-route shape under
+the namespace prefix; requests to an unknown namespace return `404 Not
+Found`, requests whose policy denies return `403 Forbidden`.
+
+| Method | Path (under `/{namespace}/`) | Purpose |
 |---|---|---|
 | `GET …` | `/…` | … |
 | `PUT …` | `/…` | … |
@@ -50,13 +69,15 @@ Client configuration (`pip.conf`, `~/.m2/settings.xml`, `~/.npmrc`,
 Concrete examples for the most common deploys / fetches:
 
 ```
-GET /…
-PUT /…
+GET /myteam/…
+PUT /myteam/…
 ```
 
 Any path validation rules (`pkg/handler/<format>/paths.go` if you
 borrow the Maven pattern). Reject anything that could escape the OCI
-repo namespace at the handler boundary.
+repo namespace at the handler boundary; the data-plane wrapper's
+`resolveRepo` is the second line of defence but per-handler
+validation produces better error messages.
 
 ## Supported client commands
 
@@ -73,15 +94,22 @@ repo namespace at the handler boundary.
 
 | Client URL | OCI repo | OCI tag | Layer name |
 |---|---|---|---|
-| … | `<format>/<package>` | `<version>` | `<filename>` |
-| … | `index` | `<package>` | `<sentinel>` |
+| … | `<namespace>/<format>/<package>` | `<version>` | `<filename>` |
+| … | `<namespace>/index` | `<package>` | `<sentinel>` |
 
-`artifactType` = `application/vnd.ocifactory.<format>`.
+`artifactType` (base) = `application/vnd.ocifactory.<format>`. The
+data-plane wrapper adds the `<namespace>/` prefix to every OwningRepo
+transparently; per-format handlers address repos without the
+namespace and the wrapper joins them at request time. A separate
+`<namespace>/ocifactory-packages` repo is maintained by the wrapper
+itself — its tags enumerate every owning-repo the wrapper has written
+to, and the admin service's soft-delete consults it. Format handlers
+don't write there directly.
 
-> **Template note:** if you maintain an `index` repo for the "list all
-> packages" use case, document the sentinel layer's name and body
-> exactly. The Python handler's pattern is the reference — see
-> `docs/repos/python.md`.
+> **Template note:** if you maintain a per-format `index` repo for
+> the "list all packages" use case, document the sentinel layer's
+> name and body exactly. The Python handler's pattern is the
+> reference — see `docs/repos/python.md`.
 
 ## Protocol compliance
 
@@ -90,11 +118,11 @@ repo namespace at the handler boundary.
 | <core protocol feature> | ✅ Supported | … |
 | <optional feature> | ❌ Not supported | tracking issue |
 
-## Authentication
+## Authentication and authorization
 
 State whether every route is gated, or whether some routes are
-public-by-default (npm registry root, future Go module proxy
-listings). If there are public routes, list them explicitly.
+public-by-default (Go module proxy listings, anonymous-read
+mirrors). If there are public routes, list them explicitly.
 
 ```
 - All routes gated by pkg/auth.Middleware: yes / no
@@ -102,7 +130,13 @@ listings). If there are public routes, list them explicitly.
 - Outlier endpoints with their own auth contract (if any): /...
 ```
 
-See [`docs/auth.md`](../auth.md) for authenticator configuration.
+Describe per-op mapping (which client commands invoke `OpRead`
+versus `OpWrite`). The namespace's `Policy` (readers / writers
+`SubjectMatcher` lists) controls both — see
+[`docs/auth.md#namespace-authorization`](../auth.md#namespace-authorization).
+Note any granularity beyond per-namespace (almost certainly: none
+in v1; per-package authz is operator-pluggable via
+`namespace.WithAuthzFactory`).
 
 ## Operator knobs
 

--- a/docs/repos/maven.md
+++ b/docs/repos/maven.md
@@ -55,7 +55,20 @@ ocifactory serve \
 
 ## Quickstart
 
-After starting the server (above), configure `~/.m2/settings.xml`:
+After starting the server (above), create a namespace via the admin
+service (see [`../admin.md`](../admin.md)). Every Maven URL lives
+under `/{namespace}/maven2/...` — there is no implicit root namespace.
+
+```bash
+curl -X PUT https://ocifactory-admin.your-domain/admin/v1/namespaces/myteam \
+  -H 'content-type: application/json' \
+  -d '{"policy":{
+        "readers":[{"issuer":"https://accounts.google.com"}],
+        "writers":[{"issuer":"https://accounts.google.com",
+                    "email":"release-bot@myteam.example"}]}}'
+```
+
+Then configure `~/.m2/settings.xml`:
 
 ```xml
 <settings>
@@ -74,7 +87,7 @@ After starting the server (above), configure `~/.m2/settings.xml`:
       <repositories>
         <repository>
           <id>ocifactory</id>
-          <url>https://ocifactory.your-domain/</url>
+          <url>https://ocifactory.your-domain/myteam/maven2/</url>
         </repository>
       </repositories>
     </profile>
@@ -91,11 +104,11 @@ And in `pom.xml`:
 <distributionManagement>
   <repository>
     <id>ocifactory</id>
-    <url>https://ocifactory.your-domain/</url>
+    <url>https://ocifactory.your-domain/myteam/maven2/</url>
   </repository>
   <snapshotRepository>
     <id>ocifactory</id>
-    <url>https://ocifactory.your-domain/</url>
+    <url>https://ocifactory.your-domain/myteam/maven2/</url>
   </snapshotRepository>
 </distributionManagement>
 ```
@@ -106,16 +119,23 @@ The `password` is an OIDC ID token — there is no static-password path.
 
 ## URL layout
 
+Every route lives under `/{namespace}/maven2/...`. The `maven2/`
+segment after the namespace is a fixed format prefix — it lets one
+hostname route python, maven, and npm under disjoint paths per
+namespace without ambiguity. Requests to an unknown namespace return
+`404 Not Found`; requests whose verified OIDC subject doesn't match
+the namespace's `readers` / `writers` policy return `403 Forbidden`.
+
 All routes accept `PUT` and `POST` for upload, and `GET` and `HEAD`
 for resolve.
 
-| Path | Purpose |
+| Path (under `/{namespace}/maven2/`) | Purpose |
 |---|---|
 | `/{groupId}/{artifactId}/{version}/{filename}` | Regular artifact (jar, pom, sources, javadoc). |
 | `/{groupId}/{artifactId}/{version}/{filename}.{sha1,md5,sha256,sha512}` | Checksum companion. **Must arrive after the artifact it covers.** |
 | `/{groupId}/{artifactId}/{version}-SNAPSHOT/maven-metadata.xml` | Version-level snapshot metadata. Always overwritable (snapshot-mutable). |
 | `/{groupId}/{artifactId}/maven-metadata.xml` | Artifact-level metadata. Follows release-immutability semantics — see the [Snapshots vs releases](#snapshots-vs-releases-overwrite-semantics) section above. |
-| `/archetype-catalog.xml` | Global archetype catalog. |
+| `/archetype-catalog.xml` | Global archetype catalog (one per namespace). |
 
 `{groupId}` is the dotted Java group with `.` rewritten to `/`
 (e.g. `com.example.foo` → `/com/example/foo/`), matching standard
@@ -126,16 +146,16 @@ version segment.
 ### Concrete examples
 
 ```
-PUT /com/example/foo/1.0.0/foo-1.0.0.jar
-PUT /com/example/foo/1.0.0/foo-1.0.0.jar.sha1
-PUT /com/example/foo/1.0.0/foo-1.0.0.pom
-PUT /com/example/foo/1.0.0/foo-1.0.0.pom.sha1
-PUT /com/example/foo/maven-metadata.xml
-PUT /com/example/foo/maven-metadata.xml.sha1
+PUT /myteam/maven2/com/example/foo/1.0.0/foo-1.0.0.jar
+PUT /myteam/maven2/com/example/foo/1.0.0/foo-1.0.0.jar.sha1
+PUT /myteam/maven2/com/example/foo/1.0.0/foo-1.0.0.pom
+PUT /myteam/maven2/com/example/foo/1.0.0/foo-1.0.0.pom.sha1
+PUT /myteam/maven2/com/example/foo/maven-metadata.xml
+PUT /myteam/maven2/com/example/foo/maven-metadata.xml.sha1
 
 # Snapshot
-PUT /com/example/foo/1.1.0-SNAPSHOT/foo-1.1.0-20260101.123456-1.jar
-PUT /com/example/foo/1.1.0-SNAPSHOT/maven-metadata.xml
+PUT /myteam/maven2/com/example/foo/1.1.0-SNAPSHOT/foo-1.1.0-20260101.123456-1.jar
+PUT /myteam/maven2/com/example/foo/1.1.0-SNAPSHOT/maven-metadata.xml
 ```
 
 ## Path validation grammar
@@ -224,16 +244,26 @@ manifest tagged with the canonical tag, plus one file manifest per
 uploaded file (subject-linked to the anchor, addressable via the
 OCI 1.1 referrers API, and individually tagged with a deterministic
 `_f_<sha256>` for fast reads). The mapping from Maven URL to the tuple
-the file lands under:
+the file lands under (with `<ns>` standing for the URL's namespace
+segment):
 
 | Maven URL | OCI repo | Canonical tag | File name on the file manifest |
 |---|---|---|---|
-| `/{groupId}/{artifactId}/{version}/{filename}` | `{groupId}/{artifactId}` | `{version}` | `{filename}` |
-| `/{groupId}/{artifactId}/{version}-SNAPSHOT/maven-metadata.xml` | `{groupId}/{artifactId}` | `{version}-SNAPSHOT-metadata` | `maven-metadata.xml` |
-| `/{groupId}/{artifactId}/maven-metadata.xml` | `{groupId}/{artifactId}` | `metadata` | `maven-metadata.xml` |
-| `/archetype-catalog.xml` | `archetype` | `latest` | `archetype-catalog.xml` |
+| `/{ns}/maven2/{groupId}/{artifactId}/{version}/{filename}` | `<ns>/{groupId}/{artifactId}` | `{version}` | `{filename}` |
+| `/{ns}/maven2/{groupId}/{artifactId}/{version}-SNAPSHOT/maven-metadata.xml` | `<ns>/{groupId}/{artifactId}` | `{version}-SNAPSHOT-metadata` | `maven-metadata.xml` |
+| `/{ns}/maven2/{groupId}/{artifactId}/maven-metadata.xml` | `<ns>/{groupId}/{artifactId}` | `metadata` | `maven-metadata.xml` |
+| `/{ns}/maven2/archetype-catalog.xml` | `<ns>/archetype` | `latest` | `archetype-catalog.xml` |
 
 `{groupId}` keeps its slash form (`com/example/foo`), matching the URL.
+The namespace wrapper adds the `<ns>/` prefix transparently; the maven
+handler addresses repos as `{groupId}/{artifactId}` and the wrapper
+turns them into `<ns>/{groupId}/{artifactId}` before they hit the OCI
+backend.
+
+A fourth per-namespace repo, `<ns>/ocifactory-packages`, is maintained
+by the namespace wrapper itself — its tags enumerate every owning-repo
+the wrapper has written to. It backs the admin service's "namespace is
+empty" check on soft delete; operators don't write to it directly.
 
 The base `artifactType` is `application/vnd.ocifactory.maven` and
 ocifactory appends `.version`, `.file`, and `.alias` suffixes to
@@ -277,7 +307,7 @@ practice because checksum files arrive immediately after the artifact
 
 Reference: `pkg/handler/maven/checksum.go`.
 
-## Authentication
+## Authentication and authorization
 
 Every Maven route is gated by `pkg/auth.Middleware` — there are no
 public-by-default endpoints in the Maven format. The middleware chain
@@ -287,9 +317,19 @@ a `401 Unauthorized` before touching the OCI backend.
 Configure the authenticator via `--authn-*` (or `--disable-authn` for
 local dev). See [`docs/auth.md`](../auth.md) for the full table.
 
-Authorization (per-coordinate, per-operation policy) is **not**
-implemented yet — every authenticated caller can read and write every
-artifact. Tracked by [#49](https://github.com/yolocs/ocifactory/issues/49).
+Authorization is **per-namespace**: every read and write is checked
+against the namespace's `Policy` (the `readers` / `writers` matchers
+operators wrote when they created the namespace via the admin API).
+Authenticated callers whose `(issuer, sub, email, claims)` don't match
+any matcher get a `403 Forbidden`. Granularity is coarse — `OpRead`
+covers blob fetches and metadata reads, `OpWrite` covers every PUT/POST.
+There is no per-coordinate granularity today: every reader in a
+namespace can read every coordinate in it, every writer can write to
+any. Out-of-tree authorizers (OPA / Cedar / Casbin) plug in via
+`namespace.WithAuthzFactory` if you need finer control.
+
+See [`docs/auth.md`](../auth.md#namespace-authorization) for the
+policy model and matcher reference.
 
 ## Operator knobs
 

--- a/docs/repos/npm.md
+++ b/docs/repos/npm.md
@@ -28,6 +28,20 @@ ocifactory serve \
   --port=8080
 ```
 
+Create a namespace via the admin service (see
+[`../admin.md`](../admin.md)) — every npm URL lives under
+`/{namespace}/...`, there is no implicit root namespace:
+
+```bash
+curl -X PUT https://ocifactory-admin.your-domain/admin/v1/namespaces/myteam \
+  -H 'content-type: application/json' \
+  -d '{"policy":{
+        "readers":[{"issuer":"https://token.actions.githubusercontent.com",
+                    "sub_match":"repo:myorg/.*"}],
+        "writers":[{"issuer":"https://token.actions.githubusercontent.com",
+                    "sub_match":"repo:myorg/myapp:.*"}]}}'
+```
+
 Configure `~/.npmrc`:
 
 ```ini
@@ -50,9 +64,12 @@ npm install some-package
 
 Every route lives under `/{namespace}/` so the same ocifactory
 instance can host disjoint npm teams. `{namespace}` is what an
-operator chose via the admin namespace API; the per-team `~/.npmrc`
-points npm at `https://ocifactory.your-domain/{namespace}/` and every
-client request lands there.
+operator chose via the admin namespace API (see
+[`../admin.md`](../admin.md)); the per-team `~/.npmrc` points npm at
+`https://ocifactory.your-domain/{namespace}/` and every client request
+lands there. Requests to an unknown namespace return `404 Not Found`;
+requests whose verified OIDC subject doesn't match the namespace's
+`readers` / `writers` policy return `403 Forbidden`.
 
 | Method | Path (under `/{namespace}/`) | Purpose |
 |---|---|---|
@@ -106,13 +123,20 @@ go test -tags=integration ./pkg/handler/npm/...
 
 ## OCI storage layout
 
-Two OCI repositories per namespace under `--backend-registry`:
+Three OCI repositories per namespace under `--backend-registry`,
+prefixed with the namespace segment by the data-plane wrapper:
 
 | OCI repo | Canonical tags | What's stored |
 |---|---|---|
-| `packages/u/<name>` | `<version>` per release | A version anchor manifest tagged with `<version>`, plus two file manifests (tarball `<name>-<version>.tgz` and `package.json`) subject-linked to the anchor and addressable via the OCI 1.1 referrers API. Used for unscoped packages. |
-| `packages/s/<scope>/<name>` | `<version>` per release | Same shape; used for scoped (`@scope/name`) packages. |
-| `index` | `<encoded-name>` per package | A single sentinel layer (`name=present`, body=`"1"`). `ListTags("index")` is the package list. |
+| `<namespace>/packages/u/<name>` | `<version>` per release | A version anchor manifest tagged with `<version>`, plus two file manifests (tarball `<name>-<version>.tgz` and `package.json`) subject-linked to the anchor and addressable via the OCI 1.1 referrers API. Used for unscoped packages. |
+| `<namespace>/packages/s/<scope>/<name>` | `<version>` per release | Same shape; used for scoped (`@scope/name`) packages. |
+| `<namespace>/index` | `<encoded-name>` per package | A single sentinel layer (`name=present`, body=`"1"`). `ListTags("<namespace>/index")` is the namespace's package list. |
+
+A fourth per-namespace repo, `<namespace>/ocifactory-packages`, is
+maintained by the namespace wrapper itself — its tags enumerate every
+owning-repo the wrapper has recorded a write for. It backs the admin
+service's "namespace is empty" check on soft delete; operators don't
+write to it directly.
 
 Each file manifest also carries a deterministic `_f_<sha256>` tag so
 tarball downloads resolve in one round-trip.
@@ -174,7 +198,7 @@ The handler:
 6. Writes the per-package index sentinel if it's the first version.
 7. Returns `201 {"ok": true, "id": "<name>", "rev": "<server-token>"}`.
 
-## Authentication
+## Authentication and authorization
 
 Every npm route is gated by `pkg/auth.Middleware` — there are no
 public-by-default endpoints in the npm format. The middleware chain
@@ -184,10 +208,20 @@ a `401 Unauthorized` before touching the OCI backend.
 Configure the authenticator via `--authn-*` (or `--disable-authn` for
 local dev). See [`docs/auth.md`](../auth.md) for the full table.
 
-Authorization (per-package, per-operation policy) is **not**
-implemented yet — every authenticated caller in a namespace's
-reader / writer matchers can read and write every package in that
-namespace.
+Authorization is **per-namespace**: every read and write is checked
+against the namespace's `Policy` (the `readers` / `writers` matchers
+operators wrote when they created the namespace via the admin API).
+Authenticated callers whose `(issuer, sub, email, claims)` don't match
+any matcher get a `403 Forbidden`. Granularity is coarse — `OpRead`
+covers packument GETs, tarball downloads, and dist-tag listings;
+`OpWrite` covers publish and dist-tag add. There is no per-package
+granularity today: every reader in a namespace can read every package
+in it, every writer can publish any package in it. Out-of-tree
+authorizers (OPA / Cedar / Casbin) plug in via
+`namespace.WithAuthzFactory` if you need finer control.
+
+See [`docs/auth.md`](../auth.md#namespace-authorization) for the
+policy model and matcher reference.
 
 ## Operator knobs
 

--- a/docs/repos/python.md
+++ b/docs/repos/python.md
@@ -26,19 +26,32 @@ ocifactory serve \
   --port=8080
 ```
 
+Create a namespace via the admin service (see
+[`../admin.md`](../admin.md)). Every PyPI URL lives under
+`/{namespace}/...` — there is no implicit root namespace.
+
+```bash
+curl -X PUT https://ocifactory-admin.your-domain/admin/v1/namespaces/myteam \
+  -H 'content-type: application/json' \
+  -d '{"policy":{
+        "readers":[{"issuer":"https://accounts.google.com"}],
+        "writers":[{"issuer":"https://accounts.google.com",
+                    "email":"release-bot@myteam.example"}]}}'
+```
+
 Configure `pip`:
 
 ```ini
 # ~/.pip/pip.conf  (or pip.ini on Windows)
 [global]
-index-url = https://_oidc:${OCIFACTORY_TOKEN}@ocifactory.your-domain/simple/
+index-url = https://_oidc:${OCIFACTORY_TOKEN}@ocifactory.your-domain/myteam/simple/
 ```
 
 Configure `twine`:
 
 ```bash
 twine upload \
-  --repository-url https://ocifactory.your-domain/ \
+  --repository-url https://ocifactory.your-domain/myteam/ \
   --username _oidc \
   --password "$OCIFACTORY_TOKEN" \
   dist/*
@@ -51,11 +64,17 @@ ocifactory has no static-password path on purpose.
 
 ## URL layout
 
-| Method | Path | Purpose |
+Every route lives under `/{namespace}/...` — the namespace is the team /
+project / environment slot an operator created via the admin API. Requests
+to an unknown namespace return `404 Not Found`; requests whose verified
+OIDC subject doesn't match the namespace's `readers` or `writers` policy
+return `403 Forbidden`.
+
+| Method | Path (under `/{namespace}/`) | Purpose |
 |---|---|---|
 | `POST /` (or `PUT /`) | (multipart) | `twine upload` — accepts the legacy PyPI multipart form. |
-| `GET /simple/` | — | Root simple index: every package the registry knows about. |
-| `GET /simple/{pkg}/` | — | Per-package simple index: every file for `pkg`. |
+| `GET /simple/` | — | Root simple index: every package this namespace knows about. |
+| `GET /simple/{pkg}/` | — | Per-package simple index: every file for `pkg` in this namespace. |
 | `GET\|HEAD /packages/{pkg}/{version}/{filename}` | — | Download a wheel/sdist blob. |
 
 Trailing slashes are tolerated on `/simple` and `/simple/{pkg}` — both
@@ -116,12 +135,18 @@ property either ocifactory or PyPI provides.
 
 ## OCI storage layout
 
-Two OCI repositories under `--backend-registry`:
+Two OCI repositories **per namespace** under `--backend-registry`:
 
 | OCI repo | Canonical tags | What's stored |
 |---|---|---|
-| `packages/<pkg>` | `<version>` per release | A version anchor manifest tagged with `<version>`, plus one file manifest per uploaded wheel / sdist (subject-linked to the version anchor and addressable via the OCI 1.1 referrers API). Each file manifest also carries a deterministic `_f_<sha256>` tag so reads resolve in one round-trip. |
-| `index` | `<pkg>` per package | A single sentinel layer (`name=present`, body=`"1"`). The body is unused; `ListTags("index")` is the package list. |
+| `<namespace>/packages/<pkg>` | `<version>` per release | A version anchor manifest tagged with `<version>`, plus one file manifest per uploaded wheel / sdist (subject-linked to the version anchor and addressable via the OCI 1.1 referrers API). Each file manifest also carries a deterministic `_f_<sha256>` tag so reads resolve in one round-trip. |
+| `<namespace>/index` | `<pkg>` per package | A single sentinel layer (`name=present`, body=`"1"`). The body is unused; `ListTags("<namespace>/index")` is the package list for this namespace. |
+
+A third per-namespace repo, `<namespace>/ocifactory-packages`, is
+maintained by the data-plane namespace wrapper itself — its tags
+enumerate every OwningRepo the wrapper has recorded a write for, and
+it backs the admin service's "namespace is empty" check on soft
+delete. Operators don't write to it directly.
 
 `<pkg>` is always the PEP 503 normalised name. The base
 `artifactType` is `application/vnd.ocifactory.python` and ocifactory
@@ -159,7 +184,7 @@ verify the download against the OCI backend's digest without an extra
 round-trip. The JSON index emits the same digest under
 `files[].hashes.sha256`.
 
-## Authentication
+## Authentication and authorization
 
 Every PyPI route is gated by `pkg/auth.Middleware` — there are no
 public-by-default endpoints in the Python format. The middleware
@@ -169,9 +194,20 @@ gets a `401 Unauthorized` before touching the OCI backend.
 Configure the authenticator via `--authn-*` (or `--disable-authn` for
 local dev). See [`docs/auth.md`](../auth.md) for the full table.
 
-Authorization (per-package, per-operation policy) is **not** implemented
-yet — every authenticated caller can read and write every package.
-Tracked by [#49](https://github.com/yolocs/ocifactory/issues/49).
+Authorization is **per-namespace**: every read and write is checked
+against the namespace's `Policy` (the `readers` / `writers` matchers
+operators wrote when they created the namespace via the admin API).
+Authenticated callers whose `(issuer, sub, email, claims)` don't match
+any matcher get a `403 Forbidden`. Granularity is coarse — `OpRead`
+covers `/simple/...` listings and `/packages/.../<file>` blob fetches;
+`OpWrite` covers `POST /` (twine upload). There is no per-package
+granularity today: every reader in a namespace can read every package
+in it, every writer can write to any package in it. Out-of-tree
+authorizers (OPA / Cedar / Casbin) plug in via
+`namespace.WithAuthzFactory` if you need finer control.
+
+See [`docs/auth.md`](../auth.md#namespace-authorization) for the
+policy model and matcher reference.
 
 ## Operator knobs
 
@@ -185,27 +221,45 @@ Common server-wide flags (`--port`, `--backend-registry`, `--enable-metrics`,
 the `--authn-*` and `--backend-auth-*` families) are documented in
 [`docs/auth.md`](../auth.md) and [`docs/observability.md`](../observability.md).
 
-## Migration: pre-existing un-normalized data in the OCI backend
+## Migration: pre-existing data in the OCI backend
+
+Two migrations may apply.
+
+### 1. Pre-existing un-normalized package names
 
 The handler normalises package names at every entry point: writes
 canonicalise `Foo_Bar` → `foo-bar` before pushing, and reads
 canonicalise the requested name before looking up. **Reads of the
 un-normalized name are not aliased back to the canonical name.**
 
-Concretely: if you populated `packages/Foo_Bar:1.0` in your OCI backend
-before upgrading to a normalising ocifactory, `pip install Foo_Bar`
-will look for `packages/foo-bar:1.0` and 404. Two ways forward:
+Concretely: if you populated `<namespace>/packages/Foo_Bar:1.0` in your
+OCI backend before upgrading to a normalising ocifactory, `pip install
+Foo_Bar` will look for `<namespace>/packages/foo-bar:1.0` and 404. Two
+ways forward:
 
 1. **Re-upload** the affected versions (`twine upload`). The handler
    normalises on write, so the new manifest lands at
-   `packages/foo-bar:1.0`. The old `packages/Foo_Bar` repo is harmless
-   but unreachable; clean it up via your OCI backend's tooling.
+   `<namespace>/packages/foo-bar:1.0`. The old `Foo_Bar` repo is
+   harmless but unreachable; clean it up via your OCI backend's
+   tooling.
 2. **Rename in place** at the OCI layer. Out of ocifactory's scope —
    doable with `oras cp` against your backend, but verify the resulting
    manifest's `artifactType` annotation still reads
-   `application/vnd.ocifactory.python`.
+   `application/vnd.ocifactory.python.version` /
+   `.file` / `.alias`.
 
 For new deployments this never matters: every write canonicalises.
+
+### 2. Data published before the namespace prefix
+
+Earlier ocifactory versions served PyPI URLs at the registry root
+(`/simple/`, `/packages/...`). Today every URL lives under a
+namespace. If you have `packages/<pkg>` repos in your OCI backend left
+over from that era, point ocifactory at them by `oras cp`-ing them
+under a namespace prefix (`<namespace>/packages/<pkg>`) and creating
+the matching namespace via the admin API. The on-manifest shape (file
+manifests + version anchors + alias manifests) is unchanged across
+this migration — only the repo path moved.
 
 ## Limitations
 


### PR DESCRIPTION
The docs lagged several large landings: per-namespace URL prefixes for every
format (python and npm at /{namespace}/..., maven at /{namespace}/maven2/...),
the per-namespace authorization model in pkg/namespace, the admin control-plane
service, and the Goreleaser-based release pipeline. Update README.md, AGENTS.md
(= CLAUDE.md), ROADMAP, the per-repo docs, auth.md (new namespace-authorization
section), admin.md (policy / SubjectMatcher reference), observability.md,
operations/partial-uploads.md, architecture/storage-model.md, and the new-format
template so an operator reading top-to-bottom no longer hits stale claims.

https://claude.ai/code/session_01KKfooFe6FEDBAobfkBjPaX