### PR TITLE
Add pkg/proxy/filter: Filter interface + allowlist/denylist/delay

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -111,11 +111,10 @@ Names must satisfy:
   Required when `mode` is `"proxy"`; must parse as an absolute
   `http`/`https` URL. A `proxy` block on a hosted namespace is
   rejected at validation.
-- `proxy.filters` is the ordered filter chain applied before any
-  upstream call (allowlist / denylist / publish-time delay). The
-  concrete shape lands in a follow-up issue; today ocifactory accepts
-  and roundtrips arbitrary filter JSON so an operator's spec written
-  for a newer ocifactory survives older binaries.
+- `proxy.filters` is the ordered filter chain applied to upstream
+  file downloads (allow / deny / publish-time delay). Index requests
+  bypass the chain. See [`docs/proxy/filter-policy.md`](proxy/filter-policy.md)
+  for the policy semantics and config shapes.
 - `format` is reserved for future format-specific knobs; ocifactory
   preserves it across roundtrips so a newer ocifactory's keys aren't
   silently dropped by an older one.

--- a/docs/proxy/filter-policy.md
+++ b/docs/proxy/filter-policy.md
@@ -1,0 +1,166 @@
+# Proxy filter policy
+
+This doc describes how proxy namespaces decide whether to fetch and
+serve a given upstream package version. Filters apply only to **file
+downloads** — index requests are always passed through unfiltered.
+
+## Where filters live
+
+Filters are configured on a proxy namespace's `Spec.proxy.filters`:
+
+```json
+{
+  "mode": "proxy",
+  "proxy": {
+    "upstream": "https://registry.npmjs.org",
+    "filters": [
+      {"kind": "allow", "patterns": ["@myorg/*"]},
+      {"kind": "deny", "rules": [{"package": "log4j-core", "version": "2.14.*"}]},
+      {"kind": "delay", "min_age": "24h"}
+    ]
+  }
+}
+```
+
+The chain is an **ordered** list. Each filter is one of three kinds:
+
+| Kind | What it does |
+|---|---|
+| `allow` | If the ref matches an entry, return **allow** (short-circuit). Otherwise abstain. |
+| `deny`  | If the ref matches an entry, return **deny** (short-circuit). Otherwise abstain. |
+| `delay` | If the version was published at least `min_age` ago, allow. If younger, deny. If the upload time isn't known yet, fetch upstream metadata and re-run. |
+
+## How the chain runs
+
+For every **file download** request the chain is evaluated:
+
+1. The first filter that returns **allow** or **deny** wins — the
+   chain short-circuits and the request is passed through or rejected
+   accordingly.
+2. A filter that **abstains** (doesn't match) advances to the next
+   filter.
+3. If every filter in the chain abstains, the request is **allowed**.
+
+Index requests (no specific version pinned — e.g. the PyPI simple
+index for a package, the npm package metadata document, the Maven
+`maven-metadata.xml`) are **not** evaluated against the filter chain.
+Clients see the upstream index as-is; per-version blocking happens at
+download time.
+
+This matters because:
+
+- An operator who denies `log4j-core@2.14.*` doesn't need to also
+  strip those versions from the index document. Pip / Maven / npm
+  will see them listed, attempt to download, and get a 404 — with
+  a clear policy reason in the server log.
+- The same allowlist entry works for both indexes and downloads,
+  even though only downloads run through the chain (the index is
+  served upstream unchanged either way).
+
+## Filter shapes
+
+### `allow` and `deny`
+
+Both kinds accept two parallel input shapes, ORed together:
+
+- `patterns`: a list of package-name globs. Each pattern is the
+  equivalent of a rule with only `package` set.
+- `rules`: a list of `{package, version}` entries. At least one of
+  the two fields must be set; the other defaults to "match
+  anything".
+
+```json
+{"kind": "deny",
+ "patterns": ["evil-*"],
+ "rules": [
+   {"package": "log4j-core", "version": "2.14.*"},
+   {"package": "log4j-core", "version": "2.15.*"}
+ ]}
+```
+
+Globs use `path.Match` semantics: `*` matches a single path segment
+(does not cross `/`), `?` matches one char, `[abc]` matches a
+character class. Exact-string entries match literally.
+
+A direct call to `Allowlist.Decide` / `Denylist.Decide` with
+`Ref.Version == ""` ignores any rule's `version` constraint — the
+rule falls back to its `package` check alone. The chain entry point
+never invokes filters with an empty `Ref.Version`, so this only
+matters to in-process callers exercising filters directly.
+
+### `delay`
+
+A single `min_age` duration string (Go's
+[`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) format):
+
+```json
+{"kind": "delay", "min_age": "24h"}
+```
+
+Decision:
+
+- Upload time unknown → **needs more data** (the caller fetches
+  upstream metadata and re-runs).
+- Version younger than `min_age` → **deny**.
+- Version at least `min_age` old → **allow**.
+
+`min_age` must be positive. Common values: `24h`, `72h`, `7d`-style
+durations not supported (use `168h` for a week).
+
+## Composing the chain
+
+The typical shape is `[allow?, deny?, delay]`:
+
+```json
+"filters": [
+  {"kind": "allow",  "patterns": ["@myorg/*"]},
+  {"kind": "deny",   "patterns": ["evil-*"]},
+  {"kind": "delay",  "min_age": "24h"}
+]
+```
+
+What that says, in order:
+
+1. Internal `@myorg/*` packages are always allowed — they're
+   trusted publishers, bypass everything below.
+2. Anything matching `evil-*` is always denied.
+3. Everything else must have been published at least 24h ago.
+
+Order matters. Putting `delay` first would force *every* version
+(including internal `@myorg/*` releases) through the age check.
+
+## Deny reasons
+
+`Filters.Decide` returns the deciding `Filter` alongside the
+decision. Callers identify the policy via `filter.Kinded`:
+
+```go
+d, f, err := fs.Decide(ctx, ref)
+if d == filter.DecisionDeny {
+    kind := "unknown"
+    if k, ok := f.(filter.Kinded); ok {
+        kind = k.Kind()
+    }
+    log.Info("blocked by policy", "kind", kind, "package", ref.Package, "version", ref.Version)
+}
+```
+
+In-tree filters return `"allow"`, `"deny"`, or `"delay"` as their
+kind. Operators see these in deny-reason logs and metrics.
+
+## Validation
+
+Filter configuration is validated when the namespace `Spec` is
+written via the admin API:
+
+- An empty `allow` or `deny` (no patterns and no rules) is
+  rejected — it would never fire, which is almost always a
+  configuration error.
+- A rule with neither `package` nor `version` is rejected — it
+  would match everything.
+- Invalid globs (`path.Match` errors) are rejected.
+- `delay.min_age` must be positive.
+
+Invalid filters fail the `PUT /admin/v1/namespaces/{name}` call
+with HTTP 400 rather than the first request hitting the bad
+config.

--- a/pkg/handler/admin/handler_test.go
+++ b/pkg/handler/admin/handler_test.go
@@ -130,7 +130,7 @@ func TestHandler_NamespaceCRUD(t *testing.T) {
 			name:       "put proxy with future filter fields",
 			method:     http.MethodPut,
 			path:       "/admin/v1/namespaces/futureproxy",
-			rawBody:    `{"mode":"proxy","proxy":{"upstream":"https://pypi.org","filters":[{"kind":"allowlist","patterns":["foo"],"future_field":true}]}}`,
+			rawBody:    `{"mode":"proxy","proxy":{"upstream":"https://pypi.org","filters":[{"kind":"allow","patterns":["foo"],"future_field":true}]}}`,
 			wantStatus: http.StatusCreated,
 			wantBody: &namespace.Namespace{
 				Name: "futureproxy",

--- a/pkg/handler/admin/handler_test.go
+++ b/pkg/handler/admin/handler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/yolocs/ocifactory/pkg/handler/admin"
 	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
+	"github.com/yolocs/ocifactory/pkg/proxy/filter"
 )
 
 func TestHandler_NamespaceCRUD(t *testing.T) {
@@ -119,17 +120,17 @@ func TestHandler_NamespaceCRUD(t *testing.T) {
 			wantBody:   map[string]string{"error": "invalid proxy: proxy block must be empty on mode \"hosted\""},
 		},
 		{
-			// Filter is an opaque json.RawMessage today (concrete shape
-			// lands in #110), so unknown keys inside a filter object
-			// must NOT trip the DisallowUnknownFields top-level guard —
-			// otherwise an older binary would reject a body written by
-			// a newer binary that added typed filter fields. Pin that
-			// property here so a future refactor can't silently break
-			// the forward-compat contract.
+			// Filters dispatch on the "kind" discriminator and use a
+			// non-strict decoder for the per-kind body, so unknown
+			// keys *within* a known filter kind must NOT trip the
+			// top-level DisallowUnknownFields guard. That preserves
+			// forward-compat for filter fields added in a later
+			// version while still rejecting unknown kinds (covered by
+			// "put proxy with unknown filter kind" below).
 			name:       "put proxy with future filter fields",
 			method:     http.MethodPut,
 			path:       "/admin/v1/namespaces/futureproxy",
-			rawBody:    `{"mode":"proxy","proxy":{"upstream":"https://pypi.org","filters":[{"future_filter_field":true,"nested":{"k":"v"}}]}}`,
+			rawBody:    `{"mode":"proxy","proxy":{"upstream":"https://pypi.org","filters":[{"kind":"allowlist","patterns":["foo"],"future_field":true}]}}`,
 			wantStatus: http.StatusCreated,
 			wantBody: &namespace.Namespace{
 				Name: "futureproxy",
@@ -138,12 +139,20 @@ func TestHandler_NamespaceCRUD(t *testing.T) {
 					Mode:          namespace.ModeProxy,
 					Proxy: namespace.Proxy{
 						Upstream: "https://pypi.org",
-						Filters: []namespace.Filter{
-							[]byte(`{"future_filter_field":true,"nested":{"k":"v"}}`),
+						Filters: filter.Filters{
+							&filter.Allowlist{Patterns: []string{"foo"}},
 						},
 					},
 				},
 			},
+		},
+		{
+			name:       "put proxy with unknown filter kind",
+			method:     http.MethodPut,
+			path:       "/admin/v1/namespaces/badfilter",
+			rawBody:    `{"mode":"proxy","proxy":{"upstream":"https://pypi.org","filters":[{"kind":"nope"}]}}`,
+			wantStatus: http.StatusBadRequest,
+			wantBody:   map[string]string{"error": `invalid JSON body: filters[0]: invalid filter: unknown kind "nope"`},
 		},
 		{
 			name:       "put malformed json",

--- a/pkg/namespace/proxy.go
+++ b/pkg/namespace/proxy.go
@@ -36,9 +36,10 @@ type Proxy struct {
 	Upstream string `json:"upstream,omitempty"`
 
 	// Filters is the ordered filter chain applied before any upstream
-	// call. First deny wins; [filter.DecisionNeedsMoreData] from a
-	// metadata-dependent filter is re-run after upstream metadata
-	// fetch.
+	// file download. Index requests bypass the chain. Explicit allow
+	// or deny from a filter short-circuits; abstain advances to the
+	// next filter; [filter.DecisionNeedsMoreData] is re-run after
+	// upstream metadata fetch. See [docs/proxy/filter-policy.md].
 	Filters filter.Filters `json:"filters,omitempty"`
 }
 

--- a/pkg/namespace/proxy.go
+++ b/pkg/namespace/proxy.go
@@ -1,10 +1,11 @@
 package namespace
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
+
+	"github.com/yolocs/ocifactory/pkg/proxy/filter"
 )
 
 // ModeHosted is the default namespace mode. A hosted namespace stores
@@ -35,19 +36,16 @@ type Proxy struct {
 	Upstream string `json:"upstream,omitempty"`
 
 	// Filters is the ordered filter chain applied before any upstream
-	// call. First deny wins.
-	//
-	// The concrete element shape will land in #110; for now Filter is
-	// an opaque JSON value so older binaries roundtrip future filter
-	// content unchanged.
-	Filters []Filter `json:"filters,omitempty"`
+	// call. First deny wins; [filter.DecisionNeedsMoreData] from a
+	// metadata-dependent filter is re-run after upstream metadata
+	// fetch.
+	Filters filter.Filters `json:"filters,omitempty"`
 }
 
-// Filter is one element of the proxy filter chain. The concrete shape
-// is defined in #110; until then it is a passthrough JSON value so
-// older binaries can roundtrip future filter content without dropping
-// it on a read/write cycle.
-type Filter = json.RawMessage
+// Filter is one element of the proxy filter chain. Concrete shapes
+// live in [pkg/proxy/filter]; the type alias keeps the
+// namespace-package call sites readable.
+type Filter = filter.Filter
 
 // Validate returns nil iff p is consistent with mode: when mode is
 // [ModeProxy], Upstream must be a parseable absolute URL; when mode is
@@ -79,6 +77,9 @@ func (p *Proxy) Validate(mode string) error {
 	}
 	if u.Scheme != "http" && u.Scheme != "https" {
 		return fmt.Errorf("%w: upstream %q scheme must be http or https", ErrInvalidProxy, p.Upstream)
+	}
+	if err := p.Filters.Validate(); err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidProxy, err)
 	}
 	return nil
 }

--- a/pkg/namespace/spec_test.go
+++ b/pkg/namespace/spec_test.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/yolocs/ocifactory/pkg/proxy/filter"
 )
 
 // TestSpec_JSONRoundtrip pins the on-disk JSON shape so future spec
@@ -124,13 +126,14 @@ func TestSpec_JSONRoundtrip(t *testing.T) {
 				Mode: ModeProxy,
 				Proxy: Proxy{
 					Upstream: "https://registry.npmjs.org",
-					Filters: []Filter{
-						json.RawMessage(`{"type":"allowlist","patterns":["@myorg/*"]}`),
-						json.RawMessage(`{"type":"delay","min_age":"24h"}`),
+					Filters: filter.Filters{
+						&filter.Allowlist{Patterns: []string{"@myorg/*"}},
+						&filter.Denylist{Patterns: []string{"evil-*"}},
+						&filter.Delay{MinAge: 24 * time.Hour},
 					},
 				},
 			},
-			want: `{"mode":"proxy","proxy":{"upstream":"https://registry.npmjs.org","filters":[{"type":"allowlist","patterns":["@myorg/*"]},{"type":"delay","min_age":"24h"}]}}`,
+			want: `{"mode":"proxy","proxy":{"upstream":"https://registry.npmjs.org","filters":[{"kind":"allowlist","patterns":["@myorg/*"]},{"kind":"denylist","patterns":["evil-*"]},{"kind":"delay","min_age":"24h0m0s"}]}}`,
 		},
 	}
 
@@ -262,8 +265,8 @@ func TestSpec_Validate_ModeAndProxy(t *testing.T) {
 			name: "proxy-with-empty-upstream-and-filters",
 			spec: Spec{
 				Mode: ModeProxy,
-				Proxy: Proxy{Filters: []Filter{
-					[]byte(`{"type":"allowlist"}`),
+				Proxy: Proxy{Filters: filter.Filters{
+					&filter.Allowlist{Patterns: []string{"foo"}},
 				}},
 			},
 			wantErr:         ErrInvalidProxy,
@@ -289,7 +292,9 @@ func TestSpec_Validate_ModeAndProxy(t *testing.T) {
 		{
 			name: "hosted-rejects-proxy-filters",
 			spec: Spec{
-				Proxy: Proxy{Filters: []Filter{[]byte(`{}`)}},
+				Proxy: Proxy{Filters: filter.Filters{
+					&filter.Allowlist{Patterns: []string{"foo"}},
+				}},
 			},
 			wantErr:         ErrInvalidProxy,
 			wantMsgContains: "proxy block must be empty",

--- a/pkg/namespace/spec_test.go
+++ b/pkg/namespace/spec_test.go
@@ -136,7 +136,7 @@ func TestSpec_JSONRoundtrip(t *testing.T) {
 					},
 				},
 			},
-			want: `{"mode":"proxy","proxy":{"upstream":"https://registry.npmjs.org","filters":[{"kind":"allowlist","patterns":["@myorg/*"]},{"kind":"denylist","patterns":["evil-*"],"rules":[{"package":"log4j-core","version":"2.14.*"}]},{"kind":"delay","min_age":"24h0m0s"}]}}`,
+			want: `{"mode":"proxy","proxy":{"upstream":"https://registry.npmjs.org","filters":[{"kind":"allow","patterns":["@myorg/*"]},{"kind":"deny","patterns":["evil-*"],"rules":[{"package":"log4j-core","version":"2.14.*"}]},{"kind":"delay","min_age":"24h0m0s"}]}}`,
 		},
 	}
 

--- a/pkg/namespace/spec_test.go
+++ b/pkg/namespace/spec_test.go
@@ -128,12 +128,15 @@ func TestSpec_JSONRoundtrip(t *testing.T) {
 					Upstream: "https://registry.npmjs.org",
 					Filters: filter.Filters{
 						&filter.Allowlist{Patterns: []string{"@myorg/*"}},
-						&filter.Denylist{Patterns: []string{"evil-*"}},
+						&filter.Denylist{
+							Patterns: []string{"evil-*"},
+							Rules:    []filter.Rule{{Package: "log4j-core", Version: "2.14.*"}},
+						},
 						&filter.Delay{MinAge: 24 * time.Hour},
 					},
 				},
 			},
-			want: `{"mode":"proxy","proxy":{"upstream":"https://registry.npmjs.org","filters":[{"kind":"allowlist","patterns":["@myorg/*"]},{"kind":"denylist","patterns":["evil-*"]},{"kind":"delay","min_age":"24h0m0s"}]}}`,
+			want: `{"mode":"proxy","proxy":{"upstream":"https://registry.npmjs.org","filters":[{"kind":"allowlist","patterns":["@myorg/*"]},{"kind":"denylist","patterns":["evil-*"],"rules":[{"package":"log4j-core","version":"2.14.*"}]},{"kind":"delay","min_age":"24h0m0s"}]}}`,
 		},
 	}
 

--- a/pkg/proxy/filter/allowlist.go
+++ b/pkg/proxy/filter/allowlist.go
@@ -8,7 +8,7 @@ import (
 )
 
 // KindAllowlist is the JSON discriminator for [Allowlist].
-const KindAllowlist = "allowlist"
+const KindAllowlist = "allow"
 
 // Allowlist denies any [Ref] that doesn't match at least one entry.
 // Two parallel input shapes are supported and ORed together:

--- a/pkg/proxy/filter/allowlist.go
+++ b/pkg/proxy/filter/allowlist.go
@@ -10,20 +10,19 @@ import (
 // KindAllowlist is the JSON discriminator for [Allowlist].
 const KindAllowlist = "allow"
 
-// Allowlist denies any [Ref] that doesn't match at least one entry.
+// Allowlist returns [DecisionAllow] for any [Ref] that matches at
+// least one entry, and [DecisionAbstain] otherwise — it is an
+// explicit allow override that lets a request bypass any later filter
+// in the chain (notably [Delay]). It never denies on its own.
+//
 // Two parallel input shapes are supported and ORed together:
 //
 //   - Patterns: terse list of package-name globs (the common case).
 //     Each pattern is the equivalent of a [Rule] with only Package set.
-//   - Rules: full (package, version) entries. Each rule's version
-//     constraint is ignored when [Ref.Version] is empty, so an
-//     allowlist of `{package:requests, version:2.31.*}` allows the
-//     requests index through and only restricts per-version file
-//     requests.
+//   - Rules: full (package, version) entries.
 //
-// An Allowlist with no entries denies everything; that's a useful
-// "off switch" for a proxy namespace but also an easy footgun, so
-// [Allowlist.validate] rejects it.
+// An empty Allowlist would abstain on every ref, which is useless,
+// so [Allowlist.validate] rejects it at construction.
 type Allowlist struct {
 	Patterns []string `json:"patterns,omitempty"`
 	Rules    []Rule   `json:"rules,omitempty"`
@@ -32,9 +31,9 @@ type Allowlist struct {
 // Kind returns [KindAllowlist].
 func (a *Allowlist) Kind() string { return KindAllowlist }
 
-// Allow returns [DecisionAllow] iff ref matches at least one entry;
-// otherwise [DecisionDeny].
-func (a *Allowlist) Allow(ctx context.Context, ref Ref) (Decision, error) {
+// Decide returns [DecisionAllow] when ref matches an entry, otherwise
+// [DecisionAbstain].
+func (a *Allowlist) Decide(ctx context.Context, ref Ref) (Decision, error) {
 	for _, p := range a.Patterns {
 		ok, err := matchPattern(p, ref.Package)
 		if err != nil {
@@ -53,7 +52,7 @@ func (a *Allowlist) Allow(ctx context.Context, ref Ref) (Decision, error) {
 			return DecisionAllow, nil
 		}
 	}
-	return DecisionDeny, nil
+	return DecisionAbstain, nil
 }
 
 // MarshalJSON emits the kind discriminator alongside the entries so

--- a/pkg/proxy/filter/allowlist.go
+++ b/pkg/proxy/filter/allowlist.go
@@ -1,0 +1,69 @@
+package filter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+)
+
+// KindAllowlist is the JSON discriminator for [Allowlist].
+const KindAllowlist = "allowlist"
+
+// Allowlist denies any package whose name does not match at least
+// one of Patterns. Patterns are matched against [Ref.Package] in
+// order; the first match allows. Each pattern is either an exact
+// name or a shell-style glob (`*`, `?`, `[...]`) interpreted by
+// [path.Match] — `*` does not cross `/` boundaries, which gives
+// scoped npm packages (`@myorg/*`) intuitive single-segment matching.
+//
+// An Allowlist with zero patterns denies everything; that is a
+// useful "off switch" for a proxy namespace but also an easy
+// footgun, so [Allowlist.validate] rejects it.
+type Allowlist struct {
+	// Patterns is the set of allowed package names / globs. Order
+	// is preserved for log readability but does not affect the
+	// decision — matching is OR across patterns.
+	Patterns []string `json:"patterns"`
+}
+
+// Kind returns [KindAllowlist].
+func (a *Allowlist) Kind() string { return KindAllowlist }
+
+// Allow returns [DecisionAllow] iff [Ref.Package] matches at least
+// one pattern; otherwise [DecisionDeny].
+func (a *Allowlist) Allow(ctx context.Context, ref Ref) (Decision, error) {
+	for _, p := range a.Patterns {
+		ok, err := matchPattern(p, ref.Package)
+		if err != nil {
+			return DecisionDeny, fmt.Errorf("allowlist: pattern %q: %w", p, err)
+		}
+		if ok {
+			return DecisionAllow, nil
+		}
+	}
+	return DecisionDeny, nil
+}
+
+// MarshalJSON emits the kind discriminator alongside the pattern
+// list so [Filters] can roundtrip a heterogeneous chain.
+func (a *Allowlist) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Kind     string   `json:"kind"`
+		Patterns []string `json:"patterns"`
+	}{KindAllowlist, a.Patterns})
+}
+
+// validate runs at construction time (in [UnmarshalFilter]) so an
+// invalid pattern is rejected on PUT, not at first request.
+func (a *Allowlist) validate() error {
+	if len(a.Patterns) == 0 {
+		return fmt.Errorf("%w: allowlist must have at least one pattern", ErrInvalidFilter)
+	}
+	for _, p := range a.Patterns {
+		if _, err := path.Match(p, ""); err != nil {
+			return fmt.Errorf("%w: allowlist pattern %q: %v", ErrInvalidFilter, p, err)
+		}
+	}
+	return nil
+}

--- a/pkg/proxy/filter/allowlist.go
+++ b/pkg/proxy/filter/allowlist.go
@@ -10,28 +10,30 @@ import (
 // KindAllowlist is the JSON discriminator for [Allowlist].
 const KindAllowlist = "allowlist"
 
-// Allowlist denies any package whose name does not match at least
-// one of Patterns. Patterns are matched against [Ref.Package] in
-// order; the first match allows. Each pattern is either an exact
-// name or a shell-style glob (`*`, `?`, `[...]`) interpreted by
-// [path.Match] — `*` does not cross `/` boundaries, which gives
-// scoped npm packages (`@myorg/*`) intuitive single-segment matching.
+// Allowlist denies any [Ref] that doesn't match at least one entry.
+// Two parallel input shapes are supported and ORed together:
 //
-// An Allowlist with zero patterns denies everything; that is a
-// useful "off switch" for a proxy namespace but also an easy
-// footgun, so [Allowlist.validate] rejects it.
+//   - Patterns: terse list of package-name globs (the common case).
+//     Each pattern is the equivalent of a [Rule] with only Package set.
+//   - Rules: full (package, version) entries. Each rule's version
+//     constraint is ignored when [Ref.Version] is empty, so an
+//     allowlist of `{package:requests, version:2.31.*}` allows the
+//     requests index through and only restricts per-version file
+//     requests.
+//
+// An Allowlist with no entries denies everything; that's a useful
+// "off switch" for a proxy namespace but also an easy footgun, so
+// [Allowlist.validate] rejects it.
 type Allowlist struct {
-	// Patterns is the set of allowed package names / globs. Order
-	// is preserved for log readability but does not affect the
-	// decision — matching is OR across patterns.
-	Patterns []string `json:"patterns"`
+	Patterns []string `json:"patterns,omitempty"`
+	Rules    []Rule   `json:"rules,omitempty"`
 }
 
 // Kind returns [KindAllowlist].
 func (a *Allowlist) Kind() string { return KindAllowlist }
 
-// Allow returns [DecisionAllow] iff [Ref.Package] matches at least
-// one pattern; otherwise [DecisionDeny].
+// Allow returns [DecisionAllow] iff ref matches at least one entry;
+// otherwise [DecisionDeny].
 func (a *Allowlist) Allow(ctx context.Context, ref Ref) (Decision, error) {
 	for _, p := range a.Patterns {
 		ok, err := matchPattern(p, ref.Package)
@@ -42,27 +44,42 @@ func (a *Allowlist) Allow(ctx context.Context, ref Ref) (Decision, error) {
 			return DecisionAllow, nil
 		}
 	}
+	for i, r := range a.Rules {
+		ok, err := r.matches(ref)
+		if err != nil {
+			return DecisionDeny, fmt.Errorf("allowlist: rules[%d]: %w", i, err)
+		}
+		if ok {
+			return DecisionAllow, nil
+		}
+	}
 	return DecisionDeny, nil
 }
 
-// MarshalJSON emits the kind discriminator alongside the pattern
-// list so [Filters] can roundtrip a heterogeneous chain.
+// MarshalJSON emits the kind discriminator alongside the entries so
+// [Filters] can roundtrip a heterogeneous chain.
 func (a *Allowlist) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		Kind     string   `json:"kind"`
-		Patterns []string `json:"patterns"`
-	}{KindAllowlist, a.Patterns})
+		Patterns []string `json:"patterns,omitempty"`
+		Rules    []Rule   `json:"rules,omitempty"`
+	}{KindAllowlist, a.Patterns, a.Rules})
 }
 
 // validate runs at construction time (in [UnmarshalFilter]) so an
 // invalid pattern is rejected on PUT, not at first request.
 func (a *Allowlist) validate() error {
-	if len(a.Patterns) == 0 {
-		return fmt.Errorf("%w: allowlist must have at least one pattern", ErrInvalidFilter)
+	if len(a.Patterns) == 0 && len(a.Rules) == 0 {
+		return fmt.Errorf("%w: allowlist must have at least one pattern or rule", ErrInvalidFilter)
 	}
 	for _, p := range a.Patterns {
 		if _, err := path.Match(p, ""); err != nil {
 			return fmt.Errorf("%w: allowlist pattern %q: %v", ErrInvalidFilter, p, err)
+		}
+	}
+	for i, r := range a.Rules {
+		if err := r.validate(); err != nil {
+			return fmt.Errorf("allowlist rules[%d]: %w", i, err)
 		}
 	}
 	return nil

--- a/pkg/proxy/filter/allowlist_test.go
+++ b/pkg/proxy/filter/allowlist_test.go
@@ -141,43 +141,43 @@ func TestAllowlist_Construction(t *testing.T) {
 	}{
 		{
 			name: "valid-exact",
-			body: `{"kind":"allowlist","patterns":["foo"]}`,
+			body: `{"kind":"allow","patterns":["foo"]}`,
 		},
 		{
 			name: "valid-glob",
-			body: `{"kind":"allowlist","patterns":["foo*","@scope/*"]}`,
+			body: `{"kind":"allow","patterns":["foo*","@scope/*"]}`,
 		},
 		{
 			name: "valid-rules",
-			body: `{"kind":"allowlist","rules":[{"package":"requests","version":"2.31.*"}]}`,
+			body: `{"kind":"allow","rules":[{"package":"requests","version":"2.31.*"}]}`,
 		},
 		{
 			name: "valid-mixed",
-			body: `{"kind":"allowlist","patterns":["foo"],"rules":[{"package":"bar","version":"1.*"}]}`,
+			body: `{"kind":"allow","patterns":["foo"],"rules":[{"package":"bar","version":"1.*"}]}`,
 		},
 		{
 			name:    "empty-everything",
-			body:    `{"kind":"allowlist"}`,
+			body:    `{"kind":"allow"}`,
 			wantErr: true,
 		},
 		{
 			name:    "empty-patterns-and-rules",
-			body:    `{"kind":"allowlist","patterns":[],"rules":[]}`,
+			body:    `{"kind":"allow","patterns":[],"rules":[]}`,
 			wantErr: true,
 		},
 		{
 			name:    "malformed-pattern-glob",
-			body:    `{"kind":"allowlist","patterns":["[unbalanced"]}`,
+			body:    `{"kind":"allow","patterns":["[unbalanced"]}`,
 			wantErr: true,
 		},
 		{
 			name:    "rule-with-no-fields",
-			body:    `{"kind":"allowlist","rules":[{}]}`,
+			body:    `{"kind":"allow","rules":[{}]}`,
 			wantErr: true,
 		},
 		{
 			name:    "rule-with-malformed-version-glob",
-			body:    `{"kind":"allowlist","rules":[{"package":"foo","version":"[bad"}]}`,
+			body:    `{"kind":"allow","rules":[{"package":"foo","version":"[bad"}]}`,
 			wantErr: true,
 		},
 	}

--- a/pkg/proxy/filter/allowlist_test.go
+++ b/pkg/proxy/filter/allowlist_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/yolocs/ocifactory/pkg/proxy/filter"
 )
 
-func TestAllowlist_Allow(t *testing.T) {
+func TestAllowlist_Decide(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -20,19 +20,19 @@ func TestAllowlist_Allow(t *testing.T) {
 		{
 			name:     "patterns-exact-match",
 			patterns: []string{"requests"},
-			ref:      filter.Ref{Package: "requests"},
+			ref:      filter.Ref{Package: "requests", Version: "2.31.0"},
 			want:     filter.DecisionAllow,
 		},
 		{
-			name:     "patterns-exact-miss",
+			name:     "patterns-exact-miss-abstains",
 			patterns: []string{"requests"},
-			ref:      filter.Ref{Package: "urllib3"},
-			want:     filter.DecisionDeny,
+			ref:      filter.Ref{Package: "urllib3", Version: "2.0.0"},
+			want:     filter.DecisionAbstain,
 		},
 		{
 			name:     "patterns-glob-suffix",
 			patterns: []string{"@myorg/*"},
-			ref:      filter.Ref{Package: "@myorg/sdk"},
+			ref:      filter.Ref{Package: "@myorg/sdk", Version: "1.0.0"},
 			want:     filter.DecisionAllow,
 		},
 		{
@@ -41,13 +41,13 @@ func TestAllowlist_Allow(t *testing.T) {
 			// single-segment match for npm scoped packages.
 			name:     "patterns-glob-does-not-cross-slash",
 			patterns: []string{"@myorg/*"},
-			ref:      filter.Ref{Package: "@myorg/sub/sdk"},
-			want:     filter.DecisionDeny,
+			ref:      filter.Ref{Package: "@myorg/sub/sdk", Version: "1.0.0"},
+			want:     filter.DecisionAbstain,
 		},
 		{
 			name:     "patterns-any-of-multiple",
 			patterns: []string{"foo", "bar", "baz*"},
-			ref:      filter.Ref{Package: "baz-extras"},
+			ref:      filter.Ref{Package: "baz-extras", Version: "1.0.0"},
 			want:     filter.DecisionAllow,
 		},
 		{
@@ -63,17 +63,15 @@ func TestAllowlist_Allow(t *testing.T) {
 			want:  filter.DecisionAllow,
 		},
 		{
-			name:  "rule-version-mismatch-denies",
+			name:  "rule-version-mismatch-abstains",
 			rules: []filter.Rule{{Package: "requests", Version: "2.31.*"}},
 			ref:   filter.Ref{Package: "requests", Version: "2.30.5"},
-			want:  filter.DecisionDeny,
+			want:  filter.DecisionAbstain,
 		},
 		{
-			// Index-time (no version on the ref): the rule's version
-			// constraint is ignored and we fall back to package match,
-			// so the allowlist lets the index through. File-level
-			// requests are still subject to the version constraint
-			// (see "rule-version-mismatch-denies" above).
+			// Direct callers can still pass an empty-Version ref. In
+			// that case the rule's version constraint is ignored and
+			// the rule falls back to its package check alone.
 			name:  "rule-empty-ref-version-treats-version-as-wildcard",
 			rules: []filter.Rule{{Package: "requests", Version: "2.31.*"}},
 			ref:   filter.Ref{Package: "requests"},
@@ -108,12 +106,12 @@ func TestAllowlist_Allow(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			a := &filter.Allowlist{Patterns: tc.patterns, Rules: tc.rules}
-			got, err := a.Allow(t.Context(), tc.ref)
+			got, err := a.Decide(t.Context(), tc.ref)
 			if err != nil {
-				t.Fatalf("Allow: %v", err)
+				t.Fatalf("Decide: %v", err)
 			}
 			if got != tc.want {
-				t.Errorf("Allow(%+v) = %v, want %v", tc.ref, got, tc.want)
+				t.Errorf("Decide(%+v) = %v, want %v", tc.ref, got, tc.want)
 			}
 		})
 	}

--- a/pkg/proxy/filter/allowlist_test.go
+++ b/pkg/proxy/filter/allowlist_test.go
@@ -1,0 +1,138 @@
+package filter_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/yolocs/ocifactory/pkg/proxy/filter"
+)
+
+func TestAllowlist_Allow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		patterns []string
+		pkg      string
+		want     filter.Decision
+	}{
+		{
+			name:     "exact-match",
+			patterns: []string{"requests"},
+			pkg:      "requests",
+			want:     filter.DecisionAllow,
+		},
+		{
+			name:     "exact-miss",
+			patterns: []string{"requests"},
+			pkg:      "urllib3",
+			want:     filter.DecisionDeny,
+		},
+		{
+			name:     "glob-suffix",
+			patterns: []string{"@myorg/*"},
+			pkg:      "@myorg/sdk",
+			want:     filter.DecisionAllow,
+		},
+		{
+			name: "glob-does-not-cross-slash",
+			// path.Match's `*` does not span `/`, so `@myorg/*` matches
+			// `@myorg/sdk` but not `@myorg/sub/sdk`. That's the intuitive
+			// single-segment match for npm scoped packages.
+			patterns: []string{"@myorg/*"},
+			pkg:      "@myorg/sub/sdk",
+			want:     filter.DecisionDeny,
+		},
+		{
+			name:     "any-of-multiple",
+			patterns: []string{"foo", "bar", "baz*"},
+			pkg:      "baz-extras",
+			want:     filter.DecisionAllow,
+		},
+		{
+			name:     "no-pattern-matches-empty-name",
+			patterns: []string{"requests"},
+			pkg:      "",
+			want:     filter.DecisionDeny,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			a := &filter.Allowlist{Patterns: tc.patterns}
+			got, err := a.Allow(t.Context(), filter.Ref{Package: tc.pkg})
+			if err != nil {
+				t.Fatalf("Allow: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("Allow(%q) = %v, want %v", tc.pkg, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAllowlist_Kind(t *testing.T) {
+	t.Parallel()
+	a := &filter.Allowlist{Patterns: []string{"foo"}}
+	if got := a.Kind(); got != filter.KindAllowlist {
+		t.Errorf("Kind() = %q, want %q", got, filter.KindAllowlist)
+	}
+}
+
+// TestAllowlist_Construction pins the validation rules surfaced when
+// an Allowlist is parsed from JSON. Constructors don't exist by
+// design — the struct is exported so tests can build values
+// directly; validation happens at UnmarshalFilter time.
+func TestAllowlist_Construction(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		body    string
+		wantErr bool
+	}{
+		{
+			name: "valid-exact",
+			body: `{"kind":"allowlist","patterns":["foo"]}`,
+		},
+		{
+			name: "valid-glob",
+			body: `{"kind":"allowlist","patterns":["foo*","@scope/*"]}`,
+		},
+		{
+			name:    "empty-patterns",
+			body:    `{"kind":"allowlist","patterns":[]}`,
+			wantErr: true,
+		},
+		{
+			name:    "missing-patterns",
+			body:    `{"kind":"allowlist"}`,
+			wantErr: true,
+		},
+		{
+			name:    "malformed-glob",
+			body:    `{"kind":"allowlist","patterns":["[unbalanced"]}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := filter.UnmarshalFilter([]byte(tc.body))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("UnmarshalFilter(%q) = nil, want error", tc.body)
+				}
+				if !errors.Is(err, filter.ErrInvalidFilter) {
+					t.Errorf("UnmarshalFilter error = %v, want errors.Is ErrInvalidFilter", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("UnmarshalFilter(%q) error: %v", tc.body, err)
+			}
+		})
+	}
+}

--- a/pkg/proxy/filter/allowlist_test.go
+++ b/pkg/proxy/filter/allowlist_test.go
@@ -13,60 +13,107 @@ func TestAllowlist_Allow(t *testing.T) {
 	tests := []struct {
 		name     string
 		patterns []string
-		pkg      string
+		rules    []filter.Rule
+		ref      filter.Ref
 		want     filter.Decision
 	}{
 		{
-			name:     "exact-match",
+			name:     "patterns-exact-match",
 			patterns: []string{"requests"},
-			pkg:      "requests",
+			ref:      filter.Ref{Package: "requests"},
 			want:     filter.DecisionAllow,
 		},
 		{
-			name:     "exact-miss",
+			name:     "patterns-exact-miss",
 			patterns: []string{"requests"},
-			pkg:      "urllib3",
+			ref:      filter.Ref{Package: "urllib3"},
 			want:     filter.DecisionDeny,
 		},
 		{
-			name:     "glob-suffix",
+			name:     "patterns-glob-suffix",
 			patterns: []string{"@myorg/*"},
-			pkg:      "@myorg/sdk",
+			ref:      filter.Ref{Package: "@myorg/sdk"},
 			want:     filter.DecisionAllow,
 		},
 		{
-			name: "glob-does-not-cross-slash",
 			// path.Match's `*` does not span `/`, so `@myorg/*` matches
 			// `@myorg/sdk` but not `@myorg/sub/sdk`. That's the intuitive
 			// single-segment match for npm scoped packages.
+			name:     "patterns-glob-does-not-cross-slash",
 			patterns: []string{"@myorg/*"},
-			pkg:      "@myorg/sub/sdk",
+			ref:      filter.Ref{Package: "@myorg/sub/sdk"},
 			want:     filter.DecisionDeny,
 		},
 		{
-			name:     "any-of-multiple",
+			name:     "patterns-any-of-multiple",
 			patterns: []string{"foo", "bar", "baz*"},
-			pkg:      "baz-extras",
+			ref:      filter.Ref{Package: "baz-extras"},
 			want:     filter.DecisionAllow,
 		},
 		{
-			name:     "no-pattern-matches-empty-name",
+			name:  "rule-package-only-matches",
+			rules: []filter.Rule{{Package: "requests"}},
+			ref:   filter.Ref{Package: "requests", Version: "2.31.0"},
+			want:  filter.DecisionAllow,
+		},
+		{
+			name:  "rule-package-and-version-both-match",
+			rules: []filter.Rule{{Package: "requests", Version: "2.31.*"}},
+			ref:   filter.Ref{Package: "requests", Version: "2.31.0"},
+			want:  filter.DecisionAllow,
+		},
+		{
+			name:  "rule-version-mismatch-denies",
+			rules: []filter.Rule{{Package: "requests", Version: "2.31.*"}},
+			ref:   filter.Ref{Package: "requests", Version: "2.30.5"},
+			want:  filter.DecisionDeny,
+		},
+		{
+			// Index-time (no version on the ref): the rule's version
+			// constraint is ignored and we fall back to package match,
+			// so the allowlist lets the index through. File-level
+			// requests are still subject to the version constraint
+			// (see "rule-version-mismatch-denies" above).
+			name:  "rule-empty-ref-version-treats-version-as-wildcard",
+			rules: []filter.Rule{{Package: "requests", Version: "2.31.*"}},
+			ref:   filter.Ref{Package: "requests"},
+			want:  filter.DecisionAllow,
+		},
+		{
+			name:  "rule-package-glob-and-version",
+			rules: []filter.Rule{{Package: "@myorg/*", Version: "1.*"}},
+			ref:   filter.Ref{Package: "@myorg/sdk", Version: "1.4.0"},
+			want:  filter.DecisionAllow,
+		},
+		{
+			name:     "patterns-and-rules-or",
 			patterns: []string{"requests"},
-			pkg:      "",
-			want:     filter.DecisionDeny,
+			rules:    []filter.Rule{{Package: "log4j-core", Version: "2.17.*"}},
+			ref:      filter.Ref{Package: "log4j-core", Version: "2.17.1"},
+			want:     filter.DecisionAllow,
+		},
+		{
+			name: "rule-version-only-matches-any-package-at-version",
+			// Edge case: a rule with only Version set matches any
+			// package at that version. Rarely useful but a defined
+			// semantic — the operator can express "only allow 1.0.0
+			// across the board" with one rule.
+			rules: []filter.Rule{{Version: "1.0.0"}},
+			ref:   filter.Ref{Package: "anything", Version: "1.0.0"},
+			want:  filter.DecisionAllow,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			a := &filter.Allowlist{Patterns: tc.patterns}
-			got, err := a.Allow(t.Context(), filter.Ref{Package: tc.pkg})
+			a := &filter.Allowlist{Patterns: tc.patterns, Rules: tc.rules}
+			got, err := a.Allow(t.Context(), tc.ref)
 			if err != nil {
 				t.Fatalf("Allow: %v", err)
 			}
 			if got != tc.want {
-				t.Errorf("Allow(%q) = %v, want %v", tc.pkg, got, tc.want)
+				t.Errorf("Allow(%+v) = %v, want %v", tc.ref, got, tc.want)
 			}
 		})
 	}
@@ -101,18 +148,36 @@ func TestAllowlist_Construction(t *testing.T) {
 			body: `{"kind":"allowlist","patterns":["foo*","@scope/*"]}`,
 		},
 		{
-			name:    "empty-patterns",
-			body:    `{"kind":"allowlist","patterns":[]}`,
-			wantErr: true,
+			name: "valid-rules",
+			body: `{"kind":"allowlist","rules":[{"package":"requests","version":"2.31.*"}]}`,
 		},
 		{
-			name:    "missing-patterns",
+			name: "valid-mixed",
+			body: `{"kind":"allowlist","patterns":["foo"],"rules":[{"package":"bar","version":"1.*"}]}`,
+		},
+		{
+			name:    "empty-everything",
 			body:    `{"kind":"allowlist"}`,
 			wantErr: true,
 		},
 		{
-			name:    "malformed-glob",
+			name:    "empty-patterns-and-rules",
+			body:    `{"kind":"allowlist","patterns":[],"rules":[]}`,
+			wantErr: true,
+		},
+		{
+			name:    "malformed-pattern-glob",
 			body:    `{"kind":"allowlist","patterns":["[unbalanced"]}`,
+			wantErr: true,
+		},
+		{
+			name:    "rule-with-no-fields",
+			body:    `{"kind":"allowlist","rules":[{}]}`,
+			wantErr: true,
+		},
+		{
+			name:    "rule-with-malformed-version-glob",
+			body:    `{"kind":"allowlist","rules":[{"package":"foo","version":"[bad"}]}`,
 			wantErr: true,
 		},
 	}

--- a/pkg/proxy/filter/delay.go
+++ b/pkg/proxy/filter/delay.go
@@ -1,0 +1,117 @@
+package filter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// KindDelay is the JSON discriminator for [Delay].
+const KindDelay = "delay"
+
+// Delay denies any version whose upstream upload time is more recent
+// than MinAge ago. It returns [DecisionNeedsMoreData] when
+// [Ref.UploadTime] is zero, signalling the chain caller to fetch
+// upstream metadata before re-running the chain.
+//
+// Use case: defang typosquats and freshly-published malicious
+// versions by forcing every fetched version to "age" upstream first.
+// A 24h delay is a common starting point.
+//
+// Delay holds nothing but configuration; the wall clock comes from
+// the request context via [WithClock] (tests) or [time.Now]
+// (production). That keeps the value comparable by [cmp.Diff] in
+// spec roundtrip tests and free of per-instance mutable state.
+type Delay struct {
+	// MinAge is the minimum age a version must have upstream before
+	// this filter allows it through. Must be positive; zero or
+	// negative is rejected at construction.
+	MinAge time.Duration `json:"-"`
+}
+
+// Kind returns [KindDelay].
+func (d *Delay) Kind() string { return KindDelay }
+
+// Allow returns [DecisionNeedsMoreData] when ref.UploadTime is zero
+// (the chain should re-run after upstream metadata fetch), otherwise
+// [DecisionDeny] when the version is younger than MinAge and
+// [DecisionAllow] when it has aged enough.
+func (d *Delay) Allow(ctx context.Context, ref Ref) (Decision, error) {
+	if ref.UploadTime.IsZero() {
+		return DecisionNeedsMoreData, nil
+	}
+	now := ClockFromContext(ctx)
+	if now().Sub(ref.UploadTime) < d.MinAge {
+		return DecisionDeny, nil
+	}
+	return DecisionAllow, nil
+}
+
+// MarshalJSON emits the kind discriminator plus a human-friendly
+// duration string (e.g. "24h0m0s") via [time.Duration.String]. The
+// parse side accepts any form [time.ParseDuration] accepts ("24h",
+// "1m30s", …).
+func (d *Delay) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Kind   string `json:"kind"`
+		MinAge string `json:"min_age"`
+	}{KindDelay, d.MinAge.String()})
+}
+
+// UnmarshalJSON parses the duration string form. Numeric durations
+// (e.g. `"min_age": 86400000000000`) are not supported: the operator
+// is expected to write the human form so the spec is readable when
+// inspected directly.
+func (d *Delay) UnmarshalJSON(data []byte) error {
+	var aux struct {
+		Kind   string `json:"kind"`
+		MinAge string `json:"min_age"`
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if aux.MinAge == "" {
+		// Leave MinAge zero; validate() rejects it with a clearer
+		// message than ParseDuration's "invalid duration".
+		return nil
+	}
+	dur, err := time.ParseDuration(aux.MinAge)
+	if err != nil {
+		return fmt.Errorf("%w: delay min_age %q: %v", ErrInvalidFilter, aux.MinAge, err)
+	}
+	d.MinAge = dur
+	return nil
+}
+
+// validate runs at construction time.
+func (d *Delay) validate() error {
+	if d.MinAge <= 0 {
+		return fmt.Errorf("%w: delay min_age must be positive (got %s)", ErrInvalidFilter, d.MinAge)
+	}
+	return nil
+}
+
+// clockKey is the unexported context key under which [WithClock]
+// stores a test clock. Unexported so callers must go through
+// [WithClock] / [ClockFromContext].
+type clockKey struct{}
+
+// WithClock returns a context that overrides the wall clock used by
+// [Delay] and any future time-dependent filter. Intended for tests;
+// production code never calls this and gets [time.Now].
+func WithClock(ctx context.Context, now func() time.Time) context.Context {
+	if now == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, clockKey{}, now)
+}
+
+// ClockFromContext returns the clock installed by [WithClock], or
+// [time.Now] if none is set.
+func ClockFromContext(ctx context.Context) func() time.Time {
+	if fn, ok := ctx.Value(clockKey{}).(func() time.Time); ok {
+		return fn
+	}
+	return time.Now
+}

--- a/pkg/proxy/filter/delay.go
+++ b/pkg/proxy/filter/delay.go
@@ -33,11 +33,11 @@ type Delay struct {
 // Kind returns [KindDelay].
 func (d *Delay) Kind() string { return KindDelay }
 
-// Allow returns [DecisionNeedsMoreData] when ref.UploadTime is zero
+// Decide returns [DecisionNeedsMoreData] when ref.UploadTime is zero
 // (the chain should re-run after upstream metadata fetch), otherwise
 // [DecisionDeny] when the version is younger than MinAge and
 // [DecisionAllow] when it has aged enough.
-func (d *Delay) Allow(ctx context.Context, ref Ref) (Decision, error) {
+func (d *Delay) Decide(ctx context.Context, ref Ref) (Decision, error) {
 	if ref.UploadTime.IsZero() {
 		return DecisionNeedsMoreData, nil
 	}

--- a/pkg/proxy/filter/delay_test.go
+++ b/pkg/proxy/filter/delay_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/yolocs/ocifactory/pkg/proxy/filter"
 )
 
-func TestDelay_Allow(t *testing.T) {
+func TestDelay_Decide(t *testing.T) {
 	t.Parallel()
 
 	// Pin a wall clock so test outcomes are deterministic.
@@ -56,12 +56,12 @@ func TestDelay_Allow(t *testing.T) {
 			t.Parallel()
 			d := &filter.Delay{MinAge: tc.minAge}
 			ctx := filter.WithClock(t.Context(), func() time.Time { return frozen })
-			got, err := d.Allow(ctx, filter.Ref{Package: "pkg", Version: "1.0.0", UploadTime: tc.uploadTime})
+			got, err := d.Decide(ctx, filter.Ref{Package: "pkg", Version: "1.0.0", UploadTime: tc.uploadTime})
 			if err != nil {
-				t.Fatalf("Allow: %v", err)
+				t.Fatalf("Decide: %v", err)
 			}
 			if got != tc.want {
-				t.Errorf("Allow() = %v, want %v", got, tc.want)
+				t.Errorf("Decide() = %v, want %v", got, tc.want)
 			}
 		})
 	}
@@ -74,16 +74,16 @@ func TestDelay_Allow(t *testing.T) {
 func TestDelay_ContextlessUsesWallClock(t *testing.T) {
 	t.Parallel()
 	d := &filter.Delay{MinAge: time.Hour}
-	got, err := d.Allow(t.Context(), filter.Ref{
+	got, err := d.Decide(t.Context(), filter.Ref{
 		Package:    "pkg",
 		Version:    "1.0.0",
 		UploadTime: time.Now().Add(-10 * 365 * 24 * time.Hour),
 	})
 	if err != nil {
-		t.Fatalf("Allow: %v", err)
+		t.Fatalf("Decide: %v", err)
 	}
 	if got != filter.DecisionAllow {
-		t.Errorf("Allow() = %v, want %v", got, filter.DecisionAllow)
+		t.Errorf("Decide() = %v, want %v", got, filter.DecisionAllow)
 	}
 }
 

--- a/pkg/proxy/filter/delay_test.go
+++ b/pkg/proxy/filter/delay_test.go
@@ -1,0 +1,151 @@
+package filter_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/yolocs/ocifactory/pkg/proxy/filter"
+)
+
+func TestDelay_Allow(t *testing.T) {
+	t.Parallel()
+
+	// Pin a wall clock so test outcomes are deterministic.
+	frozen := time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		minAge     time.Duration
+		uploadTime time.Time
+		want       filter.Decision
+	}{
+		{
+			name:       "zero-upload-time-needs-more-data",
+			minAge:     24 * time.Hour,
+			uploadTime: time.Time{},
+			want:       filter.DecisionNeedsMoreData,
+		},
+		{
+			name:       "younger-than-min-age-denied",
+			minAge:     24 * time.Hour,
+			uploadTime: frozen.Add(-1 * time.Hour),
+			want:       filter.DecisionDeny,
+		},
+		{
+			name:       "exactly-min-age-allowed",
+			minAge:     24 * time.Hour,
+			uploadTime: frozen.Add(-24 * time.Hour),
+			want:       filter.DecisionAllow,
+		},
+		{
+			name:       "older-than-min-age-allowed",
+			minAge:     24 * time.Hour,
+			uploadTime: frozen.Add(-7 * 24 * time.Hour),
+			want:       filter.DecisionAllow,
+		},
+		{
+			name:       "future-upload-time-treated-as-fresh",
+			minAge:     1 * time.Hour,
+			uploadTime: frozen.Add(1 * time.Hour),
+			want:       filter.DecisionDeny,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			d := &filter.Delay{MinAge: tc.minAge}
+			ctx := filter.WithClock(t.Context(), func() time.Time { return frozen })
+			got, err := d.Allow(ctx, filter.Ref{Package: "pkg", Version: "1.0.0", UploadTime: tc.uploadTime})
+			if err != nil {
+				t.Fatalf("Allow: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("Allow() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDelay_ContextlessUsesWallClock pins the production code path:
+// when no clock is installed via WithClock, Delay falls back to
+// time.Now. Using a clearly stale upload time (10y in the past) makes
+// the assertion robust against wall-clock skew.
+func TestDelay_ContextlessUsesWallClock(t *testing.T) {
+	t.Parallel()
+	d := &filter.Delay{MinAge: time.Hour}
+	got, err := d.Allow(t.Context(), filter.Ref{
+		Package:    "pkg",
+		Version:    "1.0.0",
+		UploadTime: time.Now().Add(-10 * 365 * 24 * time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("Allow: %v", err)
+	}
+	if got != filter.DecisionAllow {
+		t.Errorf("Allow() = %v, want %v", got, filter.DecisionAllow)
+	}
+}
+
+func TestDelay_Kind(t *testing.T) {
+	t.Parallel()
+	d := &filter.Delay{MinAge: time.Hour}
+	if got := d.Kind(); got != filter.KindDelay {
+		t.Errorf("Kind() = %q, want %q", got, filter.KindDelay)
+	}
+}
+
+func TestDelay_Construction(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		body    string
+		wantErr bool
+	}{
+		{
+			name: "valid-hours",
+			body: `{"kind":"delay","min_age":"24h"}`,
+		},
+		{
+			name: "valid-compound",
+			body: `{"kind":"delay","min_age":"1h30m"}`,
+		},
+		{
+			name:    "missing-min-age",
+			body:    `{"kind":"delay"}`,
+			wantErr: true,
+		},
+		{
+			name:    "zero-min-age",
+			body:    `{"kind":"delay","min_age":"0s"}`,
+			wantErr: true,
+		},
+		{
+			name:    "negative-min-age",
+			body:    `{"kind":"delay","min_age":"-1h"}`,
+			wantErr: true,
+		},
+		{
+			name:    "unparseable",
+			body:    `{"kind":"delay","min_age":"forever"}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := filter.UnmarshalFilter([]byte(tc.body))
+			if tc.wantErr {
+				if err == nil || !errors.Is(err, filter.ErrInvalidFilter) {
+					t.Errorf("UnmarshalFilter(%q) error = %v, want errors.Is ErrInvalidFilter", tc.body, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("UnmarshalFilter(%q) error: %v", tc.body, err)
+			}
+		})
+	}
+}

--- a/pkg/proxy/filter/denylist.go
+++ b/pkg/proxy/filter/denylist.go
@@ -8,7 +8,7 @@ import (
 )
 
 // KindDenylist is the JSON discriminator for [Denylist].
-const KindDenylist = "denylist"
+const KindDenylist = "deny"
 
 // Denylist denies any [Ref] that matches at least one entry. Two
 // parallel input shapes are supported and ORed together:

--- a/pkg/proxy/filter/denylist.go
+++ b/pkg/proxy/filter/denylist.go
@@ -10,24 +10,32 @@ import (
 // KindDenylist is the JSON discriminator for [Denylist].
 const KindDenylist = "denylist"
 
-// Denylist denies any package whose name matches one of Patterns.
-// Patterns are matched against [Ref.Package] in order; the first
-// match denies. Pattern semantics are identical to [Allowlist] (exact
-// or shell-style glob via [path.Match]).
+// Denylist denies any [Ref] that matches at least one entry. Two
+// parallel input shapes are supported and ORed together:
+//
+//   - Patterns: terse list of package-name globs (the common case).
+//     Each pattern is the equivalent of a [Rule] with only Package set.
+//   - Rules: full (package, version) entries. Each rule's version
+//     constraint is ignored when [Ref.Version] is empty, so a
+//     denylist of `{package:log4j-core, version:2.14.*}` denies the
+//     log4j-core index AND the specific 2.14.x files; 2.17.x file
+//     requests are still allowed.
 //
 // An empty Denylist allows everything; it is valid but typically
 // indicates a misconfiguration, so the spec layer surfaces it
-// visually rather than rejecting it.
+// visually rather than rejecting it. (A no-entries Denylist is
+// caught by validate as a misconfig — operators who actually want
+// "no denies" simply omit the filter.)
 type Denylist struct {
-	// Patterns is the set of denied package names / globs.
-	Patterns []string `json:"patterns"`
+	Patterns []string `json:"patterns,omitempty"`
+	Rules    []Rule   `json:"rules,omitempty"`
 }
 
 // Kind returns [KindDenylist].
 func (d *Denylist) Kind() string { return KindDenylist }
 
-// Allow returns [DecisionDeny] iff [Ref.Package] matches at least
-// one pattern; otherwise [DecisionAllow].
+// Allow returns [DecisionDeny] iff ref matches at least one entry;
+// otherwise [DecisionAllow].
 func (d *Denylist) Allow(ctx context.Context, ref Ref) (Decision, error) {
 	for _, p := range d.Patterns {
 		ok, err := matchPattern(p, ref.Package)
@@ -38,40 +46,42 @@ func (d *Denylist) Allow(ctx context.Context, ref Ref) (Decision, error) {
 			return DecisionDeny, nil
 		}
 	}
+	for i, r := range d.Rules {
+		ok, err := r.matches(ref)
+		if err != nil {
+			return DecisionDeny, fmt.Errorf("denylist: rules[%d]: %w", i, err)
+		}
+		if ok {
+			return DecisionDeny, nil
+		}
+	}
 	return DecisionAllow, nil
 }
 
-// MarshalJSON emits the kind discriminator alongside the pattern
-// list so [Filters] can roundtrip a heterogeneous chain.
+// MarshalJSON emits the kind discriminator alongside the entries so
+// [Filters] can roundtrip a heterogeneous chain.
 func (d *Denylist) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		Kind     string   `json:"kind"`
-		Patterns []string `json:"patterns"`
-	}{KindDenylist, d.Patterns})
+		Patterns []string `json:"patterns,omitempty"`
+		Rules    []Rule   `json:"rules,omitempty"`
+	}{KindDenylist, d.Patterns, d.Rules})
 }
 
 // validate runs at construction time (in [UnmarshalFilter]).
 func (d *Denylist) validate() error {
-	if len(d.Patterns) == 0 {
-		return fmt.Errorf("%w: denylist must have at least one pattern", ErrInvalidFilter)
+	if len(d.Patterns) == 0 && len(d.Rules) == 0 {
+		return fmt.Errorf("%w: denylist must have at least one pattern or rule", ErrInvalidFilter)
 	}
 	for _, p := range d.Patterns {
 		if _, err := path.Match(p, ""); err != nil {
 			return fmt.Errorf("%w: denylist pattern %q: %v", ErrInvalidFilter, p, err)
 		}
 	}
-	return nil
-}
-
-// matchPattern is the shared exact-or-glob match used by Allowlist
-// and Denylist. Exact match wins as a fast path so a literal
-// pattern doesn't depend on [path.Match]'s glob interpretation
-// (which would surprise nobody for normal names but means a literal
-// "*" in a name is hard to express — operators who actually need a
-// literal glob char can escape it via [path.Match]'s `\`).
-func matchPattern(pattern, name string) (bool, error) {
-	if pattern == name {
-		return true, nil
+	for i, r := range d.Rules {
+		if err := r.validate(); err != nil {
+			return fmt.Errorf("denylist rules[%d]: %w", i, err)
+		}
 	}
-	return path.Match(pattern, name)
+	return nil
 }

--- a/pkg/proxy/filter/denylist.go
+++ b/pkg/proxy/filter/denylist.go
@@ -1,0 +1,77 @@
+package filter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+)
+
+// KindDenylist is the JSON discriminator for [Denylist].
+const KindDenylist = "denylist"
+
+// Denylist denies any package whose name matches one of Patterns.
+// Patterns are matched against [Ref.Package] in order; the first
+// match denies. Pattern semantics are identical to [Allowlist] (exact
+// or shell-style glob via [path.Match]).
+//
+// An empty Denylist allows everything; it is valid but typically
+// indicates a misconfiguration, so the spec layer surfaces it
+// visually rather than rejecting it.
+type Denylist struct {
+	// Patterns is the set of denied package names / globs.
+	Patterns []string `json:"patterns"`
+}
+
+// Kind returns [KindDenylist].
+func (d *Denylist) Kind() string { return KindDenylist }
+
+// Allow returns [DecisionDeny] iff [Ref.Package] matches at least
+// one pattern; otherwise [DecisionAllow].
+func (d *Denylist) Allow(ctx context.Context, ref Ref) (Decision, error) {
+	for _, p := range d.Patterns {
+		ok, err := matchPattern(p, ref.Package)
+		if err != nil {
+			return DecisionDeny, fmt.Errorf("denylist: pattern %q: %w", p, err)
+		}
+		if ok {
+			return DecisionDeny, nil
+		}
+	}
+	return DecisionAllow, nil
+}
+
+// MarshalJSON emits the kind discriminator alongside the pattern
+// list so [Filters] can roundtrip a heterogeneous chain.
+func (d *Denylist) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Kind     string   `json:"kind"`
+		Patterns []string `json:"patterns"`
+	}{KindDenylist, d.Patterns})
+}
+
+// validate runs at construction time (in [UnmarshalFilter]).
+func (d *Denylist) validate() error {
+	if len(d.Patterns) == 0 {
+		return fmt.Errorf("%w: denylist must have at least one pattern", ErrInvalidFilter)
+	}
+	for _, p := range d.Patterns {
+		if _, err := path.Match(p, ""); err != nil {
+			return fmt.Errorf("%w: denylist pattern %q: %v", ErrInvalidFilter, p, err)
+		}
+	}
+	return nil
+}
+
+// matchPattern is the shared exact-or-glob match used by Allowlist
+// and Denylist. Exact match wins as a fast path so a literal
+// pattern doesn't depend on [path.Match]'s glob interpretation
+// (which would surprise nobody for normal names but means a literal
+// "*" in a name is hard to express — operators who actually need a
+// literal glob char can escape it via [path.Match]'s `\`).
+func matchPattern(pattern, name string) (bool, error) {
+	if pattern == name {
+		return true, nil
+	}
+	return path.Match(pattern, name)
+}

--- a/pkg/proxy/filter/denylist.go
+++ b/pkg/proxy/filter/denylist.go
@@ -10,22 +10,18 @@ import (
 // KindDenylist is the JSON discriminator for [Denylist].
 const KindDenylist = "deny"
 
-// Denylist denies any [Ref] that matches at least one entry. Two
-// parallel input shapes are supported and ORed together:
+// Denylist returns [DecisionDeny] for any [Ref] that matches at least
+// one entry, and [DecisionAbstain] otherwise — it is an explicit deny
+// override that short-circuits the chain. It never allows on its own.
+//
+// Two parallel input shapes are supported and ORed together:
 //
 //   - Patterns: terse list of package-name globs (the common case).
 //     Each pattern is the equivalent of a [Rule] with only Package set.
-//   - Rules: full (package, version) entries. Each rule's version
-//     constraint is ignored when [Ref.Version] is empty, so a
-//     denylist of `{package:log4j-core, version:2.14.*}` denies the
-//     log4j-core index AND the specific 2.14.x files; 2.17.x file
-//     requests are still allowed.
+//   - Rules: full (package, version) entries.
 //
-// An empty Denylist allows everything; it is valid but typically
-// indicates a misconfiguration, so the spec layer surfaces it
-// visually rather than rejecting it. (A no-entries Denylist is
-// caught by validate as a misconfig — operators who actually want
-// "no denies" simply omit the filter.)
+// An empty Denylist would abstain on every ref, which is useless, so
+// [Denylist.validate] rejects it at construction.
 type Denylist struct {
 	Patterns []string `json:"patterns,omitempty"`
 	Rules    []Rule   `json:"rules,omitempty"`
@@ -34,9 +30,9 @@ type Denylist struct {
 // Kind returns [KindDenylist].
 func (d *Denylist) Kind() string { return KindDenylist }
 
-// Allow returns [DecisionDeny] iff ref matches at least one entry;
-// otherwise [DecisionAllow].
-func (d *Denylist) Allow(ctx context.Context, ref Ref) (Decision, error) {
+// Decide returns [DecisionDeny] when ref matches an entry, otherwise
+// [DecisionAbstain].
+func (d *Denylist) Decide(ctx context.Context, ref Ref) (Decision, error) {
 	for _, p := range d.Patterns {
 		ok, err := matchPattern(p, ref.Package)
 		if err != nil {
@@ -55,7 +51,7 @@ func (d *Denylist) Allow(ctx context.Context, ref Ref) (Decision, error) {
 			return DecisionDeny, nil
 		}
 	}
-	return DecisionAllow, nil
+	return DecisionAbstain, nil
 }
 
 // MarshalJSON emits the kind discriminator alongside the entries so

--- a/pkg/proxy/filter/denylist_test.go
+++ b/pkg/proxy/filter/denylist_test.go
@@ -13,51 +13,89 @@ func TestDenylist_Allow(t *testing.T) {
 	tests := []struct {
 		name     string
 		patterns []string
-		pkg      string
+		rules    []filter.Rule
+		ref      filter.Ref
 		want     filter.Decision
 	}{
 		{
-			name:     "exact-match-denies",
+			name:     "patterns-exact-match-denies",
 			patterns: []string{"evil"},
-			pkg:      "evil",
+			ref:      filter.Ref{Package: "evil"},
 			want:     filter.DecisionDeny,
 		},
 		{
-			name:     "no-match-allows",
+			name:     "patterns-no-match-allows",
 			patterns: []string{"evil"},
-			pkg:      "safe",
+			ref:      filter.Ref{Package: "safe"},
 			want:     filter.DecisionAllow,
 		},
 		{
-			name:     "glob-match",
+			name:     "patterns-glob-match",
 			patterns: []string{"evil-*"},
-			pkg:      "evil-package",
+			ref:      filter.Ref{Package: "evil-package"},
+			want:     filter.DecisionDeny,
+		},
+		{
+			name:  "rule-package-and-version-both-match-denies",
+			rules: []filter.Rule{{Package: "log4j-core", Version: "2.14.*"}},
+			ref:   filter.Ref{Package: "log4j-core", Version: "2.14.1"},
+			want:  filter.DecisionDeny,
+		},
+		{
+			name:  "rule-version-mismatch-allows",
+			rules: []filter.Rule{{Package: "log4j-core", Version: "2.14.*"}},
+			ref:   filter.Ref{Package: "log4j-core", Version: "2.17.1"},
+			want:  filter.DecisionAllow,
+		},
+		{
+			// Index-time (no version on the ref): the rule's version
+			// constraint is ignored and we fall back to package match,
+			// so the denylist denies the log4j-core index entirely.
+			// That's the symmetric "missing version = wildcard"
+			// semantic the operator chose; per-version requests are
+			// still individually checked.
+			name:  "rule-empty-ref-version-treats-version-as-wildcard",
+			rules: []filter.Rule{{Package: "log4j-core", Version: "2.14.*"}},
+			ref:   filter.Ref{Package: "log4j-core"},
+			want:  filter.DecisionDeny,
+		},
+		{
+			name:     "patterns-and-rules-both-checked",
+			patterns: []string{"banned"},
+			rules:    []filter.Rule{{Package: "log4j-core", Version: "2.14.*"}},
+			ref:      filter.Ref{Package: "log4j-core", Version: "2.14.1"},
 			want:     filter.DecisionDeny,
 		},
 		{
 			name:     "first-of-many-allows",
 			patterns: []string{"a", "b", "c"},
-			pkg:      "d",
+			ref:      filter.Ref{Package: "d"},
 			want:     filter.DecisionAllow,
 		},
 		{
 			name:     "later-of-many-denies",
 			patterns: []string{"a", "b", "c"},
-			pkg:      "c",
+			ref:      filter.Ref{Package: "c"},
 			want:     filter.DecisionDeny,
+		},
+		{
+			name:  "rule-package-only-denies-any-version",
+			rules: []filter.Rule{{Package: "evil"}},
+			ref:   filter.Ref{Package: "evil", Version: "9.9.9"},
+			want:  filter.DecisionDeny,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			d := &filter.Denylist{Patterns: tc.patterns}
-			got, err := d.Allow(t.Context(), filter.Ref{Package: tc.pkg})
+			d := &filter.Denylist{Patterns: tc.patterns, Rules: tc.rules}
+			got, err := d.Allow(t.Context(), tc.ref)
 			if err != nil {
 				t.Fatalf("Allow: %v", err)
 			}
 			if got != tc.want {
-				t.Errorf("Allow(%q) = %v, want %v", tc.pkg, got, tc.want)
+				t.Errorf("Allow(%+v) = %v, want %v", tc.ref, got, tc.want)
 			}
 		})
 	}
@@ -80,17 +118,30 @@ func TestDenylist_Construction(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "valid",
+			name: "valid-patterns",
 			body: `{"kind":"denylist","patterns":["evil","evil-*"]}`,
 		},
 		{
-			name:    "empty-patterns",
-			body:    `{"kind":"denylist","patterns":[]}`,
+			name: "valid-rules",
+			body: `{"kind":"denylist","rules":[{"package":"log4j-core","version":"2.14.*"}]}`,
+		},
+		{
+			name: "valid-mixed",
+			body: `{"kind":"denylist","patterns":["evil"],"rules":[{"package":"log4j-core","version":"2.14.*"}]}`,
+		},
+		{
+			name:    "empty-everything",
+			body:    `{"kind":"denylist"}`,
 			wantErr: true,
 		},
 		{
-			name:    "malformed-glob",
+			name:    "malformed-pattern",
 			body:    `{"kind":"denylist","patterns":["[bad"]}`,
+			wantErr: true,
+		},
+		{
+			name:    "rule-empty",
+			body:    `{"kind":"denylist","rules":[{}]}`,
 			wantErr: true,
 		},
 	}

--- a/pkg/proxy/filter/denylist_test.go
+++ b/pkg/proxy/filter/denylist_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/yolocs/ocifactory/pkg/proxy/filter"
 )
 
-func TestDenylist_Allow(t *testing.T) {
+func TestDenylist_Decide(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -20,19 +20,19 @@ func TestDenylist_Allow(t *testing.T) {
 		{
 			name:     "patterns-exact-match-denies",
 			patterns: []string{"evil"},
-			ref:      filter.Ref{Package: "evil"},
+			ref:      filter.Ref{Package: "evil", Version: "1.0.0"},
 			want:     filter.DecisionDeny,
 		},
 		{
-			name:     "patterns-no-match-allows",
+			name:     "patterns-no-match-abstains",
 			patterns: []string{"evil"},
-			ref:      filter.Ref{Package: "safe"},
-			want:     filter.DecisionAllow,
+			ref:      filter.Ref{Package: "safe", Version: "1.0.0"},
+			want:     filter.DecisionAbstain,
 		},
 		{
 			name:     "patterns-glob-match",
 			patterns: []string{"evil-*"},
-			ref:      filter.Ref{Package: "evil-package"},
+			ref:      filter.Ref{Package: "evil-package", Version: "1.0.0"},
 			want:     filter.DecisionDeny,
 		},
 		{
@@ -42,18 +42,15 @@ func TestDenylist_Allow(t *testing.T) {
 			want:  filter.DecisionDeny,
 		},
 		{
-			name:  "rule-version-mismatch-allows",
+			name:  "rule-version-mismatch-abstains",
 			rules: []filter.Rule{{Package: "log4j-core", Version: "2.14.*"}},
 			ref:   filter.Ref{Package: "log4j-core", Version: "2.17.1"},
-			want:  filter.DecisionAllow,
+			want:  filter.DecisionAbstain,
 		},
 		{
-			// Index-time (no version on the ref): the rule's version
-			// constraint is ignored and we fall back to package match,
-			// so the denylist denies the log4j-core index entirely.
-			// That's the symmetric "missing version = wildcard"
-			// semantic the operator chose; per-version requests are
-			// still individually checked.
+			// Direct callers can still pass an empty-Version ref. In
+			// that case the rule's version constraint is ignored and
+			// the denylist denies the whole log4j-core package.
 			name:  "rule-empty-ref-version-treats-version-as-wildcard",
 			rules: []filter.Rule{{Package: "log4j-core", Version: "2.14.*"}},
 			ref:   filter.Ref{Package: "log4j-core"},
@@ -67,15 +64,15 @@ func TestDenylist_Allow(t *testing.T) {
 			want:     filter.DecisionDeny,
 		},
 		{
-			name:     "first-of-many-allows",
+			name:     "first-of-many-abstains",
 			patterns: []string{"a", "b", "c"},
-			ref:      filter.Ref{Package: "d"},
-			want:     filter.DecisionAllow,
+			ref:      filter.Ref{Package: "d", Version: "1.0.0"},
+			want:     filter.DecisionAbstain,
 		},
 		{
 			name:     "later-of-many-denies",
 			patterns: []string{"a", "b", "c"},
-			ref:      filter.Ref{Package: "c"},
+			ref:      filter.Ref{Package: "c", Version: "1.0.0"},
 			want:     filter.DecisionDeny,
 		},
 		{
@@ -90,12 +87,12 @@ func TestDenylist_Allow(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			d := &filter.Denylist{Patterns: tc.patterns, Rules: tc.rules}
-			got, err := d.Allow(t.Context(), tc.ref)
+			got, err := d.Decide(t.Context(), tc.ref)
 			if err != nil {
-				t.Fatalf("Allow: %v", err)
+				t.Fatalf("Decide: %v", err)
 			}
 			if got != tc.want {
-				t.Errorf("Allow(%+v) = %v, want %v", tc.ref, got, tc.want)
+				t.Errorf("Decide(%+v) = %v, want %v", tc.ref, got, tc.want)
 			}
 		})
 	}

--- a/pkg/proxy/filter/denylist_test.go
+++ b/pkg/proxy/filter/denylist_test.go
@@ -119,29 +119,29 @@ func TestDenylist_Construction(t *testing.T) {
 	}{
 		{
 			name: "valid-patterns",
-			body: `{"kind":"denylist","patterns":["evil","evil-*"]}`,
+			body: `{"kind":"deny","patterns":["evil","evil-*"]}`,
 		},
 		{
 			name: "valid-rules",
-			body: `{"kind":"denylist","rules":[{"package":"log4j-core","version":"2.14.*"}]}`,
+			body: `{"kind":"deny","rules":[{"package":"log4j-core","version":"2.14.*"}]}`,
 		},
 		{
 			name: "valid-mixed",
-			body: `{"kind":"denylist","patterns":["evil"],"rules":[{"package":"log4j-core","version":"2.14.*"}]}`,
+			body: `{"kind":"deny","patterns":["evil"],"rules":[{"package":"log4j-core","version":"2.14.*"}]}`,
 		},
 		{
 			name:    "empty-everything",
-			body:    `{"kind":"denylist"}`,
+			body:    `{"kind":"deny"}`,
 			wantErr: true,
 		},
 		{
 			name:    "malformed-pattern",
-			body:    `{"kind":"denylist","patterns":["[bad"]}`,
+			body:    `{"kind":"deny","patterns":["[bad"]}`,
 			wantErr: true,
 		},
 		{
 			name:    "rule-empty",
-			body:    `{"kind":"denylist","rules":[{}]}`,
+			body:    `{"kind":"deny","rules":[{}]}`,
 			wantErr: true,
 		},
 	}

--- a/pkg/proxy/filter/denylist_test.go
+++ b/pkg/proxy/filter/denylist_test.go
@@ -1,0 +1,113 @@
+package filter_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/yolocs/ocifactory/pkg/proxy/filter"
+)
+
+func TestDenylist_Allow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		patterns []string
+		pkg      string
+		want     filter.Decision
+	}{
+		{
+			name:     "exact-match-denies",
+			patterns: []string{"evil"},
+			pkg:      "evil",
+			want:     filter.DecisionDeny,
+		},
+		{
+			name:     "no-match-allows",
+			patterns: []string{"evil"},
+			pkg:      "safe",
+			want:     filter.DecisionAllow,
+		},
+		{
+			name:     "glob-match",
+			patterns: []string{"evil-*"},
+			pkg:      "evil-package",
+			want:     filter.DecisionDeny,
+		},
+		{
+			name:     "first-of-many-allows",
+			patterns: []string{"a", "b", "c"},
+			pkg:      "d",
+			want:     filter.DecisionAllow,
+		},
+		{
+			name:     "later-of-many-denies",
+			patterns: []string{"a", "b", "c"},
+			pkg:      "c",
+			want:     filter.DecisionDeny,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			d := &filter.Denylist{Patterns: tc.patterns}
+			got, err := d.Allow(t.Context(), filter.Ref{Package: tc.pkg})
+			if err != nil {
+				t.Fatalf("Allow: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("Allow(%q) = %v, want %v", tc.pkg, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDenylist_Kind(t *testing.T) {
+	t.Parallel()
+	d := &filter.Denylist{Patterns: []string{"foo"}}
+	if got := d.Kind(); got != filter.KindDenylist {
+		t.Errorf("Kind() = %q, want %q", got, filter.KindDenylist)
+	}
+}
+
+func TestDenylist_Construction(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		body    string
+		wantErr bool
+	}{
+		{
+			name: "valid",
+			body: `{"kind":"denylist","patterns":["evil","evil-*"]}`,
+		},
+		{
+			name:    "empty-patterns",
+			body:    `{"kind":"denylist","patterns":[]}`,
+			wantErr: true,
+		},
+		{
+			name:    "malformed-glob",
+			body:    `{"kind":"denylist","patterns":["[bad"]}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := filter.UnmarshalFilter([]byte(tc.body))
+			if tc.wantErr {
+				if err == nil || !errors.Is(err, filter.ErrInvalidFilter) {
+					t.Errorf("UnmarshalFilter(%q) error = %v, want errors.Is ErrInvalidFilter", tc.body, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("UnmarshalFilter(%q) error: %v", tc.body, err)
+			}
+		})
+	}
+}

--- a/pkg/proxy/filter/filter.go
+++ b/pkg/proxy/filter/filter.go
@@ -1,15 +1,17 @@
 // Package filter is the proxy governance layer. It defines the
 // [Filter] interface a proxy namespace runs against each upstream
-// reference and the [Chain] composition that runs filters in order.
-// In-tree filters cover the v1 needs: name [Allowlist], name
-// [Denylist], and a publish-time [Delay].
+// reference and the [Filters] chain that composes them.
 //
-// Filters are run as early as their inputs allow. Name-only filters
-// run before any upstream call; metadata-dependent filters (e.g.
-// [Delay]) return [DecisionNeedsMoreData] when they don't have what
-// they need yet, and the chain caller re-runs after fetching the
-// upstream metadata. See https://github.com/yolocs/ocifactory/issues/118
-// for the design.
+// Policy in one paragraph: an [Allowlist] match returns
+// [DecisionAllow]; a [Denylist] match returns [DecisionDeny]; either
+// short-circuits the chain. A list that doesn't match returns
+// [DecisionAbstain] and the chain moves to the next filter. A
+// metadata-dependent filter like [Delay] makes the final call on
+// anything no list pre-decided. Index requests ([Ref.Version] == "")
+// bypass the chain entirely — filtering applies to file downloads
+// only.
+//
+// See [docs/proxy/filter-policy.md] for the operator-facing version.
 package filter
 
 import (
@@ -27,9 +29,7 @@ import (
 var ErrInvalidFilter = errors.New("invalid filter")
 
 // Ref identifies a package and (optionally) a specific version that
-// a proxy filter is being asked to decide on. Empty fields signal
-// "not known yet" — filters that depend on them should return
-// [DecisionNeedsMoreData] rather than denying.
+// a proxy filter is being asked to decide on.
 type Ref struct {
 	// Package is the upstream package identifier — PyPI normalized
 	// name, npm name (including any "@scope/" prefix), or Maven
@@ -37,15 +37,14 @@ type Ref struct {
 	Package string
 
 	// Version is the upstream version string when resolved. Empty
-	// when the request hasn't pinned a version yet (e.g. an index
-	// fetch). Version-constrained rules treat an empty Version as
-	// "matches any version" so an index request isn't surprised by
-	// a per-version rule firing prematurely.
+	// when the request is an index fetch rather than a file
+	// download; [Filters.Decide] bypasses the chain in that case.
 	Version string
 
 	// UploadTime is when the version was published upstream. Zero
-	// when not yet known; filters depending on it return
-	// [DecisionNeedsMoreData] in that case.
+	// when not yet known; [Delay] returns [DecisionNeedsMoreData]
+	// in that case so the caller can fetch upstream metadata and
+	// re-run.
 	UploadTime time.Time
 }
 
@@ -58,11 +57,9 @@ type Ref struct {
 //     [path.Match] glob).
 //   - Version, when set, is matched against [Ref.Version] (same
 //     semantics) — but only when [Ref.Version] is itself non-empty.
-//     An index request (Version="") makes any per-version rule fall
-//     back to its package check alone, so a rule like
-//     {Package:"log4j-core", Version:"2.14.*"} on a denylist denies
-//     the whole log4j-core index AND the specific 2.14.x files,
-//     symmetrically for allowlist.
+//     An empty [Ref.Version] (which only [Filters.Decide] skips, but
+//     direct callers can still pass) makes any per-version rule fall
+//     back to its package check alone.
 type Rule struct {
 	Package string `json:"package,omitempty"`
 	Version string `json:"version,omitempty"`
@@ -110,10 +107,7 @@ func (r Rule) validate() error {
 
 // matchPattern is the shared exact-or-glob match used by [Rule].
 // Exact match wins as a fast path so a literal pattern doesn't
-// depend on [path.Match]'s glob interpretation (which would surprise
-// nobody for normal names but means a literal glob char in a name
-// is hard to express — operators who actually need a literal glob
-// char can escape it via [path.Match]'s `\`).
+// depend on [path.Match]'s glob interpretation.
 func matchPattern(pattern, name string) (bool, error) {
 	if pattern == name {
 		return true, nil
@@ -121,24 +115,29 @@ func matchPattern(pattern, name string) (bool, error) {
 	return path.Match(pattern, name)
 }
 
-// Decision is the outcome of a single [Filter.Allow] call.
+// Decision is the outcome of a single [Filter.Decide] call.
 type Decision int
 
 const (
-	// DecisionAllow lets the [Ref] pass this filter. The chain
-	// continues to the next filter; a chain that ends with every
-	// filter returning DecisionAllow allows the request overall.
+	// DecisionAllow is an explicit allow. [Filters.Decide]
+	// short-circuits and the request is passed through.
 	DecisionAllow Decision = iota
 
-	// DecisionDeny rejects the [Ref]. The chain short-circuits and
-	// the caller surfaces a 404 (with a deny log + counter at the
-	// caller layer).
+	// DecisionDeny is an explicit deny. [Filters.Decide]
+	// short-circuits and the deciding filter is returned to the
+	// caller for the deny reason.
 	DecisionDeny
+
+	// DecisionAbstain means the filter has no opinion on this ref.
+	// [Filters.Decide] advances to the next filter. When every
+	// filter in the chain abstains the chain returns
+	// [DecisionAllow].
+	DecisionAbstain
 
 	// DecisionNeedsMoreData signals the filter could not evaluate
 	// with the data on the [Ref] (e.g. [Delay] without an
-	// UploadTime). The chain skips this filter for now and the
-	// caller re-runs the chain after fetching upstream metadata.
+	// UploadTime). [Filters.Decide] returns it so the caller can
+	// fetch upstream metadata and re-run.
 	DecisionNeedsMoreData
 )
 
@@ -149,6 +148,8 @@ func (d Decision) String() string {
 		return "allow"
 	case DecisionDeny:
 		return "deny"
+	case DecisionAbstain:
+		return "abstain"
 	case DecisionNeedsMoreData:
 		return "needs-more-data"
 	default:
@@ -162,68 +163,58 @@ func (d Decision) String() string {
 // value is shared across every request that hits a namespace and is
 // expected to be free of per-call mutable state.
 type Filter interface {
-	// Allow decides whether ref should pass this filter. Returning
-	// a non-nil error is reserved for genuinely unexpected failures
-	// (a Filter that wants to deny on a normal condition returns
-	// DecisionDeny with a nil error); the chain treats a non-nil
-	// error as fatal and propagates it.
-	Allow(ctx context.Context, ref Ref) (Decision, error)
+	// Decide returns one of [DecisionAllow], [DecisionDeny],
+	// [DecisionAbstain], or [DecisionNeedsMoreData]. A non-nil
+	// error is reserved for genuinely unexpected failures; a
+	// filter denying on a normal condition returns DecisionDeny
+	// with a nil error.
+	Decide(ctx context.Context, ref Ref) (Decision, error)
 }
 
 // Kinded is the optional extension implemented by every in-tree
 // filter. It exposes the JSON discriminator value so callers
-// (metrics, structured logs) can label denies by filter kind without
-// reflecting on the concrete type.
+// (metrics, structured logs, deny-reason strings) can label by
+// filter kind without reflecting on the concrete type.
 type Kinded interface {
 	Kind() string
 }
 
-// Chain composes filters in order. First [DecisionDeny] wins;
-// [DecisionNeedsMoreData] from one filter does not short-circuit but
-// is "remembered" so the chain's overall return reflects it when no
-// other filter denies.
-type Chain []Filter
-
-// Allow runs the chain.
+// Filters is a serialisable ordered chain. The first filter to
+// return [DecisionAllow], [DecisionDeny], or [DecisionNeedsMoreData]
+// wins; [DecisionAbstain] advances. An empty chain or one whose
+// every filter abstained returns [DecisionAllow] overall.
 //
-// The returned Filter is the deciding filter on DecisionDeny (so
-// callers can label metrics / structured logs by it) and nil
-// otherwise. On DecisionNeedsMoreData the returned Filter is the
-// first filter that asked for more data — useful in tests but not
-// load-bearing for callers, which simply re-run the chain after
-// enriching the ref.
-func (c Chain) Allow(ctx context.Context, ref Ref) (Decision, Filter, error) {
-	var pendingFilter Filter
-	for _, f := range c {
-		d, err := f.Allow(ctx, ref)
+// Index requests ([Ref.Version] == "") bypass the chain — filtering
+// applies to file downloads only.
+type Filters []Filter
+
+// Decide runs the chain.
+//
+// The returned Filter is the deciding filter for any non-Abstain
+// outcome (so callers can log it / label metrics / format a deny
+// reason via [Kinded.Kind]) and nil otherwise. Index requests
+// (empty [Ref.Version]) return [DecisionAllow] with a nil Filter
+// without invoking any filter.
+func (fs Filters) Decide(ctx context.Context, ref Ref) (Decision, Filter, error) {
+	if ref.Version == "" {
+		return DecisionAllow, nil, nil
+	}
+	for _, f := range fs {
+		d, err := f.Decide(ctx, ref)
 		if err != nil {
 			return DecisionDeny, f, err
 		}
 		switch d {
-		case DecisionAllow:
-			// keep going
-		case DecisionDeny:
-			return DecisionDeny, f, nil
-		case DecisionNeedsMoreData:
-			if pendingFilter == nil {
-				pendingFilter = f
-			}
+		case DecisionAllow, DecisionDeny, DecisionNeedsMoreData:
+			return d, f, nil
+		case DecisionAbstain:
+			continue
 		default:
 			return DecisionDeny, f, fmt.Errorf("filter %T returned unknown decision %d", f, d)
 		}
 	}
-	if pendingFilter != nil {
-		return DecisionNeedsMoreData, pendingFilter, nil
-	}
 	return DecisionAllow, nil, nil
 }
-
-// Filters is a serialisable ordered chain. It exists as a named
-// slice (not a bare []Filter) so JSON unmarshaling can dispatch each
-// element to a concrete filter implementation by kind — Go's default
-// encoder can't pick a concrete type for an interface field on its
-// own.
-type Filters []Filter
 
 // MarshalJSON encodes fs as a JSON array. Each element delegates to
 // its concrete filter's MarshalJSON, which embeds the kind

--- a/pkg/proxy/filter/filter.go
+++ b/pkg/proxy/filter/filter.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path"
 	"time"
 )
 
@@ -37,13 +38,87 @@ type Ref struct {
 
 	// Version is the upstream version string when resolved. Empty
 	// when the request hasn't pinned a version yet (e.g. an index
-	// fetch).
+	// fetch). Version-constrained rules treat an empty Version as
+	// "matches any version" so an index request isn't surprised by
+	// a per-version rule firing prematurely.
 	Version string
 
 	// UploadTime is when the version was published upstream. Zero
 	// when not yet known; filters depending on it return
 	// [DecisionNeedsMoreData] in that case.
 	UploadTime time.Time
+}
+
+// Rule is one entry in an [Allowlist] or [Denylist]. Both fields are
+// optional individually but at least one must be set — an empty rule
+// matches every ref, which is almost certainly a misconfiguration.
+//
+// Matching rules:
+//   - Package, when set, is matched against [Ref.Package] (exact or
+//     [path.Match] glob).
+//   - Version, when set, is matched against [Ref.Version] (same
+//     semantics) — but only when [Ref.Version] is itself non-empty.
+//     An index request (Version="") makes any per-version rule fall
+//     back to its package check alone, so a rule like
+//     {Package:"log4j-core", Version:"2.14.*"} on a denylist denies
+//     the whole log4j-core index AND the specific 2.14.x files,
+//     symmetrically for allowlist.
+type Rule struct {
+	Package string `json:"package,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+
+// matches reports whether ref triggers this rule.
+func (r Rule) matches(ref Ref) (bool, error) {
+	if r.Package != "" {
+		ok, err := matchPattern(r.Package, ref.Package)
+		if err != nil {
+			return false, fmt.Errorf("package pattern %q: %w", r.Package, err)
+		}
+		if !ok {
+			return false, nil
+		}
+	}
+	if r.Version != "" && ref.Version != "" {
+		ok, err := matchPattern(r.Version, ref.Version)
+		if err != nil {
+			return false, fmt.Errorf("version pattern %q: %w", r.Version, err)
+		}
+		if !ok {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (r Rule) validate() error {
+	if r.Package == "" && r.Version == "" {
+		return fmt.Errorf("%w: rule must populate at least one of package or version", ErrInvalidFilter)
+	}
+	if r.Package != "" {
+		if _, err := path.Match(r.Package, ""); err != nil {
+			return fmt.Errorf("%w: rule package %q: %v", ErrInvalidFilter, r.Package, err)
+		}
+	}
+	if r.Version != "" {
+		if _, err := path.Match(r.Version, ""); err != nil {
+			return fmt.Errorf("%w: rule version %q: %v", ErrInvalidFilter, r.Version, err)
+		}
+	}
+	return nil
+}
+
+// matchPattern is the shared exact-or-glob match used by [Rule].
+// Exact match wins as a fast path so a literal pattern doesn't
+// depend on [path.Match]'s glob interpretation (which would surprise
+// nobody for normal names but means a literal glob char in a name
+// is hard to express — operators who actually need a literal glob
+// char can escape it via [path.Match]'s `\`).
+func matchPattern(pattern, name string) (bool, error) {
+	if pattern == name {
+		return true, nil
+	}
+	return path.Match(pattern, name)
 }
 
 // Decision is the outcome of a single [Filter.Allow] call.

--- a/pkg/proxy/filter/filter.go
+++ b/pkg/proxy/filter/filter.go
@@ -1,0 +1,265 @@
+// Package filter is the proxy governance layer. It defines the
+// [Filter] interface a proxy namespace runs against each upstream
+// reference and the [Chain] composition that runs filters in order.
+// In-tree filters cover the v1 needs: name [Allowlist], name
+// [Denylist], and a publish-time [Delay].
+//
+// Filters are run as early as their inputs allow. Name-only filters
+// run before any upstream call; metadata-dependent filters (e.g.
+// [Delay]) return [DecisionNeedsMoreData] when they don't have what
+// they need yet, and the chain caller re-runs after fetching the
+// upstream metadata. See https://github.com/yolocs/ocifactory/issues/118
+// for the design.
+package filter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ErrInvalidFilter is the sentinel for filter construction /
+// validation failures (invalid glob pattern, non-positive delay,
+// unknown kind). Wrapped via fmt.Errorf("...: %w", ErrInvalidFilter).
+var ErrInvalidFilter = errors.New("invalid filter")
+
+// Ref identifies a package and (optionally) a specific version that
+// a proxy filter is being asked to decide on. Empty fields signal
+// "not known yet" — filters that depend on them should return
+// [DecisionNeedsMoreData] rather than denying.
+type Ref struct {
+	// Package is the upstream package identifier — PyPI normalized
+	// name, npm name (including any "@scope/" prefix), or Maven
+	// "groupId:artifactId".
+	Package string
+
+	// Version is the upstream version string when resolved. Empty
+	// when the request hasn't pinned a version yet (e.g. an index
+	// fetch).
+	Version string
+
+	// UploadTime is when the version was published upstream. Zero
+	// when not yet known; filters depending on it return
+	// [DecisionNeedsMoreData] in that case.
+	UploadTime time.Time
+}
+
+// Decision is the outcome of a single [Filter.Allow] call.
+type Decision int
+
+const (
+	// DecisionAllow lets the [Ref] pass this filter. The chain
+	// continues to the next filter; a chain that ends with every
+	// filter returning DecisionAllow allows the request overall.
+	DecisionAllow Decision = iota
+
+	// DecisionDeny rejects the [Ref]. The chain short-circuits and
+	// the caller surfaces a 404 (with a deny log + counter at the
+	// caller layer).
+	DecisionDeny
+
+	// DecisionNeedsMoreData signals the filter could not evaluate
+	// with the data on the [Ref] (e.g. [Delay] without an
+	// UploadTime). The chain skips this filter for now and the
+	// caller re-runs the chain after fetching upstream metadata.
+	DecisionNeedsMoreData
+)
+
+// String makes Decision values readable in test failures and logs.
+func (d Decision) String() string {
+	switch d {
+	case DecisionAllow:
+		return "allow"
+	case DecisionDeny:
+		return "deny"
+	case DecisionNeedsMoreData:
+		return "needs-more-data"
+	default:
+		return fmt.Sprintf("decision(%d)", int(d))
+	}
+}
+
+// Filter is a single check in the proxy governance chain.
+//
+// Implementations must be safe for concurrent use: a single Filter
+// value is shared across every request that hits a namespace and is
+// expected to be free of per-call mutable state.
+type Filter interface {
+	// Allow decides whether ref should pass this filter. Returning
+	// a non-nil error is reserved for genuinely unexpected failures
+	// (a Filter that wants to deny on a normal condition returns
+	// DecisionDeny with a nil error); the chain treats a non-nil
+	// error as fatal and propagates it.
+	Allow(ctx context.Context, ref Ref) (Decision, error)
+}
+
+// Kinded is the optional extension implemented by every in-tree
+// filter. It exposes the JSON discriminator value so callers
+// (metrics, structured logs) can label denies by filter kind without
+// reflecting on the concrete type.
+type Kinded interface {
+	Kind() string
+}
+
+// Chain composes filters in order. First [DecisionDeny] wins;
+// [DecisionNeedsMoreData] from one filter does not short-circuit but
+// is "remembered" so the chain's overall return reflects it when no
+// other filter denies.
+type Chain []Filter
+
+// Allow runs the chain.
+//
+// The returned Filter is the deciding filter on DecisionDeny (so
+// callers can label metrics / structured logs by it) and nil
+// otherwise. On DecisionNeedsMoreData the returned Filter is the
+// first filter that asked for more data — useful in tests but not
+// load-bearing for callers, which simply re-run the chain after
+// enriching the ref.
+func (c Chain) Allow(ctx context.Context, ref Ref) (Decision, Filter, error) {
+	var pendingFilter Filter
+	for _, f := range c {
+		d, err := f.Allow(ctx, ref)
+		if err != nil {
+			return DecisionDeny, f, err
+		}
+		switch d {
+		case DecisionAllow:
+			// keep going
+		case DecisionDeny:
+			return DecisionDeny, f, nil
+		case DecisionNeedsMoreData:
+			if pendingFilter == nil {
+				pendingFilter = f
+			}
+		default:
+			return DecisionDeny, f, fmt.Errorf("filter %T returned unknown decision %d", f, d)
+		}
+	}
+	if pendingFilter != nil {
+		return DecisionNeedsMoreData, pendingFilter, nil
+	}
+	return DecisionAllow, nil, nil
+}
+
+// Filters is a serialisable ordered chain. It exists as a named
+// slice (not a bare []Filter) so JSON unmarshaling can dispatch each
+// element to a concrete filter implementation by kind — Go's default
+// encoder can't pick a concrete type for an interface field on its
+// own.
+type Filters []Filter
+
+// MarshalJSON encodes fs as a JSON array. Each element delegates to
+// its concrete filter's MarshalJSON, which embeds the kind
+// discriminator alongside its fields.
+//
+// nil and empty slices both marshal as `null`/`[]` per encoding/json's
+// defaults; callers that want the field omitted from the parent
+// document should set the parent's JSON tag to `omitempty`.
+func (fs Filters) MarshalJSON() ([]byte, error) {
+	if fs == nil {
+		return []byte("null"), nil
+	}
+	out := make([]json.RawMessage, len(fs))
+	for i, f := range fs {
+		if f == nil {
+			return nil, fmt.Errorf("%w: nil filter at index %d", ErrInvalidFilter, i)
+		}
+		b, err := json.Marshal(f)
+		if err != nil {
+			return nil, fmt.Errorf("filters[%d]: %w", i, err)
+		}
+		out[i] = b
+	}
+	return json.Marshal(out)
+}
+
+// UnmarshalJSON decodes fs from a JSON array. Each element is
+// dispatched to a concrete filter by its "kind" field; unknown kinds
+// are rejected so a body persisted by a newer binary doesn't load
+// silently lossy in an older one — operators get a clear upgrade
+// signal instead.
+func (fs *Filters) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		*fs = nil
+		return nil
+	}
+	var raws []json.RawMessage
+	if err := json.Unmarshal(data, &raws); err != nil {
+		return fmt.Errorf("filters: %w", err)
+	}
+	out := make(Filters, 0, len(raws))
+	for i, r := range raws {
+		f, err := UnmarshalFilter(r)
+		if err != nil {
+			return fmt.Errorf("filters[%d]: %w", i, err)
+		}
+		out = append(out, f)
+	}
+	*fs = out
+	return nil
+}
+
+// Validate returns nil iff every filter in fs validates. Filters
+// that don't implement an unexported validate hook are treated as
+// already valid (they have no construction-time arguments to check).
+func (fs Filters) Validate() error {
+	for i, f := range fs {
+		if v, ok := f.(interface{ validate() error }); ok {
+			if err := v.validate(); err != nil {
+				return fmt.Errorf("filters[%d]: %w", i, err)
+			}
+		}
+	}
+	return nil
+}
+
+// envelope is the minimal shape every persisted filter shares. The
+// concrete filter's own JSON tags add the kind-specific fields.
+type envelope struct {
+	Kind string `json:"kind"`
+}
+
+// UnmarshalFilter decodes a single filter object. It picks the
+// concrete type by the "kind" field; unknown kinds error.
+func UnmarshalFilter(data []byte) (Filter, error) {
+	var env envelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidFilter, err)
+	}
+	if env.Kind == "" {
+		return nil, fmt.Errorf("%w: missing kind", ErrInvalidFilter)
+	}
+	switch env.Kind {
+	case KindAllowlist:
+		var a Allowlist
+		if err := json.Unmarshal(data, &a); err != nil {
+			return nil, fmt.Errorf("%w: allowlist: %v", ErrInvalidFilter, err)
+		}
+		if err := a.validate(); err != nil {
+			return nil, err
+		}
+		return &a, nil
+	case KindDenylist:
+		var d Denylist
+		if err := json.Unmarshal(data, &d); err != nil {
+			return nil, fmt.Errorf("%w: denylist: %v", ErrInvalidFilter, err)
+		}
+		if err := d.validate(); err != nil {
+			return nil, err
+		}
+		return &d, nil
+	case KindDelay:
+		var d Delay
+		if err := json.Unmarshal(data, &d); err != nil {
+			return nil, fmt.Errorf("%w: delay: %v", ErrInvalidFilter, err)
+		}
+		if err := d.validate(); err != nil {
+			return nil, err
+		}
+		return &d, nil
+	default:
+		return nil, fmt.Errorf("%w: unknown kind %q", ErrInvalidFilter, env.Kind)
+	}
+}

--- a/pkg/proxy/filter/filter_test.go
+++ b/pkg/proxy/filter/filter_test.go
@@ -296,12 +296,12 @@ func TestFilters_JSONRoundtrip(t *testing.T) {
 		{
 			name: "allowlist-patterns",
 			in:   filter.Filters{&filter.Allowlist{Patterns: []string{"foo", "bar*"}}},
-			want: `[{"kind":"allowlist","patterns":["foo","bar*"]}]`,
+			want: `[{"kind":"allow","patterns":["foo","bar*"]}]`,
 		},
 		{
 			name: "allowlist-rules",
 			in:   filter.Filters{&filter.Allowlist{Rules: []filter.Rule{{Package: "requests", Version: "2.31.*"}}}},
-			want: `[{"kind":"allowlist","rules":[{"package":"requests","version":"2.31.*"}]}]`,
+			want: `[{"kind":"allow","rules":[{"package":"requests","version":"2.31.*"}]}]`,
 		},
 		{
 			name: "allowlist-mixed",
@@ -309,17 +309,17 @@ func TestFilters_JSONRoundtrip(t *testing.T) {
 				Patterns: []string{"safe"},
 				Rules:    []filter.Rule{{Package: "requests", Version: "2.31.*"}},
 			}},
-			want: `[{"kind":"allowlist","patterns":["safe"],"rules":[{"package":"requests","version":"2.31.*"}]}]`,
+			want: `[{"kind":"allow","patterns":["safe"],"rules":[{"package":"requests","version":"2.31.*"}]}]`,
 		},
 		{
 			name: "denylist-patterns",
 			in:   filter.Filters{&filter.Denylist{Patterns: []string{"evil"}}},
-			want: `[{"kind":"denylist","patterns":["evil"]}]`,
+			want: `[{"kind":"deny","patterns":["evil"]}]`,
 		},
 		{
 			name: "denylist-rules-version-pin",
 			in:   filter.Filters{&filter.Denylist{Rules: []filter.Rule{{Package: "log4j-core", Version: "2.14.*"}}}},
-			want: `[{"kind":"denylist","rules":[{"package":"log4j-core","version":"2.14.*"}]}]`,
+			want: `[{"kind":"deny","rules":[{"package":"log4j-core","version":"2.14.*"}]}]`,
 		},
 		{
 			name: "delay-hours",
@@ -338,7 +338,7 @@ func TestFilters_JSONRoundtrip(t *testing.T) {
 				&filter.Denylist{Rules: []filter.Rule{{Package: "log4j-core", Version: "2.14.*"}}},
 				&filter.Delay{MinAge: 24 * time.Hour},
 			},
-			want: `[{"kind":"allowlist","patterns":["@myorg/*"]},{"kind":"denylist","rules":[{"package":"log4j-core","version":"2.14.*"}]},{"kind":"delay","min_age":"24h0m0s"}]`,
+			want: `[{"kind":"allow","patterns":["@myorg/*"]},{"kind":"deny","rules":[{"package":"log4j-core","version":"2.14.*"}]},{"kind":"delay","min_age":"24h0m0s"}]`,
 		},
 	}
 
@@ -375,7 +375,7 @@ func TestFilters_UnmarshalErrors(t *testing.T) {
 	}{
 		{
 			name:    "not-an-array",
-			body:    `{"kind":"allowlist"}`,
+			body:    `{"kind":"allow"}`,
 			wantErr: nil, // json error, not ErrInvalidFilter
 		},
 		{
@@ -390,12 +390,12 @@ func TestFilters_UnmarshalErrors(t *testing.T) {
 		},
 		{
 			name:    "invalid-body",
-			body:    `[{"kind":"allowlist","patterns":[]}]`,
+			body:    `[{"kind":"allow","patterns":[]}]`,
 			wantErr: filter.ErrInvalidFilter,
 		},
 		{
 			name:    "invalid-rule-empty",
-			body:    `[{"kind":"denylist","rules":[{}]}]`,
+			body:    `[{"kind":"deny","rules":[{}]}]`,
 			wantErr: filter.ErrInvalidFilter,
 		},
 		{

--- a/pkg/proxy/filter/filter_test.go
+++ b/pkg/proxy/filter/filter_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // stubFilter is a Filter that returns a fixed decision and counts
-// how many times Allow has been invoked, so chain tests can pin
+// how many times Decide has been invoked, so chain tests can pin
 // ordering and short-circuit behavior.
 type stubFilter struct {
 	name     string
@@ -21,22 +21,22 @@ type stubFilter struct {
 	calls    int
 }
 
-func (s *stubFilter) Allow(ctx context.Context, ref filter.Ref) (filter.Decision, error) {
+func (s *stubFilter) Decide(ctx context.Context, ref filter.Ref) (filter.Decision, error) {
 	s.calls++
 	return s.decision, s.err
 }
 
 func (s *stubFilter) Kind() string { return s.name }
 
-// chainPath returns the chain.Allow tuple in a comparable shape.
+// chainPath returns the Filters.Decide tuple in a comparable shape.
 type chainPath struct {
 	Decision filter.Decision
 	Matched  string // "" if no filter matched
 }
 
-func runChain(t *testing.T, c filter.Chain, ref filter.Ref) (chainPath, error) {
+func runChain(t *testing.T, fs filter.Filters, ref filter.Ref) (chainPath, error) {
 	t.Helper()
-	d, f, err := c.Allow(t.Context(), ref)
+	d, f, err := fs.Decide(t.Context(), ref)
 	out := chainPath{Decision: d}
 	if f != nil {
 		if k, ok := f.(filter.Kinded); ok {
@@ -46,41 +46,56 @@ func runChain(t *testing.T, c filter.Chain, ref filter.Ref) (chainPath, error) {
 	return out, err
 }
 
-// TestChain_Allow covers the core composition semantics: an empty
-// chain allows; a chain of allows allows; the first deny wins and
-// short-circuits; NeedsMoreData is "remembered" without
-// short-circuiting; and an error short-circuits with the filter
-// returned.
-func TestChain_Allow(t *testing.T) {
+// TestFilters_Decide covers the chain composition semantics:
+//   - Empty chain allows.
+//   - All-abstain chain allows.
+//   - First explicit Allow or Deny short-circuits.
+//   - Abstain advances; NeedsMoreData short-circuits.
+//   - An error short-circuits with the deciding filter returned.
+func TestFilters_Decide(t *testing.T) {
 	t.Parallel()
+
+	// Every test case targets a file download (ref.Version set);
+	// index requests are covered by TestFilters_DecideSkipsIndex.
+	ref := filter.Ref{Package: "pkg", Version: "1.0.0"}
 
 	tests := []struct {
 		name      string
-		chain     filter.Chain
+		chain     filter.Filters
 		want      chainPath
 		wantErr   bool
-		wantCalls []int // expected call count per filter, by index
+		wantCalls []int
 	}{
 		{
 			name:      "empty-chain-allows",
-			chain:     filter.Chain{},
+			chain:     filter.Filters{},
 			want:      chainPath{Decision: filter.DecisionAllow},
 			wantCalls: nil,
 		},
 		{
-			name: "all-allow",
-			chain: filter.Chain{
-				&stubFilter{name: "a", decision: filter.DecisionAllow},
-				&stubFilter{name: "b", decision: filter.DecisionAllow},
-				&stubFilter{name: "c", decision: filter.DecisionAllow},
+			name: "all-abstain-allows",
+			chain: filter.Filters{
+				&stubFilter{name: "a", decision: filter.DecisionAbstain},
+				&stubFilter{name: "b", decision: filter.DecisionAbstain},
+				&stubFilter{name: "c", decision: filter.DecisionAbstain},
 			},
 			want:      chainPath{Decision: filter.DecisionAllow},
 			wantCalls: []int{1, 1, 1},
 		},
 		{
-			name: "first-deny-wins",
-			chain: filter.Chain{
-				&stubFilter{name: "a", decision: filter.DecisionAllow},
+			name: "first-allow-short-circuits",
+			chain: filter.Filters{
+				&stubFilter{name: "a", decision: filter.DecisionAbstain},
+				&stubFilter{name: "b", decision: filter.DecisionAllow},
+				&stubFilter{name: "c", decision: filter.DecisionDeny},
+			},
+			want:      chainPath{Decision: filter.DecisionAllow, Matched: "b"},
+			wantCalls: []int{1, 1, 0},
+		},
+		{
+			name: "first-deny-short-circuits",
+			chain: filter.Filters{
+				&stubFilter{name: "a", decision: filter.DecisionAbstain},
 				&stubFilter{name: "b", decision: filter.DecisionDeny},
 				&stubFilter{name: "c", decision: filter.DecisionAllow},
 			},
@@ -88,55 +103,19 @@ func TestChain_Allow(t *testing.T) {
 			wantCalls: []int{1, 1, 0},
 		},
 		{
-			// First deny is the one returned, even when a later
-			// filter would also deny. Pinning this so observability
-			// labels stay stable (one deny per request).
-			name: "two-denies-first-wins",
-			chain: filter.Chain{
-				&stubFilter{name: "a", decision: filter.DecisionDeny},
-				&stubFilter{name: "b", decision: filter.DecisionDeny},
-			},
-			want:      chainPath{Decision: filter.DecisionDeny, Matched: "a"},
-			wantCalls: []int{1, 0},
-		},
-		{
-			name: "needs-more-data-does-not-short-circuit",
-			chain: filter.Chain{
-				&stubFilter{name: "a", decision: filter.DecisionAllow},
+			name: "abstain-then-needs-more-data",
+			chain: filter.Filters{
+				&stubFilter{name: "a", decision: filter.DecisionAbstain},
 				&stubFilter{name: "b", decision: filter.DecisionNeedsMoreData},
 				&stubFilter{name: "c", decision: filter.DecisionAllow},
 			},
 			want:      chainPath{Decision: filter.DecisionNeedsMoreData, Matched: "b"},
-			wantCalls: []int{1, 1, 1},
-		},
-		{
-			// Deny later in the chain takes precedence over an earlier
-			// NeedsMoreData. The chain caller's contract is: if Deny,
-			// reject; if NeedsMoreData, fetch metadata and re-run; if
-			// Allow, proceed. A deny-after-needs-more-data must not
-			// leak through as NeedsMoreData.
-			name: "deny-trumps-needs-more-data",
-			chain: filter.Chain{
-				&stubFilter{name: "a", decision: filter.DecisionNeedsMoreData},
-				&stubFilter{name: "b", decision: filter.DecisionDeny},
-			},
-			want:      chainPath{Decision: filter.DecisionDeny, Matched: "b"},
-			wantCalls: []int{1, 1},
-		},
-		{
-			name: "first-needs-more-data-is-returned",
-			chain: filter.Chain{
-				&stubFilter{name: "a", decision: filter.DecisionAllow},
-				&stubFilter{name: "b", decision: filter.DecisionNeedsMoreData},
-				&stubFilter{name: "c", decision: filter.DecisionNeedsMoreData},
-			},
-			want:      chainPath{Decision: filter.DecisionNeedsMoreData, Matched: "b"},
-			wantCalls: []int{1, 1, 1},
+			wantCalls: []int{1, 1, 0},
 		},
 		{
 			name: "error-short-circuits",
-			chain: filter.Chain{
-				&stubFilter{name: "a", decision: filter.DecisionAllow},
+			chain: filter.Filters{
+				&stubFilter{name: "a", decision: filter.DecisionAbstain},
 				&stubFilter{name: "b", decision: filter.DecisionDeny, err: errors.New("boom")},
 				&stubFilter{name: "c", decision: filter.DecisionAllow},
 			},
@@ -149,12 +128,12 @@ func TestChain_Allow(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := runChain(t, tc.chain, filter.Ref{Package: "pkg"})
+			got, err := runChain(t, tc.chain, ref)
 			if (err != nil) != tc.wantErr {
-				t.Errorf("Allow() err = %v, wantErr=%v", err, tc.wantErr)
+				t.Errorf("Decide() err = %v, wantErr=%v", err, tc.wantErr)
 			}
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("Chain.Allow mismatch (-want +got):\n%s", diff)
+				t.Errorf("Filters.Decide mismatch (-want +got):\n%s", diff)
 			}
 			for i, want := range tc.wantCalls {
 				got := tc.chain[i].(*stubFilter).calls
@@ -166,82 +145,124 @@ func TestChain_Allow(t *testing.T) {
 	}
 }
 
-// TestChain_NeedsMoreDataReRun pins the documented re-run semantics:
-// callers re-invoke the chain after enriching the ref, and a filter
-// that previously returned NeedsMoreData now sees enough data to
-// decide.
-func TestChain_NeedsMoreDataReRun(t *testing.T) {
+// TestFilters_DecideSkipsIndex pins the load-bearing property that
+// filtering applies to file downloads only. An index-style request
+// (empty Ref.Version) returns DecisionAllow without invoking any
+// filter, even one that would deny by package name.
+func TestFilters_DecideSkipsIndex(t *testing.T) {
+	t.Parallel()
+
+	denyAll := &stubFilter{name: "deny-everything", decision: filter.DecisionDeny}
+	fs := filter.Filters{denyAll}
+
+	d, f, err := fs.Decide(t.Context(), filter.Ref{Package: "evil"})
+	if err != nil {
+		t.Fatalf("Decide err: %v", err)
+	}
+	if d != filter.DecisionAllow {
+		t.Errorf("Decision = %v, want Allow", d)
+	}
+	if f != nil {
+		t.Errorf("Filter = %T, want nil", f)
+	}
+	if denyAll.calls != 0 {
+		t.Errorf("filter calls = %d, want 0 (chain bypassed for index)", denyAll.calls)
+	}
+}
+
+// TestFilters_AllowlistOverridesDelay pins the headline policy
+// example: an allowlisted package bypasses delay even when the
+// version is younger than MinAge.
+func TestFilters_AllowlistOverridesDelay(t *testing.T) {
 	t.Parallel()
 
 	frozen := time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC)
-	chain := filter.Chain{
+	fs := filter.Filters{
 		&filter.Allowlist{Patterns: []string{"requests"}},
 		&filter.Delay{MinAge: 24 * time.Hour},
 	}
 	ctx := filter.WithClock(t.Context(), func() time.Time { return frozen })
+	ref := filter.Ref{Package: "requests", Version: "2.31.0", UploadTime: frozen.Add(-time.Hour)}
 
-	// Pass 1: no upload time yet.
-	ref := filter.Ref{Package: "requests", Version: "2.31.0"}
-	d, f, err := chain.Allow(ctx, ref)
+	d, f, err := fs.Decide(ctx, ref)
 	if err != nil {
-		t.Fatalf("pass 1 err: %v", err)
-	}
-	if d != filter.DecisionNeedsMoreData {
-		t.Fatalf("pass 1 decision = %v, want NeedsMoreData", d)
-	}
-	if k, _ := f.(filter.Kinded); k == nil || k.Kind() != filter.KindDelay {
-		t.Errorf("pass 1 pending filter = %T, want *Delay", f)
-	}
-
-	// Pass 2: upload time fresh — still under threshold, expect deny.
-	ref.UploadTime = frozen.Add(-1 * time.Hour)
-	d, f, err = chain.Allow(ctx, ref)
-	if err != nil {
-		t.Fatalf("pass 2 err: %v", err)
-	}
-	if d != filter.DecisionDeny {
-		t.Fatalf("pass 2 decision = %v, want Deny", d)
-	}
-	if k, _ := f.(filter.Kinded); k == nil || k.Kind() != filter.KindDelay {
-		t.Errorf("pass 2 deny filter = %T, want *Delay", f)
-	}
-
-	// Pass 3: upload time aged out — expect allow.
-	ref.UploadTime = frozen.Add(-30 * 24 * time.Hour)
-	d, f, err = chain.Allow(ctx, ref)
-	if err != nil {
-		t.Fatalf("pass 3 err: %v", err)
+		t.Fatalf("Decide err: %v", err)
 	}
 	if d != filter.DecisionAllow {
-		t.Fatalf("pass 3 decision = %v, want Allow", d)
+		t.Errorf("Decision = %v, want Allow", d)
 	}
-	if f != nil {
-		t.Errorf("pass 3 matched filter = %T, want nil", f)
+	if k, _ := f.(filter.Kinded); k == nil || k.Kind() != filter.KindAllowlist {
+		t.Errorf("deciding filter = %T, want *Allowlist", f)
 	}
 }
 
-// TestChain_DenylistShortCircuitsBeforeDelay pins that name-only
-// filters can deny before any metadata-dependent filter would have
-// asked for more data — the load-bearing property that lets a proxy
-// reject by name without ever calling upstream.
-func TestChain_DenylistShortCircuitsBeforeDelay(t *testing.T) {
+// TestFilters_DelayHandlesAbstainedRef pins the typical chain:
+// allow-listed names bypass, deny-listed names short-circuit, and
+// everything else falls through to delay.
+func TestFilters_DelayHandlesAbstainedRef(t *testing.T) {
 	t.Parallel()
 
-	delay := &filter.Delay{MinAge: 24 * time.Hour}
-	chain := filter.Chain{
-		&filter.Denylist{Patterns: []string{"evil"}},
-		delay,
+	frozen := time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC)
+	fs := filter.Filters{
+		&filter.Allowlist{Patterns: []string{"@myorg/*"}},
+		&filter.Denylist{Patterns: []string{"evil-*"}},
+		&filter.Delay{MinAge: 24 * time.Hour},
+	}
+	ctx := filter.WithClock(t.Context(), func() time.Time { return frozen })
+
+	tests := []struct {
+		name     string
+		ref      filter.Ref
+		wantDec  filter.Decision
+		wantKind string
+		wantErr  bool
+	}{
+		{
+			name:     "allowlisted-bypasses-delay",
+			ref:      filter.Ref{Package: "@myorg/sdk", Version: "1.0.0", UploadTime: frozen.Add(-time.Hour)},
+			wantDec:  filter.DecisionAllow,
+			wantKind: filter.KindAllowlist,
+		},
+		{
+			name:     "denylisted-short-circuits",
+			ref:      filter.Ref{Package: "evil-pkg", Version: "1.0.0", UploadTime: frozen.Add(-30 * 24 * time.Hour)},
+			wantDec:  filter.DecisionDeny,
+			wantKind: filter.KindDenylist,
+		},
+		{
+			name:     "fresh-version-denied-by-delay",
+			ref:      filter.Ref{Package: "neutral", Version: "1.0.0", UploadTime: frozen.Add(-time.Hour)},
+			wantDec:  filter.DecisionDeny,
+			wantKind: filter.KindDelay,
+		},
+		{
+			name:     "aged-version-allowed-by-delay",
+			ref:      filter.Ref{Package: "neutral", Version: "1.0.0", UploadTime: frozen.Add(-30 * 24 * time.Hour)},
+			wantDec:  filter.DecisionAllow,
+			wantKind: filter.KindDelay,
+		},
+		{
+			name:     "missing-upload-time-needs-more-data",
+			ref:      filter.Ref{Package: "neutral", Version: "1.0.0"},
+			wantDec:  filter.DecisionNeedsMoreData,
+			wantKind: filter.KindDelay,
+		},
 	}
 
-	d, f, err := chain.Allow(t.Context(), filter.Ref{Package: "evil"})
-	if err != nil {
-		t.Fatalf("Allow err: %v", err)
-	}
-	if d != filter.DecisionDeny {
-		t.Errorf("Decision = %v, want Deny", d)
-	}
-	if k, _ := f.(filter.Kinded); k == nil || k.Kind() != filter.KindDenylist {
-		t.Errorf("matched filter = %T, want *Denylist", f)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			d, f, err := fs.Decide(ctx, tc.ref)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("Decide err = %v, wantErr=%v", err, tc.wantErr)
+			}
+			if d != tc.wantDec {
+				t.Errorf("Decision = %v, want %v", d, tc.wantDec)
+			}
+			if k, _ := f.(filter.Kinded); k == nil || k.Kind() != tc.wantKind {
+				t.Errorf("deciding filter = %T, want kind %q", f, tc.wantKind)
+			}
+		})
 	}
 }
 
@@ -258,6 +279,7 @@ func TestDecision_String(t *testing.T) {
 	}{
 		{filter.DecisionAllow, "allow"},
 		{filter.DecisionDeny, "deny"},
+		{filter.DecisionAbstain, "abstain"},
 		{filter.DecisionNeedsMoreData, "needs-more-data"},
 		{filter.Decision(99), "decision(99)"},
 	}

--- a/pkg/proxy/filter/filter_test.go
+++ b/pkg/proxy/filter/filter_test.go
@@ -1,0 +1,444 @@
+package filter_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/yolocs/ocifactory/pkg/proxy/filter"
+)
+
+// stubFilter is a Filter that returns a fixed decision and counts
+// how many times Allow has been invoked, so chain tests can pin
+// ordering and short-circuit behavior.
+type stubFilter struct {
+	name     string
+	decision filter.Decision
+	err      error
+	calls    int
+}
+
+func (s *stubFilter) Allow(ctx context.Context, ref filter.Ref) (filter.Decision, error) {
+	s.calls++
+	return s.decision, s.err
+}
+
+func (s *stubFilter) Kind() string { return s.name }
+
+// chainPath returns the chain.Allow tuple in a comparable shape.
+type chainPath struct {
+	Decision filter.Decision
+	Matched  string // "" if no filter matched
+}
+
+func runChain(t *testing.T, c filter.Chain, ref filter.Ref) (chainPath, error) {
+	t.Helper()
+	d, f, err := c.Allow(t.Context(), ref)
+	out := chainPath{Decision: d}
+	if f != nil {
+		if k, ok := f.(filter.Kinded); ok {
+			out.Matched = k.Kind()
+		}
+	}
+	return out, err
+}
+
+// TestChain_Allow covers the core composition semantics: an empty
+// chain allows; a chain of allows allows; the first deny wins and
+// short-circuits; NeedsMoreData is "remembered" without
+// short-circuiting; and an error short-circuits with the filter
+// returned.
+func TestChain_Allow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		chain     filter.Chain
+		want      chainPath
+		wantErr   bool
+		wantCalls []int // expected call count per filter, by index
+	}{
+		{
+			name:      "empty-chain-allows",
+			chain:     filter.Chain{},
+			want:      chainPath{Decision: filter.DecisionAllow},
+			wantCalls: nil,
+		},
+		{
+			name: "all-allow",
+			chain: filter.Chain{
+				&stubFilter{name: "a", decision: filter.DecisionAllow},
+				&stubFilter{name: "b", decision: filter.DecisionAllow},
+				&stubFilter{name: "c", decision: filter.DecisionAllow},
+			},
+			want:      chainPath{Decision: filter.DecisionAllow},
+			wantCalls: []int{1, 1, 1},
+		},
+		{
+			name: "first-deny-wins",
+			chain: filter.Chain{
+				&stubFilter{name: "a", decision: filter.DecisionAllow},
+				&stubFilter{name: "b", decision: filter.DecisionDeny},
+				&stubFilter{name: "c", decision: filter.DecisionAllow},
+			},
+			want:      chainPath{Decision: filter.DecisionDeny, Matched: "b"},
+			wantCalls: []int{1, 1, 0},
+		},
+		{
+			// First deny is the one returned, even when a later
+			// filter would also deny. Pinning this so observability
+			// labels stay stable (one deny per request).
+			name: "two-denies-first-wins",
+			chain: filter.Chain{
+				&stubFilter{name: "a", decision: filter.DecisionDeny},
+				&stubFilter{name: "b", decision: filter.DecisionDeny},
+			},
+			want:      chainPath{Decision: filter.DecisionDeny, Matched: "a"},
+			wantCalls: []int{1, 0},
+		},
+		{
+			name: "needs-more-data-does-not-short-circuit",
+			chain: filter.Chain{
+				&stubFilter{name: "a", decision: filter.DecisionAllow},
+				&stubFilter{name: "b", decision: filter.DecisionNeedsMoreData},
+				&stubFilter{name: "c", decision: filter.DecisionAllow},
+			},
+			want:      chainPath{Decision: filter.DecisionNeedsMoreData, Matched: "b"},
+			wantCalls: []int{1, 1, 1},
+		},
+		{
+			// Deny later in the chain takes precedence over an earlier
+			// NeedsMoreData. The chain caller's contract is: if Deny,
+			// reject; if NeedsMoreData, fetch metadata and re-run; if
+			// Allow, proceed. A deny-after-needs-more-data must not
+			// leak through as NeedsMoreData.
+			name: "deny-trumps-needs-more-data",
+			chain: filter.Chain{
+				&stubFilter{name: "a", decision: filter.DecisionNeedsMoreData},
+				&stubFilter{name: "b", decision: filter.DecisionDeny},
+			},
+			want:      chainPath{Decision: filter.DecisionDeny, Matched: "b"},
+			wantCalls: []int{1, 1},
+		},
+		{
+			name: "first-needs-more-data-is-returned",
+			chain: filter.Chain{
+				&stubFilter{name: "a", decision: filter.DecisionAllow},
+				&stubFilter{name: "b", decision: filter.DecisionNeedsMoreData},
+				&stubFilter{name: "c", decision: filter.DecisionNeedsMoreData},
+			},
+			want:      chainPath{Decision: filter.DecisionNeedsMoreData, Matched: "b"},
+			wantCalls: []int{1, 1, 1},
+		},
+		{
+			name: "error-short-circuits",
+			chain: filter.Chain{
+				&stubFilter{name: "a", decision: filter.DecisionAllow},
+				&stubFilter{name: "b", decision: filter.DecisionDeny, err: errors.New("boom")},
+				&stubFilter{name: "c", decision: filter.DecisionAllow},
+			},
+			want:      chainPath{Decision: filter.DecisionDeny, Matched: "b"},
+			wantErr:   true,
+			wantCalls: []int{1, 1, 0},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := runChain(t, tc.chain, filter.Ref{Package: "pkg"})
+			if (err != nil) != tc.wantErr {
+				t.Errorf("Allow() err = %v, wantErr=%v", err, tc.wantErr)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Chain.Allow mismatch (-want +got):\n%s", diff)
+			}
+			for i, want := range tc.wantCalls {
+				got := tc.chain[i].(*stubFilter).calls
+				if got != want {
+					t.Errorf("filter[%d] calls = %d, want %d", i, got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestChain_NeedsMoreDataReRun pins the documented re-run semantics:
+// callers re-invoke the chain after enriching the ref, and a filter
+// that previously returned NeedsMoreData now sees enough data to
+// decide.
+func TestChain_NeedsMoreDataReRun(t *testing.T) {
+	t.Parallel()
+
+	frozen := time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC)
+	chain := filter.Chain{
+		&filter.Allowlist{Patterns: []string{"requests"}},
+		&filter.Delay{MinAge: 24 * time.Hour},
+	}
+	ctx := filter.WithClock(t.Context(), func() time.Time { return frozen })
+
+	// Pass 1: no upload time yet.
+	ref := filter.Ref{Package: "requests", Version: "2.31.0"}
+	d, f, err := chain.Allow(ctx, ref)
+	if err != nil {
+		t.Fatalf("pass 1 err: %v", err)
+	}
+	if d != filter.DecisionNeedsMoreData {
+		t.Fatalf("pass 1 decision = %v, want NeedsMoreData", d)
+	}
+	if k, _ := f.(filter.Kinded); k == nil || k.Kind() != filter.KindDelay {
+		t.Errorf("pass 1 pending filter = %T, want *Delay", f)
+	}
+
+	// Pass 2: upload time fresh — still under threshold, expect deny.
+	ref.UploadTime = frozen.Add(-1 * time.Hour)
+	d, f, err = chain.Allow(ctx, ref)
+	if err != nil {
+		t.Fatalf("pass 2 err: %v", err)
+	}
+	if d != filter.DecisionDeny {
+		t.Fatalf("pass 2 decision = %v, want Deny", d)
+	}
+	if k, _ := f.(filter.Kinded); k == nil || k.Kind() != filter.KindDelay {
+		t.Errorf("pass 2 deny filter = %T, want *Delay", f)
+	}
+
+	// Pass 3: upload time aged out — expect allow.
+	ref.UploadTime = frozen.Add(-30 * 24 * time.Hour)
+	d, f, err = chain.Allow(ctx, ref)
+	if err != nil {
+		t.Fatalf("pass 3 err: %v", err)
+	}
+	if d != filter.DecisionAllow {
+		t.Fatalf("pass 3 decision = %v, want Allow", d)
+	}
+	if f != nil {
+		t.Errorf("pass 3 matched filter = %T, want nil", f)
+	}
+}
+
+// TestChain_DenylistShortCircuitsBeforeDelay pins that name-only
+// filters can deny before any metadata-dependent filter would have
+// asked for more data — the load-bearing property that lets a proxy
+// reject by name without ever calling upstream.
+func TestChain_DenylistShortCircuitsBeforeDelay(t *testing.T) {
+	t.Parallel()
+
+	delay := &filter.Delay{MinAge: 24 * time.Hour}
+	chain := filter.Chain{
+		&filter.Denylist{Patterns: []string{"evil"}},
+		delay,
+	}
+
+	d, f, err := chain.Allow(t.Context(), filter.Ref{Package: "evil"})
+	if err != nil {
+		t.Fatalf("Allow err: %v", err)
+	}
+	if d != filter.DecisionDeny {
+		t.Errorf("Decision = %v, want Deny", d)
+	}
+	if k, _ := f.(filter.Kinded); k == nil || k.Kind() != filter.KindDenylist {
+		t.Errorf("matched filter = %T, want *Denylist", f)
+	}
+}
+
+// TestDecision_String pins the Stringer output used in logs / test
+// messages. Unknown values are surfaced rather than silently
+// formatted, so a future contributor adding a Decision constant
+// can't forget to add the case.
+func TestDecision_String(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   filter.Decision
+		want string
+	}{
+		{filter.DecisionAllow, "allow"},
+		{filter.DecisionDeny, "deny"},
+		{filter.DecisionNeedsMoreData, "needs-more-data"},
+		{filter.Decision(99), "decision(99)"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.want, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.in.String(); got != tc.want {
+				t.Errorf("Decision(%d).String() = %q, want %q", int(tc.in), got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFilters_JSONRoundtrip pins both the byte-stable marshaled form
+// and the unmarshal-back-to-typed-values dispatch. The wire shape is
+// load-bearing for the namespace spec on-disk format, so a refactor
+// can't silently rename `kind`, `patterns`, or `min_age`.
+func TestFilters_JSONRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   filter.Filters
+		want string
+	}{
+		{
+			name: "nil",
+			in:   nil,
+			want: `null`,
+		},
+		{
+			name: "empty",
+			in:   filter.Filters{},
+			want: `[]`,
+		},
+		{
+			name: "allowlist",
+			in:   filter.Filters{&filter.Allowlist{Patterns: []string{"foo", "bar*"}}},
+			want: `[{"kind":"allowlist","patterns":["foo","bar*"]}]`,
+		},
+		{
+			name: "denylist",
+			in:   filter.Filters{&filter.Denylist{Patterns: []string{"evil"}}},
+			want: `[{"kind":"denylist","patterns":["evil"]}]`,
+		},
+		{
+			name: "delay-hours",
+			in:   filter.Filters{&filter.Delay{MinAge: 24 * time.Hour}},
+			want: `[{"kind":"delay","min_age":"24h0m0s"}]`,
+		},
+		{
+			name: "delay-compound",
+			in:   filter.Filters{&filter.Delay{MinAge: time.Hour + 30*time.Minute}},
+			want: `[{"kind":"delay","min_age":"1h30m0s"}]`,
+		},
+		{
+			name: "mixed-chain",
+			in: filter.Filters{
+				&filter.Allowlist{Patterns: []string{"@myorg/*"}},
+				&filter.Denylist{Patterns: []string{"evil-*"}},
+				&filter.Delay{MinAge: 24 * time.Hour},
+			},
+			want: `[{"kind":"allowlist","patterns":["@myorg/*"]},{"kind":"denylist","patterns":["evil-*"]},{"kind":"delay","min_age":"24h0m0s"}]`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := json.Marshal(tc.in)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("Marshal:\n got: %s\nwant: %s", got, tc.want)
+			}
+			var rt filter.Filters
+			if err := json.Unmarshal([]byte(tc.want), &rt); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if diff := cmp.Diff(tc.in, rt); diff != "" {
+				t.Errorf("Roundtrip mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestFilters_UnmarshalErrors covers the rejection paths: malformed
+// JSON, missing kind, unknown kind, and invalid filter bodies.
+func TestFilters_UnmarshalErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		body    string
+		wantErr error
+	}{
+		{
+			name:    "not-an-array",
+			body:    `{"kind":"allowlist"}`,
+			wantErr: nil, // json error, not ErrInvalidFilter
+		},
+		{
+			name:    "missing-kind",
+			body:    `[{"patterns":["foo"]}]`,
+			wantErr: filter.ErrInvalidFilter,
+		},
+		{
+			name:    "unknown-kind",
+			body:    `[{"kind":"nope"}]`,
+			wantErr: filter.ErrInvalidFilter,
+		},
+		{
+			name:    "invalid-body",
+			body:    `[{"kind":"allowlist","patterns":[]}]`,
+			wantErr: filter.ErrInvalidFilter,
+		},
+		{
+			name:    "malformed",
+			body:    `[`,
+			wantErr: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var fs filter.Filters
+			err := json.Unmarshal([]byte(tc.body), &fs)
+			if err == nil {
+				t.Fatalf("Unmarshal(%q) = nil, want error", tc.body)
+			}
+			if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
+				t.Errorf("Unmarshal(%q) error = %v, want errors.Is %v", tc.body, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestFilters_Validate covers the namespace-spec validation hook:
+// any filter that exposes validation reports its errors with a
+// positional prefix. Built-in filters already validate at unmarshal
+// time, but the spec layer still calls Validate to defend against
+// values constructed in Go code (programmatic admin tools, tests)
+// rather than through JSON.
+func TestFilters_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		fs      filter.Filters
+		wantErr bool
+	}{
+		{
+			name: "all-valid",
+			fs: filter.Filters{
+				&filter.Allowlist{Patterns: []string{"foo"}},
+				&filter.Delay{MinAge: time.Hour},
+			},
+		},
+		{
+			name:    "invalid-allowlist",
+			fs:      filter.Filters{&filter.Allowlist{}},
+			wantErr: true,
+		},
+		{
+			name: "invalid-delay-after-valid-allowlist",
+			fs: filter.Filters{
+				&filter.Allowlist{Patterns: []string{"foo"}},
+				&filter.Delay{MinAge: 0},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.fs.Validate()
+			if (err != nil) != tc.wantErr {
+				t.Errorf("Validate() = %v, wantErr=%v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/proxy/filter/filter_test.go
+++ b/pkg/proxy/filter/filter_test.go
@@ -294,14 +294,32 @@ func TestFilters_JSONRoundtrip(t *testing.T) {
 			want: `[]`,
 		},
 		{
-			name: "allowlist",
+			name: "allowlist-patterns",
 			in:   filter.Filters{&filter.Allowlist{Patterns: []string{"foo", "bar*"}}},
 			want: `[{"kind":"allowlist","patterns":["foo","bar*"]}]`,
 		},
 		{
-			name: "denylist",
+			name: "allowlist-rules",
+			in:   filter.Filters{&filter.Allowlist{Rules: []filter.Rule{{Package: "requests", Version: "2.31.*"}}}},
+			want: `[{"kind":"allowlist","rules":[{"package":"requests","version":"2.31.*"}]}]`,
+		},
+		{
+			name: "allowlist-mixed",
+			in: filter.Filters{&filter.Allowlist{
+				Patterns: []string{"safe"},
+				Rules:    []filter.Rule{{Package: "requests", Version: "2.31.*"}},
+			}},
+			want: `[{"kind":"allowlist","patterns":["safe"],"rules":[{"package":"requests","version":"2.31.*"}]}]`,
+		},
+		{
+			name: "denylist-patterns",
 			in:   filter.Filters{&filter.Denylist{Patterns: []string{"evil"}}},
 			want: `[{"kind":"denylist","patterns":["evil"]}]`,
+		},
+		{
+			name: "denylist-rules-version-pin",
+			in:   filter.Filters{&filter.Denylist{Rules: []filter.Rule{{Package: "log4j-core", Version: "2.14.*"}}}},
+			want: `[{"kind":"denylist","rules":[{"package":"log4j-core","version":"2.14.*"}]}]`,
 		},
 		{
 			name: "delay-hours",
@@ -317,10 +335,10 @@ func TestFilters_JSONRoundtrip(t *testing.T) {
 			name: "mixed-chain",
 			in: filter.Filters{
 				&filter.Allowlist{Patterns: []string{"@myorg/*"}},
-				&filter.Denylist{Patterns: []string{"evil-*"}},
+				&filter.Denylist{Rules: []filter.Rule{{Package: "log4j-core", Version: "2.14.*"}}},
 				&filter.Delay{MinAge: 24 * time.Hour},
 			},
-			want: `[{"kind":"allowlist","patterns":["@myorg/*"]},{"kind":"denylist","patterns":["evil-*"]},{"kind":"delay","min_age":"24h0m0s"}]`,
+			want: `[{"kind":"allowlist","patterns":["@myorg/*"]},{"kind":"denylist","rules":[{"package":"log4j-core","version":"2.14.*"}]},{"kind":"delay","min_age":"24h0m0s"}]`,
 		},
 	}
 
@@ -376,6 +394,11 @@ func TestFilters_UnmarshalErrors(t *testing.T) {
 			wantErr: filter.ErrInvalidFilter,
 		},
 		{
+			name:    "invalid-rule-empty",
+			body:    `[{"kind":"denylist","rules":[{}]}]`,
+			wantErr: filter.ErrInvalidFilter,
+		},
+		{
 			name:    "malformed",
 			body:    `[`,
 			wantErr: nil,
@@ -428,6 +451,13 @@ func TestFilters_Validate(t *testing.T) {
 			fs: filter.Filters{
 				&filter.Allowlist{Patterns: []string{"foo"}},
 				&filter.Delay{MinAge: 0},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid-empty-rule",
+			fs: filter.Filters{
+				&filter.Denylist{Rules: []filter.Rule{{}}},
 			},
 			wantErr: true,
 		},


### PR DESCRIPTION
Introduces the governance layer of the pull-through proxy. A new
package pkg/proxy/filter defines a small Filter interface, a Chain
composition, and three in-tree implementations: Allowlist and Denylist
match by exact name or glob, Delay holds versions whose upstream
upload time is younger than a threshold. Decisions are tri-state
(Allow / Deny / NeedsMoreData) so metadata-dependent filters can defer
until the upstream metadata fetch.

Filters serialize as a tagged-union JSON array (the kind field
discriminates), and namespace.Spec.Proxy.Filters now holds a typed
filter.Filters slice instead of an opaque json.RawMessage list, so
operator-visible misconfigurations are caught at admin PUT time
rather than first request. The forward-compat property is preserved
for unknown fields within a known kind; unknown kinds are now
rejected with a clear upgrade signal.

Closes #110.