### PR TITLE
Add namespace mode + proxy spec block

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -71,6 +71,7 @@ Names must satisfy:
 ```json
 {
   "schema_version": 1,
+  "mode": "hosted",
   "policy": {
     "readers": [
       {"issuer": "https://accounts.google.com"}
@@ -80,10 +81,17 @@ Names must satisfy:
        "email": "release-bot@myteam.example"}
     ]
   },
+  "proxy": { /* only honored when mode == "proxy"; see below */ },
   "format": { /* reserved for future format-specific knobs */ }
 }
 ```
 
+- `mode` selects the namespace's operating mode. `"hosted"` (the
+  default — empty resolves to hosted) stores artifacts uploaded by
+  clients and serves them back; `"proxy"` mirrors an upstream
+  registry on demand. Existing namespaces written before this field
+  was introduced load unchanged. On write, an explicit `"hosted"`
+  collapses to the empty default to keep the on-disk shape compact.
 - `policy.readers` / `policy.writers` are independent
   `SubjectMatcher` lists. **An entirely empty policy is deny-all** —
   a caller is allowed to perform an op only if at least one matcher
@@ -95,6 +103,17 @@ Names must satisfy:
   your pattern already starts with `^` or ends with `$`, the anchor
   isn't duplicated. See [`auth.md`](auth.md#subjectmatcher-reference)
   for the full reference and worked examples.
+- `proxy.upstream` is the canonical URL of the upstream registry the
+  namespace mirrors (e.g. `https://pypi.org`,
+  `https://registry.npmjs.org`, `https://repo1.maven.org/maven2`).
+  Required when `mode` is `"proxy"`; must parse as an absolute
+  `http`/`https` URL. A `proxy` block on a hosted namespace is
+  rejected at validation.
+- `proxy.filters` is the ordered filter chain applied before any
+  upstream call (allowlist / denylist / publish-time delay). The
+  concrete shape lands in a follow-up issue; today ocifactory accepts
+  and roundtrips arbitrary filter JSON so an operator's spec written
+  for a newer ocifactory survives older binaries.
 - `format` is reserved for future format-specific knobs; ocifactory
   preserves it across roundtrips so a newer ocifactory's keys aren't
   silently dropped by an older one.
@@ -113,6 +132,31 @@ curl -X PUT https://ocifactory-admin.your-domain/admin/v1/namespaces/myteam \
 
 Response: `201 Created` with the persisted document (including the
 `schema_version: 1` ocifactory stamped on write).
+
+### Worked example — create a proxy namespace
+
+A proxy namespace mirrors an upstream registry on demand. The data
+plane will not auto-discover this — every URL still lives under
+`/{namespace}/...`, but reads to it fetch from `proxy.upstream`
+through the per-format proxy code path (which lands in follow-up
+issues).
+
+```bash
+curl -X PUT https://ocifactory-admin.your-domain/admin/v1/namespaces/pypi \
+  -H 'content-type: application/json' \
+  -d '{
+        "mode": "proxy",
+        "proxy": {"upstream": "https://pypi.org"},
+        "policy": {
+          "readers":[{"issuer":"https://token.actions.githubusercontent.com",
+                      "sub_match":"repo:myorg/.+"}]
+        }
+      }'
+```
+
+Response: `201 Created`. Validation rejects `mode: "proxy"` without a
+parseable `proxy.upstream`, and rejects a `proxy` block on a hosted
+namespace (empty `mode` or explicit `"hosted"`).
 
 ### Policy propagation
 

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -71,7 +71,7 @@ Names must satisfy:
 ```json
 {
   "schema_version": 1,
-  "mode": "hosted",
+  "mode": "proxy",
   "policy": {
     "readers": [
       {"issuer": "https://accounts.google.com"}
@@ -87,11 +87,13 @@ Names must satisfy:
 ```
 
 - `mode` selects the namespace's operating mode. `"hosted"` (the
-  default — empty resolves to hosted) stores artifacts uploaded by
-  clients and serves them back; `"proxy"` mirrors an upstream
-  registry on demand. Existing namespaces written before this field
-  was introduced load unchanged. On write, an explicit `"hosted"`
-  collapses to the empty default to keep the on-disk shape compact.
+  default) stores artifacts uploaded by clients and serves them back;
+  `"proxy"` mirrors an upstream registry on demand. The hosted
+  default is encoded by omitting the field — ocifactory canonicalises
+  an explicit `"hosted"` to the empty default on write, so a hosted
+  namespace's persisted body never contains a `mode` key. Subsequent
+  `GET` reflects the canonical form. Namespaces written before this
+  field was introduced load unchanged.
 - `policy.readers` / `policy.writers` are independent
   `SubjectMatcher` lists. **An entirely empty policy is deny-all** —
   a caller is allowed to perform an op only if at least one matcher
@@ -155,8 +157,8 @@ curl -X PUT https://ocifactory-admin.your-domain/admin/v1/namespaces/pypi \
 ```
 
 Response: `201 Created`. Validation rejects `mode: "proxy"` without a
-parseable `proxy.upstream`, and rejects a `proxy` block on a hosted
-namespace (empty `mode` or explicit `"hosted"`).
+parseable `proxy.upstream`, and rejects a non-empty `proxy` block on
+a hosted namespace.
 
 ### Policy propagation
 

--- a/pkg/handler/admin/handler.go
+++ b/pkg/handler/admin/handler.go
@@ -174,6 +174,7 @@ func writeAdminError(ctx context.Context, w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, namespace.ErrInvalidName),
 		errors.Is(err, namespace.ErrInvalidPolicy),
+		errors.Is(err, namespace.ErrInvalidProxy),
 		errors.Is(err, namespace.ErrUnsupportedSchemaVersion):
 		writeJSON(w, http.StatusBadRequest, errorResponse{Error: err.Error()})
 	case errors.Is(err, namespace.ErrNotFound):

--- a/pkg/handler/admin/handler_test.go
+++ b/pkg/handler/admin/handler_test.go
@@ -119,6 +119,33 @@ func TestHandler_NamespaceCRUD(t *testing.T) {
 			wantBody:   map[string]string{"error": "invalid proxy: proxy block must be empty on mode \"hosted\""},
 		},
 		{
+			// Filter is an opaque json.RawMessage today (concrete shape
+			// lands in #110), so unknown keys inside a filter object
+			// must NOT trip the DisallowUnknownFields top-level guard —
+			// otherwise an older binary would reject a body written by
+			// a newer binary that added typed filter fields. Pin that
+			// property here so a future refactor can't silently break
+			// the forward-compat contract.
+			name:       "put proxy with future filter fields",
+			method:     http.MethodPut,
+			path:       "/admin/v1/namespaces/futureproxy",
+			rawBody:    `{"mode":"proxy","proxy":{"upstream":"https://pypi.org","filters":[{"future_filter_field":true,"nested":{"k":"v"}}]}}`,
+			wantStatus: http.StatusCreated,
+			wantBody: &namespace.Namespace{
+				Name: "futureproxy",
+				Spec: namespace.Spec{
+					SchemaVersion: namespace.CurrentSchemaVersion,
+					Mode:          namespace.ModeProxy,
+					Proxy: namespace.Proxy{
+						Upstream: "https://pypi.org",
+						Filters: []namespace.Filter{
+							[]byte(`{"future_filter_field":true,"nested":{"k":"v"}}`),
+						},
+					},
+				},
+			},
+		},
+		{
 			name:       "put malformed json",
 			method:     http.MethodPut,
 			path:       "/admin/v1/namespaces/badjson",

--- a/pkg/handler/admin/handler_test.go
+++ b/pkg/handler/admin/handler_test.go
@@ -85,6 +85,40 @@ func TestHandler_NamespaceCRUD(t *testing.T) {
 			wantBody:   map[string]string{"error": "readers[0]: invalid policy: matcher must populate at least one field"},
 		},
 		{
+			name:   "put proxy namespace",
+			method: http.MethodPut,
+			path:   "/admin/v1/namespaces/pypi-proxy",
+			body: namespace.Spec{
+				Mode:  namespace.ModeProxy,
+				Proxy: namespace.Proxy{Upstream: "https://pypi.org"},
+			},
+			wantStatus: http.StatusCreated,
+			wantBody: &namespace.Namespace{
+				Name: "pypi-proxy",
+				Spec: namespace.Spec{
+					SchemaVersion: namespace.CurrentSchemaVersion,
+					Mode:          namespace.ModeProxy,
+					Proxy:         namespace.Proxy{Upstream: "https://pypi.org"},
+				},
+			},
+		},
+		{
+			name:       "put proxy without upstream",
+			method:     http.MethodPut,
+			path:       "/admin/v1/namespaces/badproxy",
+			rawBody:    `{"mode":"proxy"}`,
+			wantStatus: http.StatusBadRequest,
+			wantBody:   map[string]string{"error": "invalid proxy: upstream is required on mode \"proxy\""},
+		},
+		{
+			name:       "put hosted with proxy block",
+			method:     http.MethodPut,
+			path:       "/admin/v1/namespaces/badhosted",
+			rawBody:    `{"proxy":{"upstream":"https://pypi.org"}}`,
+			wantStatus: http.StatusBadRequest,
+			wantBody:   map[string]string{"error": "invalid proxy: proxy block must be empty on mode \"hosted\""},
+		},
+		{
 			name:       "put malformed json",
 			method:     http.MethodPut,
 			path:       "/admin/v1/namespaces/badjson",

--- a/pkg/namespace/namespace.go
+++ b/pkg/namespace/namespace.go
@@ -39,12 +39,25 @@ type Spec struct {
 	// than silently dropping fields an older binary can't see.
 	SchemaVersion int `json:"schema_version,omitempty"`
 
+	// Mode selects the namespace's operating mode. [ModeHosted] is
+	// the historical (and only pre-Phase-4) behaviour; [ModeProxy]
+	// turns the namespace into a pull-through mirror of [Proxy.Upstream].
+	// Empty resolves to [ModeHosted] so existing namespaces load
+	// unchanged; [Spec.Normalize] canonicalises an explicit "hosted"
+	// back to empty to keep the on-disk shape compact.
+	Mode string `json:"mode,omitempty"`
+
 	// Policy is the authz block. An empty Policy is deny-all.
 	//
 	// omitzero (Go 1.24+) is required here: omitempty does not omit
 	// a zero-value struct, which would lock "policy":{} into the
 	// on-disk shape for every namespace that hasn't set a policy.
 	Policy Policy `json:"policy,omitzero"`
+
+	// Proxy is the pull-through proxy block. Only honored when [Mode]
+	// is [ModeProxy]; presence on a hosted namespace is rejected by
+	// [Spec.Validate].
+	Proxy Proxy `json:"proxy,omitzero"`
 
 	// Format is reserved for future format-specific knobs. Preserved
 	// across roundtrips so a newer ocifactory's keys aren't silently
@@ -64,15 +77,23 @@ func (s *Spec) Validate() error {
 	if v > CurrentSchemaVersion {
 		return fmt.Errorf("%w %d (this ocifactory understands up to %d)", ErrUnsupportedSchemaVersion, v, CurrentSchemaVersion)
 	}
-	return s.Policy.Validate()
+	if err := s.Policy.Validate(); err != nil {
+		return err
+	}
+	return s.Proxy.Validate(s.Mode)
 }
 
-// Normalize stamps [CurrentSchemaVersion] onto s. The admin write path
-// calls it before persisting so every body on disk carries an explicit
-// version. Idempotent.
+// Normalize stamps [CurrentSchemaVersion] onto s and canonicalises the
+// mode field so the on-disk shape stays compact for hosted namespaces
+// (explicit "hosted" collapses to empty, which loads back as
+// [ModeHosted] by default). The admin write path calls Normalize
+// before persisting. Idempotent.
 func (s *Spec) Normalize() {
 	if s == nil {
 		return
 	}
 	s.SchemaVersion = CurrentSchemaVersion
+	if s.Mode == ModeHosted {
+		s.Mode = ""
+	}
 }

--- a/pkg/namespace/proxy.go
+++ b/pkg/namespace/proxy.go
@@ -1,0 +1,84 @@
+package namespace
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// ModeHosted is the default namespace mode. A hosted namespace stores
+// artifacts uploaded by clients and serves them back; it never reaches
+// out to an upstream registry. An empty [Spec.Mode] resolves to
+// [ModeHosted] so namespaces written before this field was introduced
+// continue to load unchanged.
+const ModeHosted = "hosted"
+
+// ModeProxy is the pull-through proxy namespace mode. A proxy namespace
+// fetches artifacts on demand from [Proxy.Upstream] and caches them in
+// the same OCI-backed shape as a hosted namespace.
+const ModeProxy = "proxy"
+
+// ErrInvalidProxy is the sentinel for [Proxy.Validate] failures. The
+// admin handler maps it to HTTP 400.
+var ErrInvalidProxy = errors.New("invalid proxy")
+
+// Proxy is the pull-through proxy block of a [Spec]. It is only
+// honored when [Spec.Mode] is [ModeProxy]; presence on a hosted
+// namespace is a validation error.
+type Proxy struct {
+	// Upstream is the canonical URL of the upstream registry this
+	// namespace mirrors (e.g. "https://pypi.org",
+	// "https://registry.npmjs.org", "https://repo1.maven.org/maven2").
+	// Required when [Spec.Mode] is [ModeProxy]; the value must parse
+	// as an absolute URL.
+	Upstream string `json:"upstream,omitempty"`
+
+	// Filters is the ordered filter chain applied before any upstream
+	// call. First deny wins.
+	//
+	// The concrete element shape will land in #110; for now Filter is
+	// an opaque JSON value so older binaries roundtrip future filter
+	// content unchanged.
+	Filters []Filter `json:"filters,omitempty"`
+}
+
+// Filter is one element of the proxy filter chain. The concrete shape
+// is defined in #110; until then it is a passthrough JSON value so
+// older binaries can roundtrip future filter content without dropping
+// it on a read/write cycle.
+type Filter = json.RawMessage
+
+// Validate returns nil iff p is consistent with mode: when mode is
+// [ModeProxy], Upstream must be a parseable absolute URL; when mode is
+// hosted (empty or [ModeHosted]), no proxy fields may be populated.
+// Errors wrap [ErrInvalidProxy].
+func (p *Proxy) Validate(mode string) error {
+	if p == nil {
+		p = &Proxy{}
+	}
+	hosted := mode == "" || mode == ModeHosted
+	if hosted {
+		if p.Upstream != "" || len(p.Filters) > 0 {
+			return fmt.Errorf("%w: proxy block must be empty on mode %q", ErrInvalidProxy, ModeHosted)
+		}
+		return nil
+	}
+	if mode != ModeProxy {
+		return fmt.Errorf("%w: unknown mode %q (want %q or %q)", ErrInvalidProxy, mode, ModeHosted, ModeProxy)
+	}
+	if p.Upstream == "" {
+		return fmt.Errorf("%w: upstream is required on mode %q", ErrInvalidProxy, ModeProxy)
+	}
+	u, err := url.Parse(p.Upstream)
+	if err != nil {
+		return fmt.Errorf("%w: upstream %q: %v", ErrInvalidProxy, p.Upstream, err)
+	}
+	if !u.IsAbs() || u.Host == "" {
+		return fmt.Errorf("%w: upstream %q must be an absolute URL with a host", ErrInvalidProxy, p.Upstream)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("%w: upstream %q scheme must be http or https", ErrInvalidProxy, p.Upstream)
+	}
+	return nil
+}

--- a/pkg/namespace/spec_test.go
+++ b/pkg/namespace/spec_test.go
@@ -212,14 +212,17 @@ func TestSpec_Validate_SchemaVersion(t *testing.T) {
 
 // TestSpec_Validate_ModeAndProxy covers the Mode/Proxy validation
 // rules: hosted (empty + explicit) accepts no proxy block; proxy
-// requires an absolute http(s) upstream URL.
+// requires an absolute http(s) upstream URL. wantMsgContains pins the
+// distinct validation path so a regression that returns the wrong
+// branch's message can't hide behind the shared sentinel.
 func TestSpec_Validate_ModeAndProxy(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
-		spec    Spec
-		wantErr error
+		name            string
+		spec            Spec
+		wantErr         error
+		wantMsgContains string
 	}{
 		{
 			name: "empty-mode-no-proxy-ok",
@@ -244,14 +247,16 @@ func TestSpec_Validate_ModeAndProxy(t *testing.T) {
 			},
 		},
 		{
-			name:    "unknown-mode",
-			spec:    Spec{Mode: "virtual"},
-			wantErr: ErrInvalidProxy,
+			name:            "unknown-mode",
+			spec:            Spec{Mode: "virtual"},
+			wantErr:         ErrInvalidProxy,
+			wantMsgContains: `unknown mode "virtual"`,
 		},
 		{
-			name:    "proxy-without-upstream",
-			spec:    Spec{Mode: ModeProxy},
-			wantErr: ErrInvalidProxy,
+			name:            "proxy-without-upstream",
+			spec:            Spec{Mode: ModeProxy},
+			wantErr:         ErrInvalidProxy,
+			wantMsgContains: "upstream is required",
 		},
 		{
 			name: "proxy-with-empty-upstream-and-filters",
@@ -261,7 +266,8 @@ func TestSpec_Validate_ModeAndProxy(t *testing.T) {
 					[]byte(`{"type":"allowlist"}`),
 				}},
 			},
-			wantErr: ErrInvalidProxy,
+			wantErr:         ErrInvalidProxy,
+			wantMsgContains: "upstream is required",
 		},
 		{
 			name: "hosted-rejects-proxy-block",
@@ -269,21 +275,24 @@ func TestSpec_Validate_ModeAndProxy(t *testing.T) {
 				Mode:  ModeHosted,
 				Proxy: Proxy{Upstream: "https://pypi.org"},
 			},
-			wantErr: ErrInvalidProxy,
+			wantErr:         ErrInvalidProxy,
+			wantMsgContains: "proxy block must be empty",
 		},
 		{
 			name: "hosted-default-rejects-proxy-block",
 			spec: Spec{
 				Proxy: Proxy{Upstream: "https://pypi.org"},
 			},
-			wantErr: ErrInvalidProxy,
+			wantErr:         ErrInvalidProxy,
+			wantMsgContains: "proxy block must be empty",
 		},
 		{
 			name: "hosted-rejects-proxy-filters",
 			spec: Spec{
 				Proxy: Proxy{Filters: []Filter{[]byte(`{}`)}},
 			},
-			wantErr: ErrInvalidProxy,
+			wantErr:         ErrInvalidProxy,
+			wantMsgContains: "proxy block must be empty",
 		},
 		{
 			name: "proxy-upstream-must-be-absolute",
@@ -291,7 +300,8 @@ func TestSpec_Validate_ModeAndProxy(t *testing.T) {
 				Mode:  ModeProxy,
 				Proxy: Proxy{Upstream: "/pypi.org"},
 			},
-			wantErr: ErrInvalidProxy,
+			wantErr:         ErrInvalidProxy,
+			wantMsgContains: "must be an absolute URL",
 		},
 		{
 			name: "proxy-upstream-rejects-non-http-scheme",
@@ -299,7 +309,8 @@ func TestSpec_Validate_ModeAndProxy(t *testing.T) {
 				Mode:  ModeProxy,
 				Proxy: Proxy{Upstream: "ftp://pypi.org"},
 			},
-			wantErr: ErrInvalidProxy,
+			wantErr:         ErrInvalidProxy,
+			wantMsgContains: "scheme must be http or https",
 		},
 		{
 			name: "proxy-upstream-rejects-unparseable",
@@ -307,7 +318,8 @@ func TestSpec_Validate_ModeAndProxy(t *testing.T) {
 				Mode:  ModeProxy,
 				Proxy: Proxy{Upstream: "http://[::1"},
 			},
-			wantErr: ErrInvalidProxy,
+			wantErr:         ErrInvalidProxy,
+			wantMsgContains: `upstream "http://[::1"`,
 		},
 	}
 
@@ -324,6 +336,9 @@ func TestSpec_Validate_ModeAndProxy(t *testing.T) {
 			}
 			if !errors.Is(err, tc.wantErr) {
 				t.Fatalf("Validate() error %v, want errors.Is %v", err, tc.wantErr)
+			}
+			if tc.wantMsgContains != "" && !strings.Contains(err.Error(), tc.wantMsgContains) {
+				t.Errorf("Validate() error %q missing substring %q", err.Error(), tc.wantMsgContains)
 			}
 		})
 	}

--- a/pkg/namespace/spec_test.go
+++ b/pkg/namespace/spec_test.go
@@ -101,6 +101,37 @@ func TestSpec_JSONRoundtrip(t *testing.T) {
 			},
 			want: `{"schema_version":1,"policy":{"readers":[{"email":"alice@example.com"}]}}`,
 		},
+		{
+			// "Empty" above already covers the hosted-by-default case
+			// (Mode == "" resolves to hosted on Validate); this case
+			// pins the explicit form so a client that opts into
+			// "mode":"hosted" gets the same on-disk shape on read.
+			name: "hosted-mode-explicit",
+			spec: Spec{Mode: ModeHosted},
+			want: `{"mode":"hosted"}`,
+		},
+		{
+			name: "proxy-mode-upstream-only",
+			spec: Spec{
+				Mode:  ModeProxy,
+				Proxy: Proxy{Upstream: "https://pypi.org"},
+			},
+			want: `{"mode":"proxy","proxy":{"upstream":"https://pypi.org"}}`,
+		},
+		{
+			name: "proxy-mode-full-block",
+			spec: Spec{
+				Mode: ModeProxy,
+				Proxy: Proxy{
+					Upstream: "https://registry.npmjs.org",
+					Filters: []Filter{
+						json.RawMessage(`{"type":"allowlist","patterns":["@myorg/*"]}`),
+						json.RawMessage(`{"type":"delay","min_age":"24h"}`),
+					},
+				},
+			},
+			want: `{"mode":"proxy","proxy":{"upstream":"https://registry.npmjs.org","filters":[{"type":"allowlist","patterns":["@myorg/*"]},{"type":"delay","min_age":"24h"}]}}`,
+		},
 	}
 
 	for _, tc := range tests {
@@ -174,6 +205,172 @@ func TestSpec_Validate_SchemaVersion(t *testing.T) {
 			// this binary understands so the upgrade path is obvious.
 			if msg := err.Error(); !strings.Contains(msg, "understands up to") {
 				t.Errorf("Validate() error %q missing supported-max hint", msg)
+			}
+		})
+	}
+}
+
+// TestSpec_Validate_ModeAndProxy covers the Mode/Proxy validation
+// rules: hosted (empty + explicit) accepts no proxy block; proxy
+// requires an absolute http(s) upstream URL.
+func TestSpec_Validate_ModeAndProxy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		spec    Spec
+		wantErr error
+	}{
+		{
+			name: "empty-mode-no-proxy-ok",
+			spec: Spec{},
+		},
+		{
+			name: "explicit-hosted-no-proxy-ok",
+			spec: Spec{Mode: ModeHosted},
+		},
+		{
+			name: "proxy-with-upstream-ok",
+			spec: Spec{
+				Mode:  ModeProxy,
+				Proxy: Proxy{Upstream: "https://pypi.org"},
+			},
+		},
+		{
+			name: "proxy-with-http-upstream-ok",
+			spec: Spec{
+				Mode:  ModeProxy,
+				Proxy: Proxy{Upstream: "http://internal-mirror.example.test"},
+			},
+		},
+		{
+			name:    "unknown-mode",
+			spec:    Spec{Mode: "virtual"},
+			wantErr: ErrInvalidProxy,
+		},
+		{
+			name:    "proxy-without-upstream",
+			spec:    Spec{Mode: ModeProxy},
+			wantErr: ErrInvalidProxy,
+		},
+		{
+			name: "proxy-with-empty-upstream-and-filters",
+			spec: Spec{
+				Mode: ModeProxy,
+				Proxy: Proxy{Filters: []Filter{
+					[]byte(`{"type":"allowlist"}`),
+				}},
+			},
+			wantErr: ErrInvalidProxy,
+		},
+		{
+			name: "hosted-rejects-proxy-block",
+			spec: Spec{
+				Mode:  ModeHosted,
+				Proxy: Proxy{Upstream: "https://pypi.org"},
+			},
+			wantErr: ErrInvalidProxy,
+		},
+		{
+			name: "hosted-default-rejects-proxy-block",
+			spec: Spec{
+				Proxy: Proxy{Upstream: "https://pypi.org"},
+			},
+			wantErr: ErrInvalidProxy,
+		},
+		{
+			name: "hosted-rejects-proxy-filters",
+			spec: Spec{
+				Proxy: Proxy{Filters: []Filter{[]byte(`{}`)}},
+			},
+			wantErr: ErrInvalidProxy,
+		},
+		{
+			name: "proxy-upstream-must-be-absolute",
+			spec: Spec{
+				Mode:  ModeProxy,
+				Proxy: Proxy{Upstream: "/pypi.org"},
+			},
+			wantErr: ErrInvalidProxy,
+		},
+		{
+			name: "proxy-upstream-rejects-non-http-scheme",
+			spec: Spec{
+				Mode:  ModeProxy,
+				Proxy: Proxy{Upstream: "ftp://pypi.org"},
+			},
+			wantErr: ErrInvalidProxy,
+		},
+		{
+			name: "proxy-upstream-rejects-unparseable",
+			spec: Spec{
+				Mode:  ModeProxy,
+				Proxy: Proxy{Upstream: "http://[::1"},
+			},
+			wantErr: ErrInvalidProxy,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.spec.Validate()
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Fatalf("Validate() = %v, want nil", err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("Validate() error %v, want errors.Is %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestSpec_Normalize_ModeCanonical pins the on-disk-shape
+// canonicalisation: explicit Mode "hosted" collapses to empty so the
+// persisted body for a hosted namespace stays compact (just
+// {"schema_version":1} in the common case), while "proxy" survives.
+func TestSpec_Normalize_ModeCanonical(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   Spec
+		want Spec
+	}{
+		{
+			name: "explicit-hosted-collapses",
+			in:   Spec{Mode: ModeHosted},
+			want: Spec{SchemaVersion: CurrentSchemaVersion},
+		},
+		{
+			name: "proxy-mode-preserved",
+			in:   Spec{Mode: ModeProxy, Proxy: Proxy{Upstream: "https://pypi.org"}},
+			want: Spec{SchemaVersion: CurrentSchemaVersion, Mode: ModeProxy, Proxy: Proxy{Upstream: "https://pypi.org"}},
+		},
+		{
+			name: "empty-mode-stays-empty",
+			in:   Spec{},
+			want: Spec{SchemaVersion: CurrentSchemaVersion},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tc.in
+			got.Normalize()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Normalize() mismatch (-want +got):\n%s", diff)
+			}
+			// Idempotent.
+			got.Normalize()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Normalize() second pass mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Adds the data-model foundation for proxy namespaces. namespace.Spec
gains a `mode` field ("hosted" | "proxy"; empty resolves to "hosted"
so existing bodies load unchanged) and a `proxy` block carrying the
upstream URL and an opaque filter chain (concrete filter shape lands
in a follow-up). Validation rejects mode "proxy" without an absolute
http(s) upstream URL and rejects any proxy block on a hosted
namespace. Normalize canonicalises explicit "hosted" to empty so the
on-disk shape for hosted namespaces stays compact.

Wires the new fields through admin CRUD (no API shape change — the
existing decode-validate-normalize flow picks them up), maps the new
ErrInvalidProxy sentinel to HTTP 400, and documents the proxy shape
plus a worked example in docs/admin.md.

No schema_version bump: the new fields are additive and
backwards-readable.

Closes #108