### PR TITLE
Add NegativeCache to pkg/proxy/indexcache

### DIFF
--- a/pkg/proxy/indexcache/negative.go
+++ b/pkg/proxy/indexcache/negative.go
@@ -1,0 +1,114 @@
+package indexcache
+
+import (
+	"time"
+
+	"github.com/hashicorp/golang-lru/v2/expirable"
+)
+
+const (
+	// DefaultNegativeCacheSize is the entry cap a [NegativeCache]
+	// uses when [WithNegativeCacheSize] is not supplied. Sized to
+	// hold a typical proxy namespace's worth of recent 404s without
+	// noticeably accruing memory.
+	DefaultNegativeCacheSize = 1024
+
+	// DefaultNegativeCacheTTL is the lifetime each [NegativeCache]
+	// entry retains when [WithNegativeCacheTTL] is not supplied.
+	// Short enough that an upstream republish becomes observable
+	// within a minute; long enough to absorb a misbehaving client
+	// looping on the same bad URL.
+	DefaultNegativeCacheTTL = 60 * time.Second
+)
+
+// NegativeCache remembers upstream lookups that recently returned a
+// definitive "not found" so per-format proxy fetchers can suppress
+// duplicate upstream calls for the same key.
+//
+// Keys are opaque to the cache. The convention is the upstream URL
+// the fetcher would otherwise call, but a fetcher may key on a
+// composed tuple (format, package, version, file) if that better
+// matches its address space.
+//
+// A NegativeCache is safe for concurrent use. A zero value is not
+// usable; construct with [NewNegativeCache].
+type NegativeCache struct {
+	lru *expirable.LRU[string, struct{}]
+}
+
+// NegativeCacheOption configures a [NegativeCache] at construction time.
+type NegativeCacheOption func(*negativeCacheConfig)
+
+type negativeCacheConfig struct {
+	size int
+	ttl  time.Duration
+}
+
+// WithNegativeCacheSize overrides [DefaultNegativeCacheSize]. A
+// non-positive size falls back to the default; this matches what
+// hashicorp/golang-lru does internally and keeps misconfiguration
+// from silently producing a zero-capacity cache.
+func WithNegativeCacheSize(size int) NegativeCacheOption {
+	return func(c *negativeCacheConfig) {
+		if size > 0 {
+			c.size = size
+		}
+	}
+}
+
+// WithNegativeCacheTTL overrides [DefaultNegativeCacheTTL]. A
+// non-positive TTL falls back to the default.
+func WithNegativeCacheTTL(ttl time.Duration) NegativeCacheOption {
+	return func(c *negativeCacheConfig) {
+		if ttl > 0 {
+			c.ttl = ttl
+		}
+	}
+}
+
+// NewNegativeCache returns a [NegativeCache] ready for use. Entries
+// expire after the TTL or are evicted in LRU order once the size cap
+// is reached, whichever comes first. The expirable LRU runs its own
+// eviction goroutine; there is nothing for the caller to start or
+// stop.
+func NewNegativeCache(opts ...NegativeCacheOption) *NegativeCache {
+	cfg := negativeCacheConfig{
+		size: DefaultNegativeCacheSize,
+		ttl:  DefaultNegativeCacheTTL,
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	return &NegativeCache{
+		lru: expirable.NewLRU[string, struct{}](cfg.size, nil, cfg.ttl),
+	}
+}
+
+// RecordMiss marks key as known-missing. Repeated calls refresh the
+// entry's TTL, so a client looping on the same bad URL keeps the
+// suppression active for as long as the loop runs.
+func (c *NegativeCache) RecordMiss(key string) {
+	c.lru.Add(key, struct{}{})
+}
+
+// IsKnownMissing reports whether key was recorded as missing within
+// the current TTL window. A cache miss (never recorded, or expired)
+// returns false so the caller proceeds with the upstream lookup.
+func (c *NegativeCache) IsKnownMissing(key string) bool {
+	_, ok := c.lru.Get(key)
+	return ok
+}
+
+// Len returns the current number of live entries. Intended for the
+// `proxy_negative_cache_size` gauge; the metric registration lives
+// at the call site so the `format` label is set by the per-format
+// proxy that owns the cache.
+func (c *NegativeCache) Len() int {
+	return c.lru.Len()
+}
+
+// Purge removes every entry. Provided for tests and operator-driven
+// cache flushes; production code paths use TTL expiry.
+func (c *NegativeCache) Purge() {
+	c.lru.Purge()
+}

--- a/pkg/proxy/indexcache/negative_test.go
+++ b/pkg/proxy/indexcache/negative_test.go
@@ -1,0 +1,185 @@
+package indexcache
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNegativeCache_HitAfterRecordMiss(t *testing.T) {
+	t.Parallel()
+
+	c := NewNegativeCache()
+
+	const key = "https://pypi.example.com/simple/does-not-exist/"
+	if c.IsKnownMissing(key) {
+		t.Fatalf("IsKnownMissing(%q) = true before RecordMiss, want false", key)
+	}
+	c.RecordMiss(key)
+	if !c.IsKnownMissing(key) {
+		t.Errorf("IsKnownMissing(%q) = false after RecordMiss, want true", key)
+	}
+}
+
+// TestNegativeCache_TTLExpiry verifies the documented contract that an
+// entry stops suppressing once its TTL has lapsed. A short TTL plus a
+// real time.Sleep is the cheapest faithful test — the expirable LRU
+// owns its own clock and there's no seam to inject a fake.
+func TestNegativeCache_TTLExpiry(t *testing.T) {
+	t.Parallel()
+
+	const ttl = 50 * time.Millisecond
+	c := NewNegativeCache(WithNegativeCacheTTL(ttl))
+
+	const key = "https://pypi.example.com/simple/temp-404/"
+	c.RecordMiss(key)
+	if !c.IsKnownMissing(key) {
+		t.Fatalf("IsKnownMissing(%q) immediately after RecordMiss = false, want true", key)
+	}
+
+	// Sleep well past the TTL so the eviction goroutine has time to
+	// reap the entry; expirable's reaper runs at the TTL interval.
+	time.Sleep(ttl * 4)
+
+	if c.IsKnownMissing(key) {
+		t.Errorf("IsKnownMissing(%q) after TTL = true, want false", key)
+	}
+}
+
+// TestNegativeCache_SizeEviction confirms the LRU honors its size cap
+// by evicting the oldest entry once the cap is exceeded.
+func TestNegativeCache_SizeEviction(t *testing.T) {
+	t.Parallel()
+
+	const size = 4
+	c := NewNegativeCache(WithNegativeCacheSize(size))
+
+	keys := make([]string, 0, size+1)
+	for i := 0; i < size+1; i++ {
+		k := "key-" + strconv.Itoa(i)
+		keys = append(keys, k)
+		c.RecordMiss(k)
+	}
+
+	if got := c.Len(); got != size {
+		t.Errorf("Len() = %d, want %d (size cap)", got, size)
+	}
+	// The first key inserted is the oldest; it must have been
+	// evicted to make room for the (size+1)th entry.
+	if c.IsKnownMissing(keys[0]) {
+		t.Errorf("IsKnownMissing(%q) = true, want false (evicted as oldest)", keys[0])
+	}
+	// Every subsequent key must still be present.
+	for _, k := range keys[1:] {
+		if !c.IsKnownMissing(k) {
+			t.Errorf("IsKnownMissing(%q) = false, want true (within size cap)", k)
+		}
+	}
+}
+
+func TestNegativeCache_Defaults(t *testing.T) {
+	t.Parallel()
+
+	c := NewNegativeCache()
+	if c.lru == nil {
+		t.Fatal("NewNegativeCache() lru = nil, want non-nil")
+	}
+	// The expirable LRU reports its cap via cap-derived behaviour;
+	// the simplest invariant we can assert without reaching into
+	// hashicorp internals is that the documented default is the one
+	// the option's fallback uses too.
+	if got, want := DefaultNegativeCacheSize, 1024; got != want {
+		t.Errorf("DefaultNegativeCacheSize = %d, want %d", got, want)
+	}
+	if got, want := DefaultNegativeCacheTTL, 60*time.Second; got != want {
+		t.Errorf("DefaultNegativeCacheTTL = %v, want %v", got, want)
+	}
+}
+
+// TestNegativeCache_NonPositiveOptionsIgnored locks in the contract
+// that misconfiguration (a 0 or negative size/TTL) falls back to the
+// defaults rather than producing an unusable cache.
+func TestNegativeCache_NonPositiveOptionsIgnored(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		opts []NegativeCacheOption
+	}{
+		{name: "zero size", opts: []NegativeCacheOption{WithNegativeCacheSize(0)}},
+		{name: "negative size", opts: []NegativeCacheOption{WithNegativeCacheSize(-5)}},
+		{name: "zero ttl", opts: []NegativeCacheOption{WithNegativeCacheTTL(0)}},
+		{name: "negative ttl", opts: []NegativeCacheOption{WithNegativeCacheTTL(-time.Second)}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			c := NewNegativeCache(tc.opts...)
+			c.RecordMiss("key")
+			if !c.IsKnownMissing("key") {
+				t.Errorf("IsKnownMissing(key) = false after RecordMiss on default-fallback cache, want true")
+			}
+		})
+	}
+}
+
+func TestNegativeCache_Len(t *testing.T) {
+	t.Parallel()
+
+	c := NewNegativeCache()
+	if got := c.Len(); got != 0 {
+		t.Errorf("Len() on empty cache = %d, want 0", got)
+	}
+	c.RecordMiss("a")
+	c.RecordMiss("b")
+	c.RecordMiss("a") // refresh, not insert — Len stays at 2.
+	if got := c.Len(); got != 2 {
+		t.Errorf("Len() after 2 distinct + 1 refresh = %d, want 2", got)
+	}
+}
+
+func TestNegativeCache_Purge(t *testing.T) {
+	t.Parallel()
+
+	c := NewNegativeCache()
+	c.RecordMiss("a")
+	c.RecordMiss("b")
+	c.Purge()
+
+	if c.IsKnownMissing("a") || c.IsKnownMissing("b") {
+		t.Errorf("IsKnownMissing(...) = true after Purge, want false for all keys")
+	}
+	if got := c.Len(); got != 0 {
+		t.Errorf("Len() after Purge = %d, want 0", got)
+	}
+}
+
+// TestNegativeCache_ConcurrentAccess exercises RecordMiss/IsKnownMissing
+// from multiple goroutines so `go test -race` can flag any unsynchronised
+// access in the wrapper. The underlying expirable LRU is safe; this
+// guards against future drift in the wrapper itself.
+func TestNegativeCache_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	c := NewNegativeCache()
+	const goroutines = 8
+	const perGoroutine = 200
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		g := g
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				k := fmt.Sprintf("g%d-k%d", g, i%32)
+				c.RecordMiss(k)
+				_ = c.IsKnownMissing(k)
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
In-memory LRU with TTL eviction, backed by
hashicorp/golang-lru/v2/expirable (already a dep via
pkg/namespace/cache.go). Defaults to 1024 entries / 60s TTL; both
tunable via WithNegativeCacheSize / WithNegativeCacheTTL.

Surface is the minimum the per-format proxy fetchers (#113/#114/#115)
need: RecordMiss / IsKnownMissing, plus Len for the eventual
proxy_negative_cache_size gauge and Purge for tests. Lives in
pkg/proxy/indexcache rather than a separate pkg/proxy/negcache to keep
the proxy-side cache primitives in one package per the issue thread.

Closes #112