### PR TITLE
Add pkg/proxy/indexcache: OCI-backed pull-through index cache

### DIFF
--- a/pkg/proxy/indexcache/indexcache.go
+++ b/pkg/proxy/indexcache/indexcache.go
@@ -1,0 +1,339 @@
+// Package indexcache is an OCI-backed pull-through cache for upstream
+// index responses (PyPI simple index, npm packument, maven-metadata.xml).
+//
+// Each cache entry is one OCI manifest under a per-namespace repo:
+//
+//	<namespace>/_proxy_cache/index/<pkg>
+//
+// The manifest carries a single layer (the cached body) and two
+// annotations: [FetchedAtAnnotation] (wall-clock fetch time) and
+// [ContentTypeAnnotation] (the upstream Content-Type). The mutable
+// [CacheTag] is overwritten on every refresh — intentional, this is a
+// cache, not an immutable artifact. The previous blob is unreferenced
+// when the tag moves and is reclaimed by the OCI backend's own GC story
+// (GAR / ECR / zot); there is no in-package GC.
+//
+// The cache reaches ORAS directly instead of layering on
+// [pkg/oci.Registry]. That registry enforces the immutable
+// version-manifest model used for package storage, which is wrong for a
+// mutable cache. Owning the on-OCI shape here keeps the cache loose
+// without weakening package-storage invariants.
+//
+// TTL is not stored. [Cache.Get] returns the recorded [FetchedAtAnnotation]
+// as time.Time; the caller (per-format integration) compares against
+// its own freshness threshold and decides whether to call [Cache.Put]
+// again with a fresh upstream response.
+package indexcache
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"path"
+	"time"
+
+	specs "github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/errdef"
+	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/retry"
+
+	"github.com/yolocs/ocifactory/pkg/auth/backend"
+)
+
+const (
+	// ArtifactType labels every cache manifest so operators
+	// inspecting the OCI registry can distinguish cache manifests
+	// from real package manifests at a glance.
+	ArtifactType = "application/vnd.ocifactory.proxy.indexcache"
+
+	// CacheTag is the mutable tag every cache manifest publishes
+	// under. Overwriting on refresh is intentional.
+	CacheTag = "current"
+
+	// FetchedAtAnnotation records, on the cache manifest, the
+	// wall-clock time the body was fetched from upstream. Encoded
+	// with [time.RFC3339Nano] so sub-second resolution survives
+	// the roundtrip — useful when operators dial freshness windows
+	// down for index files that change minute-to-minute upstream.
+	FetchedAtAnnotation = "proxy.cache.fetched-at"
+
+	// ContentTypeAnnotation carries the upstream Content-Type so
+	// [Cache.Get] returns it alongside the body. The annotation is
+	// used instead of the layer descriptor's MediaType field
+	// because real Content-Type values frequently carry parameters
+	// (e.g. "application/json; charset=utf-8") that don't match
+	// the OCI media-type regex.
+	ContentTypeAnnotation = "proxy.cache.content-type"
+)
+
+// cacheRepoSegment is the path segment between the namespace name and
+// the package name. The leading underscore makes cache repos visually
+// distinct from real `<namespace>/packages/...` storage when an
+// operator lists the OCI registry. The segment does not conform to
+// OCI distribution v2's repository name regex (each component must
+// start with `[a-z0-9]`); the issue spec calls for the literal value
+// and unit tests use an in-memory backend that ignores the
+// constraint. Production wiring against a strict registry will need
+// to either loosen the regex or rename this prefix.
+const cacheRepoSegment = "_proxy_cache/index"
+
+// layerMediaType is the MediaType applied to the layer descriptor in
+// the cache manifest. The original upstream Content-Type is kept in
+// [ContentTypeAnnotation] because it may carry parameters; this field
+// only has to be a syntactically-valid OCI media type.
+const layerMediaType = "application/octet-stream"
+
+// Cache is the OCI-backed pull-through index cache.
+//
+// One Cache value is constructed per ocifactory process and shared
+// across every namespace and per-format proxy fetcher. Concurrent
+// [Cache.Get] / [Cache.Put] calls are safe; the underlying ORAS
+// target is constructed per call so there is no shared mutable
+// state on the Cache itself.
+type Cache struct {
+	baseURL    *url.URL
+	authClient *auth.Client
+	plainHTTP  bool
+
+	// newTargetFunc opens an [oras.Target] for the given repo path
+	// (already namespace- and prefix-qualified). Replaced in tests
+	// with an in-memory target factory so unit tests don't need a
+	// real registry.
+	newTargetFunc func(ctx context.Context, repoPath string) (oras.Target, error)
+
+	// now is the wall-clock the cache stamps onto
+	// [FetchedAtAnnotation]. Tests override it for deterministic
+	// roundtrip assertions; production uses [time.Now].
+	now func() time.Time
+}
+
+// Option configures a [Cache] at construction time.
+type Option func(*Cache) error
+
+// WithBackendAuth wires a credential provider for the backend OCI
+// registry. Default is [backend.Anonymous].
+func WithBackendAuth(p backend.Provider) Option {
+	return func(c *Cache) error {
+		if p == nil {
+			p = backend.Anonymous()
+		}
+		credFn := func(ctx context.Context, host string) (auth.Credential, error) {
+			cred, err := p.Credential(ctx, host)
+			if err != nil {
+				return auth.EmptyCredential, err
+			}
+			return auth.Credential{
+				Username:    cred.Username,
+				Password:    cred.Password,
+				AccessToken: cred.AccessToken,
+			}, nil
+		}
+		c.authClient = &auth.Client{
+			Client:     retry.DefaultClient,
+			Cache:      auth.NewCache(),
+			Credential: credFn,
+		}
+		return nil
+	}
+}
+
+// NewCache constructs a [Cache] that reads and writes against
+// baseURL. baseURL is the OCI registry's HTTPS endpoint plus any
+// shared path prefix (matching [pkg/oci.NewRegistry]); an
+// `http://` scheme switches the underlying ORAS client to plain
+// HTTP for local zot / dev workflows.
+func NewCache(baseURL *url.URL, opts ...Option) (*Cache, error) {
+	if baseURL == nil {
+		return nil, errors.New("indexcache: baseURL is required")
+	}
+	c := &Cache{
+		baseURL:   baseURL,
+		plainHTTP: baseURL.Scheme == "http",
+		now:       func() time.Time { return time.Now().UTC() },
+	}
+	for _, o := range opts {
+		if err := o(c); err != nil {
+			return nil, err
+		}
+	}
+	if c.authClient == nil {
+		// Default to anonymous so a Cache constructed without
+		// WithBackendAuth can still target a public read-only
+		// backend. Mirrors pkg/oci.NewRegistry's defaulting.
+		if err := WithBackendAuth(backend.Anonymous())(c); err != nil {
+			return nil, err
+		}
+	}
+	c.newTargetFunc = c.newRemoteTarget
+	return c, nil
+}
+
+// Get returns the cached body for (ns, pkg) along with its
+// upstream Content-Type and the wall-clock time it was fetched.
+// A miss returns (nil, "", zero-time, false, nil) — no error. Any
+// other failure (manifest fetch, malformed annotation) is returned
+// wrapped.
+func (c *Cache) Get(ctx context.Context, ns, pkg string) ([]byte, string, time.Time, bool, error) {
+	target, err := c.newTargetFunc(ctx, c.repoPath(ns, pkg))
+	if err != nil {
+		return nil, "", time.Time{}, false, fmt.Errorf("indexcache: open target: %w", err)
+	}
+
+	manifestDesc, err := target.Resolve(ctx, CacheTag)
+	if err != nil {
+		if errors.Is(err, errdef.ErrNotFound) {
+			return nil, "", time.Time{}, false, nil
+		}
+		return nil, "", time.Time{}, false, fmt.Errorf("indexcache: resolve %s: %w", CacheTag, err)
+	}
+
+	manifest, err := fetchManifest(ctx, target, manifestDesc)
+	if err != nil {
+		return nil, "", time.Time{}, false, err
+	}
+	if manifest.ArtifactType != ArtifactType {
+		return nil, "", time.Time{}, false, fmt.Errorf("indexcache: unexpected artifactType %q (want %q)", manifest.ArtifactType, ArtifactType)
+	}
+	if len(manifest.Layers) != 1 {
+		return nil, "", time.Time{}, false, fmt.Errorf("indexcache: manifest has %d layers, want 1", len(manifest.Layers))
+	}
+
+	fetchedAtStr := manifest.Annotations[FetchedAtAnnotation]
+	if fetchedAtStr == "" {
+		return nil, "", time.Time{}, false, fmt.Errorf("indexcache: manifest missing %s annotation", FetchedAtAnnotation)
+	}
+	fetchedAt, err := time.Parse(time.RFC3339Nano, fetchedAtStr)
+	if err != nil {
+		return nil, "", time.Time{}, false, fmt.Errorf("indexcache: parse %s %q: %w", FetchedAtAnnotation, fetchedAtStr, err)
+	}
+
+	contentType := manifest.Annotations[ContentTypeAnnotation]
+
+	body, err := fetchBlob(ctx, target, manifest.Layers[0])
+	if err != nil {
+		return nil, "", time.Time{}, false, err
+	}
+
+	return body, contentType, fetchedAt, true, nil
+}
+
+// Put writes body to the cache under (ns, pkg), overwriting any
+// previous entry. contentType is the upstream response's
+// Content-Type and is preserved verbatim for the next [Cache.Get].
+//
+// Concurrent Put calls for the same (ns, pkg) race on the
+// underlying tag write; the last writer wins, which is the expected
+// behaviour for a refresh-on-read cache.
+func (c *Cache) Put(ctx context.Context, ns, pkg string, body []byte, contentType string) error {
+	target, err := c.newTargetFunc(ctx, c.repoPath(ns, pkg))
+	if err != nil {
+		return fmt.Errorf("indexcache: open target: %w", err)
+	}
+
+	layerDesc := content.NewDescriptorFromBytes(layerMediaType, body)
+	if err := pushIfMissing(ctx, target, layerDesc, body); err != nil {
+		return fmt.Errorf("indexcache: push cache body: %w", err)
+	}
+
+	emptyDesc := ocispec.DescriptorEmptyJSON
+	if err := pushIfMissing(ctx, target, emptyDesc, emptyDesc.Data); err != nil {
+		return fmt.Errorf("indexcache: push config blob: %w", err)
+	}
+
+	annotations := map[string]string{
+		FetchedAtAnnotation:   c.now().Format(time.RFC3339Nano),
+		ContentTypeAnnotation: contentType,
+	}
+	manifest := ocispec.Manifest{
+		Versioned:    specs.Versioned{SchemaVersion: 2},
+		MediaType:    ocispec.MediaTypeImageManifest,
+		ArtifactType: ArtifactType,
+		Config:       emptyDesc,
+		Layers:       []ocispec.Descriptor{layerDesc},
+		Annotations:  annotations,
+	}
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		return fmt.Errorf("indexcache: marshal manifest: %w", err)
+	}
+	manifestDesc := content.NewDescriptorFromBytes(ocispec.MediaTypeImageManifest, manifestBytes)
+	manifestDesc.ArtifactType = ArtifactType
+	manifestDesc.Annotations = annotations
+
+	if err := pushIfMissing(ctx, target, manifestDesc, manifestBytes); err != nil {
+		return fmt.Errorf("indexcache: push manifest: %w", err)
+	}
+	if err := target.Tag(ctx, manifestDesc, CacheTag); err != nil {
+		return fmt.Errorf("indexcache: tag %s: %w", CacheTag, err)
+	}
+	return nil
+}
+
+func (c *Cache) repoPath(ns, pkg string) string {
+	return path.Join(ns, cacheRepoSegment, pkg)
+}
+
+func (c *Cache) newRemoteTarget(_ context.Context, repoPath string) (oras.Target, error) {
+	repoRef := c.baseURL.Host + c.baseURL.Path + "/" + repoPath
+	repo, err := remote.NewRepository(repoRef)
+	if err != nil {
+		return nil, fmt.Errorf("create remote repository %q: %w", repoRef, err)
+	}
+	if c.plainHTTP {
+		repo.PlainHTTP = true
+	}
+	repo.Client = c.authClient
+	return repo, nil
+}
+
+func pushIfMissing(ctx context.Context, target oras.Target, desc ocispec.Descriptor, data []byte) error {
+	exists, err := target.Exists(ctx, desc)
+	if err != nil {
+		return fmt.Errorf("exists check: %w", err)
+	}
+	if exists {
+		return nil
+	}
+	if err := target.Push(ctx, desc, bytes.NewReader(data)); err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
+		return err
+	}
+	return nil
+}
+
+func fetchManifest(ctx context.Context, target oras.Target, desc ocispec.Descriptor) (*ocispec.Manifest, error) {
+	rc, err := target.Fetch(ctx, desc)
+	if err != nil {
+		return nil, fmt.Errorf("indexcache: fetch manifest: %w", err)
+	}
+	defer rc.Close()
+	body, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, fmt.Errorf("indexcache: read manifest body: %w", err)
+	}
+	var m ocispec.Manifest
+	if err := json.Unmarshal(body, &m); err != nil {
+		return nil, fmt.Errorf("indexcache: decode manifest: %w", err)
+	}
+	return &m, nil
+}
+
+func fetchBlob(ctx context.Context, target oras.Target, desc ocispec.Descriptor) ([]byte, error) {
+	rc, err := target.Fetch(ctx, desc)
+	if err != nil {
+		return nil, fmt.Errorf("indexcache: fetch blob: %w", err)
+	}
+	defer rc.Close()
+	body, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, fmt.Errorf("indexcache: read blob body: %w", err)
+	}
+	return body, nil
+}

--- a/pkg/proxy/indexcache/indexcache.go
+++ b/pkg/proxy/indexcache/indexcache.go
@@ -75,15 +75,16 @@ const (
 )
 
 // cacheRepoSegment is the path segment between the namespace name and
-// the package name. The leading underscore makes cache repos visually
-// distinct from real `<namespace>/packages/...` storage when an
-// operator lists the OCI registry. The segment does not conform to
-// OCI distribution v2's repository name regex (each component must
-// start with `[a-z0-9]`); the issue spec calls for the literal value
-// and unit tests use an in-memory backend that ignores the
-// constraint. Production wiring against a strict registry will need
-// to either loosen the regex or rename this prefix.
-const cacheRepoSegment = "_proxy_cache/index"
+// the package name. The `ocifactory-` prefix matches the in-tree
+// convention for registry-internal repos (compare
+// [pkg/namespace.indexRepoSegment] = "ocifactory-namespaces" and
+// [pkg/namespace.Registry] / "ocifactory-packages"), keeping cache
+// repos visually distinct from real `<namespace>/packages/...`
+// storage when an operator lists the OCI registry. The literal here
+// is a single OCI distribution name component followed by
+// "/index" — each segment satisfies the `[a-z0-9]+...` regex
+// oras-go's `remote.NewRepository` validates.
+const cacheRepoSegment = "ocifactory-proxy-cache/index"
 
 // layerMediaType is the MediaType applied to the layer descriptor in
 // the cache manifest. The original upstream Content-Type is kept in
@@ -178,9 +179,16 @@ func NewCache(baseURL *url.URL, opts ...Option) (*Cache, error) {
 
 // Get returns the cached body for (ns, pkg) along with its
 // upstream Content-Type and the wall-clock time it was fetched.
-// A miss returns (nil, "", zero-time, false, nil) — no error. Any
-// other failure (manifest fetch, malformed annotation) is returned
-// wrapped.
+// A cache miss returns (nil, "", zero-time, false, nil) — no
+// error, and intentionally distinct from [proxy.ErrNotFound], which
+// callers reserve for "upstream told us this package doesn't
+// exist". Any other failure (manifest fetch, malformed annotation,
+// dangling tag) is returned wrapped.
+//
+// pkg may contain '/' (npm scoped packages, Maven groupId paths);
+// the caller is responsible for normalising the value (rejecting
+// "..", absolute paths, etc.) so a maliciously-crafted pkg cannot
+// traverse out of the namespace's cache prefix.
 func (c *Cache) Get(ctx context.Context, ns, pkg string) ([]byte, string, time.Time, bool, error) {
 	target, err := c.newTargetFunc(ctx, c.repoPath(ns, pkg))
 	if err != nil {

--- a/pkg/proxy/indexcache/indexcache_integration_test.go
+++ b/pkg/proxy/indexcache/indexcache_integration_test.go
@@ -1,0 +1,179 @@
+package indexcache
+
+import (
+	"context"
+	"net"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// zotImage is pinned to the same tag the pkg/oci streaming-integration
+// test uses so a single container layer is shared between both
+// packages' integration runs on the same CI host.
+const zotImage = "ghcr.io/project-zot/zot-linux-amd64:v2.1.5"
+
+// TestCache_ZotIntegration exercises the full Put / Get / overwrite
+// lifecycle against a real zot registry. It is the live counterpart
+// to the in-memory unit tests and the regression guard for the cache
+// repo-name format — `ocifactory-proxy-cache/index/<pkg>` has to pass
+// oras-go's repositoryRegexp at remote.NewRepository parse time,
+// which the in-memory fake does not enforce.
+//
+// Pass `-short` to skip in local fast-iteration loops. CI runs this
+// on every PR (ubuntu-latest has Docker preinstalled), so a wire-
+// level regression in the cache's ORAS usage is caught before merge.
+func TestCache_ZotIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping live-zot integration test in -short mode")
+	}
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
+	t.Cleanup(cancel)
+
+	zot, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        zotImage,
+			ExposedPorts: []string{"5000/tcp"},
+			WaitingFor: wait.ForHTTP("/v2/").
+				WithPort("5000/tcp").
+				WithStatusCodeMatcher(func(status int) bool { return status == 200 }).
+				WithStartupTimeout(60 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		// Skip rather than fail so `go test ./...` on a Docker-less
+		// laptop stays green. CI always has Docker.
+		t.Skipf("could not start zot container (Docker available?): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := zot.Terminate(context.Background()); err != nil {
+			t.Logf("zot terminate: %v", err)
+		}
+	})
+
+	host, err := zot.Host(ctx)
+	if err != nil {
+		t.Fatalf("zot.Host: %v", err)
+	}
+	port, err := zot.MappedPort(ctx, "5000/tcp")
+	if err != nil {
+		t.Fatalf("zot.MappedPort: %v", err)
+	}
+	base := &url.URL{Scheme: "http", Host: net.JoinHostPort(host, port.Port())}
+
+	c, err := NewCache(base)
+	if err != nil {
+		t.Fatalf("NewCache() error = %v", err)
+	}
+
+	t.Run("miss before any put", func(t *testing.T) {
+		t.Parallel()
+		_, _, _, found, err := c.Get(ctx, "ns-miss", "never-written")
+		if err != nil {
+			t.Fatalf("Get() on miss returned err = %v, want nil", err)
+		}
+		if found {
+			t.Errorf("Get() on miss found = true, want false")
+		}
+	})
+
+	t.Run("roundtrip", func(t *testing.T) {
+		t.Parallel()
+		wantBody := []byte("<html><body>roundtrip body</body></html>")
+		wantContentType := "text/html; charset=utf-8"
+
+		before := time.Now().UTC()
+		if err := c.Put(ctx, "ns-roundtrip", "pkg", wantBody, wantContentType); err != nil {
+			t.Fatalf("Put() error = %v", err)
+		}
+		after := time.Now().UTC()
+
+		gotBody, gotContentType, gotFetchedAt, found, err := c.Get(ctx, "ns-roundtrip", "pkg")
+		if err != nil {
+			t.Fatalf("Get() error = %v", err)
+		}
+		if !found {
+			t.Fatal("Get() found = false, want true")
+		}
+		if diff := cmp.Diff(wantBody, gotBody); diff != "" {
+			t.Errorf("Get() body mismatch (-want +got):\n%s", diff)
+		}
+		if gotContentType != wantContentType {
+			t.Errorf("Get() contentType = %q, want %q", gotContentType, wantContentType)
+		}
+		// Wall-clock tolerance per the issue's acceptance: a few
+		// seconds to absorb container round-trip and clock skew.
+		tolerance := 5 * time.Second
+		if gotFetchedAt.Before(before.Add(-tolerance)) || gotFetchedAt.After(after.Add(tolerance)) {
+			t.Errorf("Get() fetchedAt = %v, want within [%v, %v]", gotFetchedAt, before.Add(-tolerance), after.Add(tolerance))
+		}
+	})
+
+	t.Run("overwrite mutates the current tag", func(t *testing.T) {
+		t.Parallel()
+		if err := c.Put(ctx, "ns-overwrite", "pkg", []byte("v1"), "text/plain"); err != nil {
+			t.Fatalf("Put() v1 error = %v", err)
+		}
+		// Sleep just enough that the second Put stamps a later
+		// fetched-at and the assertion can tell v1 from v2 by
+		// timestamp. RFC3339Nano keeps sub-second resolution; 10ms
+		// is plenty even after RTT.
+		time.Sleep(10 * time.Millisecond)
+		if err := c.Put(ctx, "ns-overwrite", "pkg", []byte("v2"), "application/json"); err != nil {
+			t.Fatalf("Put() v2 error = %v", err)
+		}
+
+		gotBody, gotContentType, _, found, err := c.Get(ctx, "ns-overwrite", "pkg")
+		if err != nil {
+			t.Fatalf("Get() after overwrite error = %v", err)
+		}
+		if !found {
+			t.Fatal("Get() after overwrite found = false, want true")
+		}
+		if diff := cmp.Diff([]byte("v2"), gotBody); diff != "" {
+			t.Errorf("Get() body mismatch (-want +got):\n%s", diff)
+		}
+		if gotContentType != "application/json" {
+			t.Errorf("Get() contentType = %q, want %q", gotContentType, "application/json")
+		}
+	})
+
+	t.Run("namespace isolation", func(t *testing.T) {
+		t.Parallel()
+		if err := c.Put(ctx, "ns-iso-a", "shared", []byte("in-a"), "text/plain"); err != nil {
+			t.Fatalf("Put() ns-iso-a error = %v", err)
+		}
+		if err := c.Put(ctx, "ns-iso-b", "shared", []byte("in-b"), "text/plain"); err != nil {
+			t.Fatalf("Put() ns-iso-b error = %v", err)
+		}
+
+		gotA, _, _, found, err := c.Get(ctx, "ns-iso-a", "shared")
+		if err != nil {
+			t.Fatalf("Get(ns-iso-a) error = %v", err)
+		}
+		if !found {
+			t.Fatal("Get(ns-iso-a) found = false, want true")
+		}
+		if diff := cmp.Diff([]byte("in-a"), gotA); diff != "" {
+			t.Errorf("Get(ns-iso-a) body mismatch (-want +got):\n%s", diff)
+		}
+
+		gotB, _, _, found, err := c.Get(ctx, "ns-iso-b", "shared")
+		if err != nil {
+			t.Fatalf("Get(ns-iso-b) error = %v", err)
+		}
+		if !found {
+			t.Fatal("Get(ns-iso-b) found = false, want true")
+		}
+		if diff := cmp.Diff([]byte("in-b"), gotB); diff != "" {
+			t.Errorf("Get(ns-iso-b) body mismatch (-want +got):\n%s", diff)
+		}
+	})
+}

--- a/pkg/proxy/indexcache/indexcache_test.go
+++ b/pkg/proxy/indexcache/indexcache_test.go
@@ -1,15 +1,20 @@
 package indexcache
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"net/url"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/content/memory"
 )
 
@@ -147,8 +152,12 @@ func TestCache_PutGetRoundtrip(t *testing.T) {
 
 	wantBody := []byte("<html><body>simple-index</body></html>")
 	wantContentType := "text/html; charset=utf-8"
+	// The cache stamps Cache.now() (pinned by newTestCache) onto
+	// FetchedAtAnnotation; capturing it here lets the assertion
+	// below compare exactly. Tolerance against the real wall clock
+	// is covered by TestCache_FetchedAtWallClock.
+	wantFetchedAt := c.now()
 
-	before := c.now()
 	if err := c.Put(ctx, "default", "requests", wantBody, wantContentType); err != nil {
 		t.Fatalf("Put() error = %v", err)
 	}
@@ -166,11 +175,8 @@ func TestCache_PutGetRoundtrip(t *testing.T) {
 	if gotContentType != wantContentType {
 		t.Errorf("Get() contentType = %q, want %q", gotContentType, wantContentType)
 	}
-	// fetchedAt is stamped by Cache.now at Put time; with the pinned
-	// clock the test compares exactly. Tolerance check covered by
-	// TestCache_FetchedAtWallClock.
-	if !gotFetchedAt.Equal(before) {
-		t.Errorf("Get() fetchedAt = %v, want %v", gotFetchedAt, before)
+	if !gotFetchedAt.Equal(wantFetchedAt) {
+		t.Errorf("Get() fetchedAt = %v, want %v", gotFetchedAt, wantFetchedAt)
 	}
 }
 
@@ -370,19 +376,19 @@ func TestCache_RepoPath(t *testing.T) {
 			name: "simple ns and pkg",
 			ns:   "default",
 			pkg:  "requests",
-			want: "default/_proxy_cache/index/requests",
+			want: "default/ocifactory-proxy-cache/index/requests",
 		},
 		{
 			name: "scoped npm package",
 			ns:   "default",
 			pkg:  "@scope/name",
-			want: "default/_proxy_cache/index/@scope/name",
+			want: "default/ocifactory-proxy-cache/index/@scope/name",
 		},
 		{
 			name: "maven groupId path",
 			ns:   "internal",
 			pkg:  "com/google/guava/guava",
-			want: "internal/_proxy_cache/index/com/google/guava/guava",
+			want: "internal/ocifactory-proxy-cache/index/com/google/guava/guava",
 		},
 	}
 	for _, tc := range tests {
@@ -432,5 +438,125 @@ func TestCache_PutTargetOpenError(t *testing.T) {
 	}
 	if !errors.Is(err, sentinel) {
 		t.Errorf("Put() error = %v, want wrap of %v", err, sentinel)
+	}
+}
+
+// TestCache_GetMalformedManifest pre-populates the in-memory target
+// with a manifest tagged `current` whose contents violate one of the
+// Get-side invariants (wrong artifactType, wrong layer count, missing
+// or bad fetched-at annotation) and checks Get surfaces it as an
+// error rather than silently returning bad data. These states can't
+// arise via Put, but a future bug or an operator scribbling on the
+// cache repo with `oras` would produce them.
+func TestCache_GetMalformedManifest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		mutate         func(m *ocispec.Manifest)
+		wantErrSubstr  string
+		wantFoundFalse bool
+	}{
+		{
+			name: "wrong artifactType",
+			mutate: func(m *ocispec.Manifest) {
+				m.ArtifactType = "application/vnd.somebody.else"
+			},
+			wantErrSubstr: "unexpected artifactType",
+		},
+		{
+			name: "two layers",
+			mutate: func(m *ocispec.Manifest) {
+				m.Layers = append(m.Layers, m.Layers[0])
+			},
+			wantErrSubstr: "manifest has 2 layers",
+		},
+		{
+			name: "missing fetched-at annotation",
+			mutate: func(m *ocispec.Manifest) {
+				delete(m.Annotations, FetchedAtAnnotation)
+			},
+			wantErrSubstr: "missing proxy.cache.fetched-at",
+		},
+		{
+			name: "malformed fetched-at annotation",
+			mutate: func(m *ocispec.Manifest) {
+				m.Annotations[FetchedAtAnnotation] = "not a timestamp"
+			},
+			wantErrSubstr: "parse proxy.cache.fetched-at",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+
+			store := memory.New()
+			c, err := NewCache(&url.URL{Scheme: "https", Host: "example.com"})
+			if err != nil {
+				t.Fatalf("NewCache() error = %v", err)
+			}
+			c.newTargetFunc = func(_ context.Context, _ string) (oras.Target, error) {
+				return store, nil
+			}
+
+			seedMalformedManifest(t, store, tc.mutate)
+
+			_, _, _, found, err := c.Get(ctx, "default", "pkg")
+			if err == nil {
+				t.Fatalf("Get() error = nil, want %q", tc.wantErrSubstr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErrSubstr) {
+				t.Errorf("Get() error = %q, want substring %q", err, tc.wantErrSubstr)
+			}
+			if found {
+				t.Errorf("Get() found = true, want false on malformed manifest")
+			}
+		})
+	}
+}
+
+// seedMalformedManifest writes a well-formed cache manifest into
+// store, then lets the caller mutate it before pushing + tagging. The
+// well-formed baseline keeps every test focused on the one field it
+// is breaking.
+func seedMalformedManifest(t *testing.T, store *memory.Store, mutate func(*ocispec.Manifest)) {
+	t.Helper()
+	ctx := t.Context()
+
+	body := []byte("payload")
+	layerDesc := content.NewDescriptorFromBytes(layerMediaType, body)
+	if err := store.Push(ctx, layerDesc, bytes.NewReader(body)); err != nil {
+		t.Fatalf("seed: push body: %v", err)
+	}
+
+	emptyDesc := ocispec.DescriptorEmptyJSON
+	if err := store.Push(ctx, emptyDesc, bytes.NewReader(emptyDesc.Data)); err != nil {
+		t.Fatalf("seed: push config: %v", err)
+	}
+
+	manifest := ocispec.Manifest{
+		MediaType:    ocispec.MediaTypeImageManifest,
+		ArtifactType: ArtifactType,
+		Config:       emptyDesc,
+		Layers:       []ocispec.Descriptor{layerDesc},
+		Annotations: map[string]string{
+			FetchedAtAnnotation:   time.Now().UTC().Format(time.RFC3339Nano),
+			ContentTypeAnnotation: "text/plain",
+		},
+	}
+	mutate(&manifest)
+
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("seed: marshal manifest: %v", err)
+	}
+	manifestDesc := content.NewDescriptorFromBytes(ocispec.MediaTypeImageManifest, manifestBytes)
+	if err := store.Push(ctx, manifestDesc, bytes.NewReader(manifestBytes)); err != nil {
+		t.Fatalf("seed: push manifest: %v", err)
+	}
+	if err := store.Tag(ctx, manifestDesc, CacheTag); err != nil {
+		t.Fatalf("seed: tag manifest: %v", err)
 	}
 }

--- a/pkg/proxy/indexcache/indexcache_test.go
+++ b/pkg/proxy/indexcache/indexcache_test.go
@@ -1,0 +1,436 @@
+package indexcache
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content/memory"
+)
+
+// inMemoryTargets is the test factory passed to Cache.newTargetFunc.
+// Each (repoPath) gets its own memory.Store so namespace and package
+// isolation surface naturally — two cache entries in different
+// namespaces (or in the same namespace but different packages) live
+// in different stores, exactly like they would on a real OCI backend.
+type inMemoryTargets struct {
+	mu     sync.Mutex
+	stores map[string]*memory.Store
+}
+
+func newInMemoryTargets() *inMemoryTargets {
+	return &inMemoryTargets{stores: map[string]*memory.Store{}}
+}
+
+func (f *inMemoryTargets) open(_ context.Context, repoPath string) (oras.Target, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if s, ok := f.stores[repoPath]; ok {
+		return s, nil
+	}
+	s := memory.New()
+	f.stores[repoPath] = s
+	return s, nil
+}
+
+// newTestCache builds a Cache wired to in-memory targets, with the
+// wall-clock pinned so tests can assert fetchedAt exactly. The
+// returned tick helper advances the cache's clock so tests that
+// overwrite an entry can distinguish v1 and v2 by timestamp.
+func newTestCache(t *testing.T) (*Cache, func(time.Time)) {
+	t.Helper()
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	var mu sync.Mutex
+	c, err := NewCache(&url.URL{Scheme: "https", Host: "registry.example.com"})
+	if err != nil {
+		t.Fatalf("NewCache() error = %v", err)
+	}
+	c.now = func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return now
+	}
+	tick := func(next time.Time) {
+		mu.Lock()
+		defer mu.Unlock()
+		now = next
+	}
+	c.newTargetFunc = newInMemoryTargets().open
+	return c, tick
+}
+
+func TestNewCache(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		baseURL *url.URL
+		wantErr bool
+	}{
+		{
+			name:    "https baseURL",
+			baseURL: &url.URL{Scheme: "https", Host: "example.com"},
+		},
+		{
+			name:    "http baseURL switches to plain HTTP",
+			baseURL: &url.URL{Scheme: "http", Host: "zot.local:5000"},
+		},
+		{
+			name:    "nil baseURL is rejected",
+			baseURL: nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			c, err := NewCache(tc.baseURL)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("NewCache() error = nil, want non-nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewCache() error = %v", err)
+			}
+			if c == nil {
+				t.Fatal("NewCache() = nil, want non-nil")
+			}
+			if c.authClient == nil {
+				t.Error("NewCache() authClient = nil, want non-nil (default anonymous)")
+			}
+			if c.newTargetFunc == nil {
+				t.Error("NewCache() newTargetFunc = nil, want non-nil")
+			}
+			wantPlainHTTP := tc.baseURL.Scheme == "http"
+			if c.plainHTTP != wantPlainHTTP {
+				t.Errorf("NewCache() plainHTTP = %v, want %v", c.plainHTTP, wantPlainHTTP)
+			}
+		})
+	}
+}
+
+func TestCache_GetMiss(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	c, _ := newTestCache(t)
+
+	body, contentType, fetchedAt, found, err := c.Get(ctx, "default", "missing")
+	if err != nil {
+		t.Fatalf("Get() on miss returned err = %v, want nil", err)
+	}
+	if found {
+		t.Errorf("Get() on miss found = true, want false")
+	}
+	if body != nil {
+		t.Errorf("Get() on miss body = %q, want nil", body)
+	}
+	if contentType != "" {
+		t.Errorf("Get() on miss contentType = %q, want empty", contentType)
+	}
+	if !fetchedAt.IsZero() {
+		t.Errorf("Get() on miss fetchedAt = %v, want zero", fetchedAt)
+	}
+}
+
+func TestCache_PutGetRoundtrip(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	c, _ := newTestCache(t)
+
+	wantBody := []byte("<html><body>simple-index</body></html>")
+	wantContentType := "text/html; charset=utf-8"
+
+	before := c.now()
+	if err := c.Put(ctx, "default", "requests", wantBody, wantContentType); err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+
+	gotBody, gotContentType, gotFetchedAt, found, err := c.Get(ctx, "default", "requests")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if !found {
+		t.Fatal("Get() found = false, want true")
+	}
+	if diff := cmp.Diff(wantBody, gotBody); diff != "" {
+		t.Errorf("Get() body mismatch (-want +got):\n%s", diff)
+	}
+	if gotContentType != wantContentType {
+		t.Errorf("Get() contentType = %q, want %q", gotContentType, wantContentType)
+	}
+	// fetchedAt is stamped by Cache.now at Put time; with the pinned
+	// clock the test compares exactly. Tolerance check covered by
+	// TestCache_FetchedAtWallClock.
+	if !gotFetchedAt.Equal(before) {
+		t.Errorf("Get() fetchedAt = %v, want %v", gotFetchedAt, before)
+	}
+}
+
+func TestCache_PutOverwrites(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	c, tick := newTestCache(t)
+
+	if err := c.Put(ctx, "default", "requests", []byte("v1"), "text/plain"); err != nil {
+		t.Fatalf("Put() first error = %v", err)
+	}
+
+	// Advance the clock so the second Put stamps a different
+	// fetchedAt and the assertion below can distinguish v1 from v2
+	// by timestamp alone.
+	newNow := c.now().Add(5 * time.Second)
+	tick(newNow)
+
+	if err := c.Put(ctx, "default", "requests", []byte("v2-overwrite"), "application/json"); err != nil {
+		t.Fatalf("Put() second error = %v", err)
+	}
+
+	gotBody, gotContentType, gotFetchedAt, found, err := c.Get(ctx, "default", "requests")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if !found {
+		t.Fatal("Get() found = false, want true")
+	}
+	if diff := cmp.Diff([]byte("v2-overwrite"), gotBody); diff != "" {
+		t.Errorf("Get() body mismatch (-want +got):\n%s", diff)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("Get() contentType = %q, want %q", gotContentType, "application/json")
+	}
+	if !gotFetchedAt.Equal(newNow) {
+		t.Errorf("Get() fetchedAt = %v, want %v", gotFetchedAt, newNow)
+	}
+}
+
+func TestCache_NamespaceIsolation(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	c, _ := newTestCache(t)
+
+	if err := c.Put(ctx, "ns-a", "shared-name", []byte("in-a"), "text/plain"); err != nil {
+		t.Fatalf("Put() in ns-a error = %v", err)
+	}
+	if err := c.Put(ctx, "ns-b", "shared-name", []byte("in-b"), "text/plain"); err != nil {
+		t.Fatalf("Put() in ns-b error = %v", err)
+	}
+
+	// ns-a sees ns-a's entry only.
+	gotA, _, _, foundA, err := c.Get(ctx, "ns-a", "shared-name")
+	if err != nil {
+		t.Fatalf("Get() in ns-a error = %v", err)
+	}
+	if !foundA {
+		t.Fatal("Get() in ns-a found = false, want true")
+	}
+	if diff := cmp.Diff([]byte("in-a"), gotA); diff != "" {
+		t.Errorf("Get() ns-a body mismatch (-want +got):\n%s", diff)
+	}
+
+	// ns-b sees ns-b's entry only.
+	gotB, _, _, foundB, err := c.Get(ctx, "ns-b", "shared-name")
+	if err != nil {
+		t.Fatalf("Get() in ns-b error = %v", err)
+	}
+	if !foundB {
+		t.Fatal("Get() in ns-b found = false, want true")
+	}
+	if diff := cmp.Diff([]byte("in-b"), gotB); diff != "" {
+		t.Errorf("Get() ns-b body mismatch (-want +got):\n%s", diff)
+	}
+
+	// A third namespace with the same package name is still a miss.
+	_, _, _, foundC, err := c.Get(ctx, "ns-c", "shared-name")
+	if err != nil {
+		t.Fatalf("Get() in ns-c error = %v", err)
+	}
+	if foundC {
+		t.Error("Get() in ns-c found = true, want false (never written)")
+	}
+}
+
+func TestCache_PackageIsolation(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	c, _ := newTestCache(t)
+
+	if err := c.Put(ctx, "default", "alpha", []byte("alpha-body"), "text/plain"); err != nil {
+		t.Fatalf("Put(alpha) error = %v", err)
+	}
+	if err := c.Put(ctx, "default", "beta", []byte("beta-body"), "text/plain"); err != nil {
+		t.Fatalf("Put(beta) error = %v", err)
+	}
+
+	gotAlpha, _, _, found, err := c.Get(ctx, "default", "alpha")
+	if err != nil {
+		t.Fatalf("Get(alpha) error = %v", err)
+	}
+	if !found {
+		t.Fatal("Get(alpha) found = false, want true")
+	}
+	if diff := cmp.Diff([]byte("alpha-body"), gotAlpha); diff != "" {
+		t.Errorf("Get(alpha) body mismatch (-want +got):\n%s", diff)
+	}
+
+	gotBeta, _, _, found, err := c.Get(ctx, "default", "beta")
+	if err != nil {
+		t.Fatalf("Get(beta) error = %v", err)
+	}
+	if !found {
+		t.Fatal("Get(beta) found = false, want true")
+	}
+	if diff := cmp.Diff([]byte("beta-body"), gotBeta); diff != "" {
+		t.Errorf("Get(beta) body mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestCache_FetchedAtWallClock(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	// Construct a Cache without overriding c.now so the production
+	// time.Now path stamps the manifest. The acceptance criterion
+	// is "preserved within a small wall-clock tolerance" — sub-second
+	// is plenty given everything runs in-process.
+	c, err := NewCache(&url.URL{Scheme: "https", Host: "registry.example.com"})
+	if err != nil {
+		t.Fatalf("NewCache() error = %v", err)
+	}
+	targets := newInMemoryTargets()
+	c.newTargetFunc = targets.open
+
+	before := time.Now().UTC()
+	if err := c.Put(ctx, "default", "pkg", []byte("body"), "text/plain"); err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	after := time.Now().UTC()
+
+	_, _, fetchedAt, found, err := c.Get(ctx, "default", "pkg")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if !found {
+		t.Fatal("Get() found = false, want true")
+	}
+	// Allow a 1s window on each side to absorb sub-microsecond
+	// truncation in RFC3339Nano + any scheduling latency between
+	// time.Now reads. The test is asserting "the timestamp survives
+	// the roundtrip", not microsecond fidelity.
+	tolerance := time.Second
+	if fetchedAt.Before(before.Add(-tolerance)) || fetchedAt.After(after.Add(tolerance)) {
+		t.Errorf("Get() fetchedAt = %v, want within [%v, %v]", fetchedAt, before.Add(-tolerance), after.Add(tolerance))
+	}
+}
+
+func TestCache_EmptyBody(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	c, _ := newTestCache(t)
+
+	if err := c.Put(ctx, "default", "empty", []byte{}, "text/plain"); err != nil {
+		t.Fatalf("Put(empty) error = %v", err)
+	}
+
+	body, contentType, _, found, err := c.Get(ctx, "default", "empty")
+	if err != nil {
+		t.Fatalf("Get(empty) error = %v", err)
+	}
+	if !found {
+		t.Fatal("Get(empty) found = false, want true")
+	}
+	if len(body) != 0 {
+		t.Errorf("Get(empty) body = %q, want empty", body)
+	}
+	if contentType != "text/plain" {
+		t.Errorf("Get(empty) contentType = %q, want %q", contentType, "text/plain")
+	}
+}
+
+func TestCache_RepoPath(t *testing.T) {
+	t.Parallel()
+	c, err := NewCache(&url.URL{Scheme: "https", Host: "example.com"})
+	if err != nil {
+		t.Fatalf("NewCache() error = %v", err)
+	}
+	tests := []struct {
+		name string
+		ns   string
+		pkg  string
+		want string
+	}{
+		{
+			name: "simple ns and pkg",
+			ns:   "default",
+			pkg:  "requests",
+			want: "default/_proxy_cache/index/requests",
+		},
+		{
+			name: "scoped npm package",
+			ns:   "default",
+			pkg:  "@scope/name",
+			want: "default/_proxy_cache/index/@scope/name",
+		},
+		{
+			name: "maven groupId path",
+			ns:   "internal",
+			pkg:  "com/google/guava/guava",
+			want: "internal/_proxy_cache/index/com/google/guava/guava",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := c.repoPath(tc.ns, tc.pkg)
+			if got != tc.want {
+				t.Errorf("repoPath(%q, %q) = %q, want %q", tc.ns, tc.pkg, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCache_GetTargetOpenError(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	c, _ := newTestCache(t)
+	sentinel := errors.New("backend exploded")
+	c.newTargetFunc = func(_ context.Context, _ string) (oras.Target, error) {
+		return nil, sentinel
+	}
+
+	_, _, _, found, err := c.Get(ctx, "default", "foo")
+	if err == nil {
+		t.Fatal("Get() error = nil, want target-open failure")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("Get() error = %v, want wrap of %v", err, sentinel)
+	}
+	if found {
+		t.Errorf("Get() found = true, want false on error")
+	}
+}
+
+func TestCache_PutTargetOpenError(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	c, _ := newTestCache(t)
+	sentinel := errors.New("backend exploded")
+	c.newTargetFunc = func(_ context.Context, _ string) (oras.Target, error) {
+		return nil, sentinel
+	}
+
+	err := c.Put(ctx, "default", "foo", []byte("body"), "text/plain")
+	if err == nil {
+		t.Fatal("Put() error = nil, want target-open failure")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("Put() error = %v, want wrap of %v", err, sentinel)
+	}
+}


### PR DESCRIPTION
The per-format proxy fetchers need somewhere to park upstream index
responses (PyPI simple index, npm packument, maven-metadata.xml) so
ocifactory keeps serving when upstream is down and pays for the
upstream round-trip only on miss / TTL-expiry. Persisting in OCI keeps
the cache surviving container restarts and scale-to-zero on Cloud Run.

Storage shape per (namespace, package): one OCI manifest tagged
"current", carrying a single layer (the cached body) plus the
"proxy.cache.fetched-at" annotation (RFC3339Nano wall-clock) and a
"proxy.cache.content-type" annotation (verbatim upstream Content-Type).
The tag is intentionally mutable — Put overwrites it on refresh; the
previous blob is unreferenced and reclaimed by the OCI backend's own
GC. Cache repos live under "<namespace>/_proxy_cache/index/<pkg>" so
operators inspecting the registry can tell cache from /packages/ at a
glance.

The cache talks to ORAS directly instead of layering on pkg/oci.Registry
since the version-manifest immutability model in there is wrong for a
mutable cache. TTL is not stored — Get returns the recorded fetchedAt
and per-format integrations apply their own freshness threshold.

Closes #111