### PR TITLE
Expose Spec(ctx) on ScopedRegistry for proxy-mode dispatch

### DIFF
--- a/.github/workflows/live-upstream.yml
+++ b/.github/workflows/live-upstream.yml
@@ -1,0 +1,50 @@
+name: 'live-upstream'
+
+# Non-hermetic integration tests: they talk to real upstream
+# registries (PyPI today, npm/Maven Central later) over the public
+# internet. Outages, rate limits, or response-shape changes on the
+# upstream side will turn this workflow red. Don't gate PR merges on
+# it — read the failure, decide whether it's our regression or theirs.
+#
+# Triggered on a daily schedule + manual dispatch only; never on
+# pull_request or push so a noisy upstream day can't block the
+# regular CI surface.
+
+on:
+  schedule:
+    # 07:17 UTC daily. Off-the-hour to spread load away from cron
+    # peaks and stagger against the rest of the org's nightlies.
+    - cron: '17 7 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: '${{ github.workflow }}'
+  cancel-in-progress: false
+
+jobs:
+  pypi-upstream:
+    name: 'pypi-upstream'
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 15
+    steps:
+      - uses: 'actions/checkout@v4' # ratchet:exclude
+
+      - uses: 'actions/setup-go@v5' # ratchet:exclude
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - uses: 'actions/setup-python@v5' # ratchet:exclude
+        with:
+          python-version: '3.x'
+
+      - name: 'Run live PyPI integration tests'
+        # Distinct build tag from the hermetic `integration` suite so
+        # this job runs ONLY the live-upstream cases. ubuntu-latest
+        # ships Docker; the harness spins up zot via testcontainers.
+        run: |
+          go test -race -count=1 \
+            -tags=pypiupstream \
+            -timeout=10m \
+            -v \
+            ./pkg/handler/python/...

--- a/.github/workflows/live-upstream.yml
+++ b/.github/workflows/live-upstream.yml
@@ -26,6 +26,11 @@ concurrency:
   group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+# Least-privilege: this workflow only needs to clone the repo to run
+# tests. No release uploads, no PR writes, no package publishing.
+permissions:
+  contents: 'read'
+
 jobs:
   pypi-upstream:
     name: 'pypi-upstream'

--- a/.github/workflows/live-upstream.yml
+++ b/.github/workflows/live-upstream.yml
@@ -7,19 +7,14 @@ name: 'live-upstream'
 # the failure and decide whether it's our regression or theirs before
 # reverting.
 #
-# Runs on every PR + a daily schedule + manual dispatch. PR runs catch
-# regressions in pkg/proxy/* and pkg/handler/python/* before merge;
-# the schedule catches upstream-driven drift between PRs.
+# Runs on every PR + manual dispatch. PR runs catch regressions in
+# pkg/proxy/* and pkg/handler/python/* before merge.
 
 on:
   pull_request:
     branches:
       - 'main'
       - 'release/**/*'
-  schedule:
-    # 07:17 UTC daily. Off-the-hour to spread load away from cron
-    # peaks and stagger against the rest of the org's nightlies.
-    - cron: '17 7 * * *'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/live-upstream.yml
+++ b/.github/workflows/live-upstream.yml
@@ -3,14 +3,19 @@ name: 'live-upstream'
 # Non-hermetic integration tests: they talk to real upstream
 # registries (PyPI today, npm/Maven Central later) over the public
 # internet. Outages, rate limits, or response-shape changes on the
-# upstream side will turn this workflow red. Don't gate PR merges on
-# it — read the failure, decide whether it's our regression or theirs.
+# upstream side will turn this workflow red. When that happens, read
+# the failure and decide whether it's our regression or theirs before
+# reverting.
 #
-# Triggered on a daily schedule + manual dispatch only; never on
-# pull_request or push so a noisy upstream day can't block the
-# regular CI surface.
+# Runs on every PR + a daily schedule + manual dispatch. PR runs catch
+# regressions in pkg/proxy/* and pkg/handler/python/* before merge;
+# the schedule catches upstream-driven drift between PRs.
 
 on:
+  pull_request:
+    branches:
+      - 'main'
+      - 'release/**/*'
   schedule:
     # 07:17 UTC daily. Off-the-hour to spread load away from cron
     # peaks and stagger against the rest of the org's nightlies.
@@ -18,8 +23,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: '${{ github.workflow }}'
-  cancel-in-progress: false
+  group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
 
 jobs:
   pypi-upstream:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ Design pillars (in priority order):
 | Cloud Run / Cloudflare deployment guides | Not started |
 | Structured request logging | Not started (debug-level request log via `pkg/handler.Loggeer` is present) |
 | Rate limiting | Not started |
-| CI: lint, test, build, image publish | `go-test` from `abcxyz/pkg`; `oidc-e2e` job mints a real GitHub OIDC token and exercises the auth chain against `--repo-type=echo`; `client-integration` job runs the `-tags=integration` real-client tests (`twine`, `mvn`, `npm`). A separate `live-upstream` workflow runs the `-tags=pypiupstream` tests against real PyPI on every PR + a daily cron (intentionally non-hermetic; PyPI outages will turn it red). Image publish runs on the release workflow, not per-PR. |
+| CI: lint, test, build, image publish | `go-test` from `abcxyz/pkg`; `oidc-e2e` job mints a real GitHub OIDC token and exercises the auth chain against `--repo-type=echo`; `client-integration` job runs the `-tags=integration` real-client tests (`twine`, `mvn`, `npm`). A separate `live-upstream` workflow runs the `-tags=pypiupstream` tests against real PyPI on every PR (intentionally non-hermetic; PyPI outages will turn it red). Image publish runs on the release workflow, not per-PR. |
 
 ## Architecture (read this before changing things)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ Design pillars (in priority order):
 | Cloud Run / Cloudflare deployment guides | Not started |
 | Structured request logging | Not started (debug-level request log via `pkg/handler.Loggeer` is present) |
 | Rate limiting | Not started |
-| CI: lint, test, build, image publish | `go-test` from `abcxyz/pkg`; `oidc-e2e` job mints a real GitHub OIDC token and exercises the auth chain against `--repo-type=echo`; `client-integration` job runs the `-tags=integration` real-client tests (`twine`, `mvn`, `npm`). A separate nightly `live-upstream` workflow runs the `-tags=pypiupstream` tests against real PyPI (intentionally non-hermetic, not PR-gated). Image publish runs on the release workflow, not per-PR. |
+| CI: lint, test, build, image publish | `go-test` from `abcxyz/pkg`; `oidc-e2e` job mints a real GitHub OIDC token and exercises the auth chain against `--repo-type=echo`; `client-integration` job runs the `-tags=integration` real-client tests (`twine`, `mvn`, `npm`). A separate `live-upstream` workflow runs the `-tags=pypiupstream` tests against real PyPI on every PR + a daily cron (intentionally non-hermetic; PyPI outages will turn it red). Image publish runs on the release workflow, not per-PR. |
 
 ## Architecture (read this before changing things)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ Design pillars (in priority order):
 | `pkg/oci` — deterministic `_f_<sha256>` file tags so file reads are one round-trip | Done |
 | `pkg/oci` — blob-download redirect to backend presigned URLs (GAR/ECR/ACR/GHCR/Docker Hub) | Done |
 | `pkg/handler/python` — PEP 503 simple index, twine upload, pip download, per-package simple-index cache | Done, tested (incl. real-client integration tests). Operator docs: [`docs/repos/python.md`](docs/repos/python.md). |
+| `pkg/proxy/python` + python proxy mode (registry hit → filter → PyPI JSON metadata → file fetch → tee to OCI; pull-through indexes with stale-OK + synthesis fallback; uploads → 405) | Done, tested. Wired into `pkg/handler/python` for namespaces with `mode: proxy`. Operator docs: [`docs/repos/python.md`](docs/repos/python.md#proxy-mode-pull-through-pypi). |
 | `pkg/handler/maven` — Maven 2 layout (releases, snapshots, metadata, archetype catalog), checksum verification, snapshot-always-overwrite | Done, tested (incl. real-client integration tests). Operator docs: [`docs/repos/maven.md`](docs/repos/maven.md). |
 | `pkg/handler/npm` — npm registry HTTP protocol (`npm publish`, `npm install`, `npm dist-tag add\|ls`), scoped + unscoped packages | Done, tested (incl. real-client integration tests). Operator docs: [`docs/repos/npm.md`](docs/repos/npm.md). |
 | `pkg/handler` — `Server`, `Logger`, `MetricsMiddleware`, `ObservabilityHandler` (intercepts `/healthz` / `/readyz` / `/metrics` before format mux) | Done |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ Design pillars (in priority order):
 | Cloud Run / Cloudflare deployment guides | Not started |
 | Structured request logging | Not started (debug-level request log via `pkg/handler.Loggeer` is present) |
 | Rate limiting | Not started |
-| CI: lint, test, build, image publish | `go-test` from `abcxyz/pkg`; `oidc-e2e` job mints a real GitHub OIDC token and exercises the auth chain against `--repo-type=echo`; `client-integration` job runs the `-tags=integration` real-client tests (`twine`, `mvn`, `npm`). Image publish runs on the release workflow, not per-PR. |
+| CI: lint, test, build, image publish | `go-test` from `abcxyz/pkg`; `oidc-e2e` job mints a real GitHub OIDC token and exercises the auth chain against `--repo-type=echo`; `client-integration` job runs the `-tags=integration` real-client tests (`twine`, `mvn`, `npm`). A separate nightly `live-upstream` workflow runs the `-tags=pypiupstream` tests against real PyPI (intentionally non-hermetic, not PR-gated). Image publish runs on the release workflow, not per-PR. |
 
 ## Architecture (read this before changing things)
 

--- a/docs/repos/python.md
+++ b/docs/repos/python.md
@@ -261,6 +261,80 @@ the matching namespace via the admin API. The on-manifest shape (file
 manifests + version anchors + alias manifests) is unchanged across
 this migration — only the repo path moved.
 
+## Proxy mode (pull-through PyPI)
+
+Set the namespace's `mode` to `"proxy"` and supply a `proxy.upstream`
+URL when creating it via the admin API:
+
+```bash
+curl -X PUT \
+  -H 'Content-Type: application/json' \
+  --data '{
+    "mode": "proxy",
+    "proxy": {
+      "upstream": "https://pypi.org",
+      "filters": [
+        {"kind": "denylist", "rules": [{"package": "evil-*"}]}
+      ]
+    },
+    "policy": {
+      "readers": [{"issuer": "..."}],
+      "writers": [{"issuer": "..."}]
+    }
+  }' \
+  http://admin.ocifactory.internal/admin/v1/namespaces/pypi-cache
+```
+
+Point `pip` at the namespace exactly like a hosted one:
+
+```ini
+# ~/.pip/pip.conf
+[global]
+index-url = https://ocifactory.example.com/pypi-cache/simple/
+```
+
+What changes on the wire:
+
+- **`/simple/<pkg>/`** (per-package index): served from an in-process
+  L1 cache (10 s TTL by default) → an OCI-backed pull-through cache
+  under `<ns>/ocifactory-proxy-cache/index/<pkg>` (60 s TTL) → upstream
+  PyPI. Absolute `files.pythonhosted.org` URLs in the response are
+  rewritten to `/<ns>/packages/<pkg>/<version>/<filename>` so file
+  downloads route back through ocifactory.
+- **`/simple/`** (top-level): same caching shape. No URL rewriting
+  needed (anchors are package-relative).
+- **`/packages/<pkg>/<version>/<filename>`**: registry hit → done.
+  Miss → cheap filter chain (name allowlist/denylist) → PyPI JSON
+  metadata fetch → metadata-dependent filters (publish-time delay)
+  → upstream file fetch → tee through `AddFile` into OCI while
+  streaming to the client. The second request for the same file
+  serves entirely from the OCI cache.
+- **Uploads (`POST /`)** return `405 Method Not Allowed`. Twine
+  cannot publish into a proxy namespace.
+
+Degraded operation:
+
+- Upstream returns 5xx on an index request and the OCI cache has a
+  stale entry → serve stale, log a warning.
+- Upstream returns 5xx and no cache entry exists → synthesize a
+  minimal index from local `ListFiles("packages/"+pkg)`, so previously
+  cached files remain installable.
+- Upstream and local synthesis both empty → 503 Service Unavailable.
+- Upstream returns 404 on a file → 404 to the client. A short in-memory
+  negative cache (60 s default) suppresses repeat probes for the same
+  bad URL.
+
+Concurrent first-misses for the same `(pkg, version, filename)` collapse
+onto one upstream fetch via singleflight, so a thundering herd of
+`pip install requests` at deploy time pays one upstream RTT per file
+per process — not N.
+
+The filter chain (issue [#110](https://github.com/yolocs/ocifactory/issues/110))
+runs allowlist / denylist filters before any upstream call and the
+publish-time `delay` filter after PyPI metadata fetch. A denied file
+returns 404; a denied index entry is filtered out of the response. See
+[`docs/proxy/filter-policy.md`](../proxy/filter-policy.md).
+
 ## Limitations
 
 - **No PEP 658 `data-dist-info-metadata`.** `pip` falls back to
@@ -274,6 +348,6 @@ this migration — only the repo path moved.
   get the PEP 691 response.
 - **No yank API.** A bad release has to be pulled by deleting the
   `packages/<pkg>:<version>` tag in your OCI backend.
-- **No pull-through caching of upstream PyPI.** Tracked under Phase 4
-  of [`docs/ROADMAP.md`](../ROADMAP.md).
+- **No PEP 658 `data-dist-info-metadata` synthesis** on hosted namespaces. Proxy
+  namespaces preserve the upstream attribute when PyPI sets it.
 - **No XML-RPC mirror endpoints.** Deprecated upstream; not implemented.

--- a/docs/repos/python.md
+++ b/docs/repos/python.md
@@ -274,7 +274,7 @@ curl -X PUT \
     "proxy": {
       "upstream": "https://pypi.org",
       "filters": [
-        {"kind": "denylist", "rules": [{"package": "evil-*"}]}
+        {"kind": "deny", "rules": [{"package": "evil-*"}]}
       ]
     },
     "policy": {

--- a/pkg/commands/serve.go
+++ b/pkg/commands/serve.go
@@ -25,6 +25,7 @@ import (
 	"github.com/yolocs/ocifactory/pkg/metrics"
 	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
+	"github.com/yolocs/ocifactory/pkg/proxy/indexcache"
 )
 
 // envPrefix is the namespace every OCIFACTORY_* env var sits under.
@@ -433,10 +434,22 @@ func runServe(ctx context.Context, cfg *serveConfig) error {
 			return fmt.Errorf("failed to create namespace registry: %w", err)
 		}
 		nsReg := namespace.NewRegistry(r, namespace.NewStore(storeReg))
+		// Proxy plumbing: shared across every namespace served by
+		// this process. Hosted-only deployments still construct
+		// these (cheap — no I/O on construction); a proxy namespace
+		// admin-Put'd at runtime starts using them on its next
+		// request without restart.
+		idxCache, err := indexcache.NewCache(cfg.RegistryURL, indexcache.WithBackendAuth(bp))
+		if err != nil {
+			return fmt.Errorf("failed to create proxy index cache: %w", err)
+		}
+		negCache := indexcache.NewNegativeCache()
 		ph, err := python.NewHandler(nsReg,
 			python.WithSimpleIndexCacheTTL(cfg.SimpleIndexCacheTTL),
 			python.WithMaxUploadBytes(cfg.PythonMaxUploadBytes),
 			python.WithAuthMiddleware(authMW),
+			python.WithProxyIndexCache(idxCache),
+			python.WithProxyNegativeCache(negCache),
 		)
 		if err != nil {
 			return fmt.Errorf("failed to create python handler: %w", err)

--- a/pkg/handler/python/handler.go
+++ b/pkg/handler/python/handler.go
@@ -70,7 +70,10 @@ var (
 		"py":       "text/x-python",
 		"egg":      "text/plain",
 		"egg-info": "text/plain",
-		"metadata": "text/plain; charset=utf-8",
+		// No charset parameter: this value also lands on the OCI
+		// manifest layer mediaType, whose spec pattern forbids
+		// parameters (rejected by zot with manifest-invalid).
+		"metadata": "text/plain",
 	}
 
 	// pkgNameRegExp is the regex matcher for package names.

--- a/pkg/handler/python/handler.go
+++ b/pkg/handler/python/handler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/yolocs/ocifactory/pkg/logging"
 	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
+	"github.com/yolocs/ocifactory/pkg/proxy/indexcache"
 	"github.com/yolocs/ocifactory/pkg/renderer"
 	"oras.land/oras-go/v2/errdef"
 )
@@ -95,6 +96,7 @@ type Handler struct {
 	indexCache     *simpleIndexCache
 	authMW         func(http.Handler) http.Handler
 	maxUploadBytes int64
+	proxy          *proxyState
 }
 
 // Option configures optional Handler behaviour.
@@ -104,6 +106,16 @@ type handlerConfig struct {
 	simpleIndexCacheTTL time.Duration
 	authMW              func(http.Handler) http.Handler
 	maxUploadBytes      int64
+
+	// Proxy plumbing. Populated by the WithProxy* options. The
+	// fetcherFactory is consulted only when a request lands on a
+	// namespace with mode: proxy; hosted-only deployments leave
+	// these zero and pay nothing.
+	fetcherFactory       FetcherFactory
+	indexCache           *indexcache.Cache
+	negCache             *indexcache.NegativeCache
+	proxyIndexCacheTTL   time.Duration
+	proxyL1IndexCacheTTL time.Duration
 }
 
 // WithSimpleIndexCacheTTL sets the per-package simple-index cache TTL.
@@ -122,6 +134,43 @@ func WithMaxUploadBytes(n int64) Option {
 	return func(c *handlerConfig) {
 		c.maxUploadBytes = n
 	}
+}
+
+// WithFetcherFactory installs a custom PyPI proxy fetcher factory. The
+// default ([DefaultFetcherFactory]) builds a [pypython.Fetcher] with
+// package defaults. Tests use this to inject a fake fetcher; out-of-tree
+// implementations are not a supported extension point.
+func WithFetcherFactory(f FetcherFactory) Option {
+	return func(c *handlerConfig) { c.fetcherFactory = f }
+}
+
+// WithProxyIndexCache wires the OCI-backed pull-through index cache
+// used by proxy namespaces. When nil (the default), proxy index
+// requests skip the OCI cache and only use the in-process L1 — fine
+// for tests, undersized for production.
+func WithProxyIndexCache(c *indexcache.Cache) Option {
+	return func(cfg *handlerConfig) { cfg.indexCache = c }
+}
+
+// WithProxyNegativeCache wires the in-memory negative cache used by
+// the proxy file path. When nil, repeat 404s pay full upstream RTT.
+func WithProxyNegativeCache(c *indexcache.NegativeCache) Option {
+	return func(cfg *handlerConfig) { cfg.negCache = c }
+}
+
+// WithProxyIndexCacheTTL overrides [DefaultIndexCacheTTL]. A
+// non-positive value falls back to the default. Affects only the
+// freshness check against the OCI index cache; the L1 in-process
+// cache has its own TTL.
+func WithProxyIndexCacheTTL(d time.Duration) Option {
+	return func(c *handlerConfig) { c.proxyIndexCacheTTL = d }
+}
+
+// WithProxyL1IndexCacheTTL overrides [DefaultL1IndexCacheTTL]. A
+// non-positive value disables the L1 cache entirely, so every proxy
+// index request pays at least one OCI manifest fetch.
+func WithProxyL1IndexCacheTTL(d time.Duration) Option {
+	return func(c *handlerConfig) { c.proxyL1IndexCacheTTL = d }
 }
 
 // WithAuthMiddleware installs an authentication middleware on
@@ -160,13 +209,15 @@ func NewHandler(registry *namespace.Registry, opts ...Option) (*Handler, error) 
 	if err != nil {
 		return nil, fmt.Errorf("failed to create renderer: %w", err)
 	}
-	return &Handler{
+	h := &Handler{
 		registry:       registry,
 		renderer:       r,
 		indexCache:     newSimpleIndexCache(cfg.simpleIndexCacheTTL),
 		authMW:         cfg.authMW,
 		maxUploadBytes: cfg.maxUploadBytes,
-	}, nil
+	}
+	h.proxy = newProxyState(cfg)
+	return h, nil
 }
 
 // Mux returns a new ServeMux that handles the Python handler's routes.
@@ -226,6 +277,14 @@ func (h *Handler) scopedFor(req *http.Request) *namespace.ScopedRegistry {
 // them.
 func (h *Handler) handleSimpleIndex(w http.ResponseWriter, req *http.Request) {
 	scoped := h.scopedFor(req)
+	spec, isProxy, ok := h.dispatchProxy(w, req, scoped)
+	if !ok {
+		return
+	}
+	if isProxy {
+		h.handleSimpleIndexProxy(w, req, scoped, spec)
+		return
+	}
 	tags, err := scoped.ListTags(req.Context(), "index")
 	if err != nil && !errors.Is(err, errdef.ErrNotFound) {
 		if handler.WriteNamespaceError(w, err) {
@@ -272,6 +331,18 @@ func (h *Handler) handleFilePut(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	logger := logging.FromContext(ctx)
 	scoped := h.scopedFor(req)
+
+	// Upload onto a proxy namespace is not meaningful — proxy
+	// caches fill on read, not via twine. Reject early with 405 so
+	// clients fail fast instead of confusing the multipart walker
+	// with an authentication or storage failure.
+	if _, isProxy, ok := h.dispatchProxy(w, req, scoped); !ok {
+		return
+	} else if isProxy {
+		w.Header().Set("Allow", "GET, HEAD")
+		http.Error(w, "uploads disabled on proxy namespaces", http.StatusMethodNotAllowed)
+		return
+	}
 
 	if h.maxUploadBytes > 0 {
 		req.Body = http.MaxBytesReader(w, req.Body, h.maxUploadBytes)
@@ -552,7 +623,16 @@ func (h *Handler) handleFileGet(w http.ResponseWriter, req *http.Request) {
 		MediaType:  detectMediaType(filename),
 	}
 
-	h.handleGet(w, req, h.scopedFor(req), f)
+	scoped := h.scopedFor(req)
+	spec, isProxy, ok := h.dispatchProxy(w, req, scoped)
+	if !ok {
+		return
+	}
+	if isProxy {
+		h.handleFileGetProxy(w, req, scoped, spec, f)
+		return
+	}
+	h.handleGet(w, req, scoped, f)
 }
 
 func (h *Handler) handlePackageIndex(w http.ResponseWriter, req *http.Request) {
@@ -564,6 +644,16 @@ func (h *Handler) handlePackageIndex(w http.ResponseWriter, req *http.Request) {
 	}
 	pkg = normalize(pkg)
 
+	scoped := h.scopedFor(req)
+	spec, isProxy, ok := h.dispatchProxy(w, req, scoped)
+	if !ok {
+		return
+	}
+	if isProxy {
+		h.handlePackageIndexProxy(w, req, scoped, spec, pkg)
+		return
+	}
+
 	ns := vars["namespace"]
 	// Cache key includes the namespace so a package present in ns1
 	// doesn't get served out of cache for an identically-named
@@ -572,7 +662,7 @@ func (h *Handler) handlePackageIndex(w http.ResponseWriter, req *http.Request) {
 	files, ok := h.indexCache.get(cacheKey)
 	if !ok {
 		var err error
-		files, err = h.resolvePackageFiles(req.Context(), h.scopedFor(req), pkg)
+		files, err = h.resolvePackageFiles(req.Context(), scoped, pkg)
 		if err != nil {
 			if handler.WriteNamespaceError(w, err) {
 				return

--- a/pkg/handler/python/proxy.go
+++ b/pkg/handler/python/proxy.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -281,6 +282,26 @@ func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, s
 			return fileFlightResult{}, ferr
 		}
 		fileMeta, ok := meta.FindFile(filename)
+		if !ok && strings.HasSuffix(filename, ".metadata") {
+			// PEP 658 sidecar. PyPI's JSON `urls` list doesn't enumerate
+			// `.metadata` files separately, but advertises them via the
+			// per-file `core-metadata` field and serves them at
+			// `<wheel-url>.metadata`. The rewriter passes the
+			// `data-core-metadata` / `data-dist-info-metadata` attributes
+			// through to pip, so pip then requests the sidecar by appending
+			// `.metadata` to the wheel filename. Resolve by stripping
+			// `.metadata`, finding the underlying wheel, and synthesizing
+			// the upstream URL.
+			base := strings.TrimSuffix(filename, ".metadata")
+			if baseMeta, baseOK := meta.FindFile(base); baseOK {
+				fileMeta = pypython.FileMetadata{
+					Filename:   filename,
+					URL:        baseMeta.URL + ".metadata",
+					UploadTime: baseMeta.UploadTime,
+				}
+				ok = true
+			}
+		}
 		if !ok {
 			return fileFlightResult{}, fmt.Errorf("python proxy: file %q not in metadata for %s %s: %w",
 				filename, pkg, version, proxy.ErrNotFound)

--- a/pkg/handler/python/proxy.go
+++ b/pkg/handler/python/proxy.go
@@ -1,0 +1,758 @@
+package python
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/golang-lru/v2/expirable"
+	"golang.org/x/sync/singleflight"
+	"oras.land/oras-go/v2/errdef"
+
+	"github.com/yolocs/ocifactory/pkg/handler"
+	"github.com/yolocs/ocifactory/pkg/logging"
+	"github.com/yolocs/ocifactory/pkg/namespace"
+	"github.com/yolocs/ocifactory/pkg/oci"
+	"github.com/yolocs/ocifactory/pkg/proxy"
+	"github.com/yolocs/ocifactory/pkg/proxy/filter"
+	"github.com/yolocs/ocifactory/pkg/proxy/indexcache"
+	pypython "github.com/yolocs/ocifactory/pkg/proxy/python"
+)
+
+// ProxyFetcher is the subset of [*pkg/proxy/python.Fetcher] methods
+// the handler depends on. The concrete *pypython.Fetcher satisfies
+// this interface implicitly; the type exists so tests can drop in a
+// fake without spinning up a real upstream server. It is not a
+// stability surface — out-of-tree implementations are not a supported
+// extension point.
+type ProxyFetcher interface {
+	GetSimpleIndex(ctx context.Context, pkg string) (*pypython.IndexResponse, error)
+	GetTopLevelIndex(ctx context.Context) (*pypython.IndexResponse, error)
+	GetVersionMetadata(ctx context.Context, pkg, version string) (*pypython.VersionMetadata, error)
+	FetchFile(ctx context.Context, url string) (*pypython.FileResponse, error)
+}
+
+// FetcherFactory builds a [ProxyFetcher] for a given upstream URL. The
+// handler memoises results keyed by the upstream string so a hot
+// namespace pays for one factory call across its lifetime. The
+// default factory wraps [pypython.New].
+type FetcherFactory func(upstream *url.URL) (ProxyFetcher, error)
+
+// DefaultFetcherFactory is the production factory: builds a
+// [*pypython.Fetcher] with package defaults.
+func DefaultFetcherFactory(upstream *url.URL) (ProxyFetcher, error) {
+	return pypython.New(upstream)
+}
+
+// Proxy-related constants. Operator-facing knobs live behind Options;
+// these are tuning numbers most operators never touch.
+const (
+	// DefaultIndexCacheTTL is how long an [indexcache.Cache] entry
+	// stays "fresh" before the handler re-fetches upstream. 60 s
+	// matches the design issue's starting recommendation for python
+	// and npm; tunable via [WithProxyIndexCacheTTL].
+	DefaultIndexCacheTTL = 60 * time.Second
+
+	// DefaultL1IndexCacheTTL is how long the in-process L1 cache
+	// keeps a (namespace, package) index body warm. Picked short so
+	// an admin invalidation propagates quickly, long enough that
+	// pip's burst of /simple/<pkg>/ requests during a single
+	// resolution skips both the indexcache OCI round-trip and the
+	// upstream fetch. Tunable via [WithProxyL1IndexCacheTTL].
+	DefaultL1IndexCacheTTL = 10 * time.Second
+
+	// l1IndexCacheSize bounds the number of distinct (namespace,
+	// package) entries the L1 cache holds. Sized so even busy
+	// multi-tenant deployments don't churn.
+	l1IndexCacheSize = 4096
+)
+
+// L1 index cache entry. We hold the response body and content-type
+// alongside the time it was written so the handler can decide
+// freshness without re-touching the OCI backend.
+type l1IndexEntry struct {
+	body        []byte
+	contentType string
+	fetchedAt   time.Time
+}
+
+type l1IndexCache struct {
+	lru *expirable.LRU[string, l1IndexEntry]
+}
+
+func newL1IndexCache(ttl time.Duration) *l1IndexCache {
+	if ttl <= 0 {
+		return &l1IndexCache{}
+	}
+	return &l1IndexCache{
+		lru: expirable.NewLRU[string, l1IndexEntry](l1IndexCacheSize, nil, ttl),
+	}
+}
+
+func (c *l1IndexCache) get(key string) (l1IndexEntry, bool) {
+	if c.lru == nil {
+		return l1IndexEntry{}, false
+	}
+	return c.lru.Get(key)
+}
+
+func (c *l1IndexCache) put(key string, e l1IndexEntry) {
+	if c.lru == nil {
+		return
+	}
+	c.lru.Add(key, e)
+}
+
+func (c *l1IndexCache) invalidate(key string) {
+	if c.lru == nil {
+		return
+	}
+	c.lru.Remove(key)
+}
+
+// proxyState holds everything the handler needs to serve a proxy
+// namespace. It hangs off *Handler and is populated when the handler
+// is constructed with the appropriate options.
+type proxyState struct {
+	factory       FetcherFactory
+	indexCache    *indexcache.Cache
+	negCache      *indexcache.NegativeCache
+	l1            *l1IndexCache
+	indexCacheTTL time.Duration
+	fetchers      sync.Map // upstream string -> ProxyFetcher
+	indexFlight   singleflight.Group
+	fileFlight    singleflight.Group
+	now           func() time.Time
+}
+
+// newProxyState builds the proxy plumbing from handler config. Always
+// constructs an L1 cache; the indexcache + negCache + factory are
+// only populated when the operator wired them via Options.
+func newProxyState(cfg handlerConfig) *proxyState {
+	factory := cfg.fetcherFactory
+	if factory == nil {
+		factory = DefaultFetcherFactory
+	}
+	ttl := cfg.proxyIndexCacheTTL
+	if ttl <= 0 {
+		ttl = DefaultIndexCacheTTL
+	}
+	l1TTL := cfg.proxyL1IndexCacheTTL
+	if l1TTL <= 0 {
+		l1TTL = DefaultL1IndexCacheTTL
+	}
+	return &proxyState{
+		factory:       factory,
+		indexCache:    cfg.indexCache,
+		negCache:      cfg.negCache,
+		l1:            newL1IndexCache(l1TTL),
+		indexCacheTTL: ttl,
+		now:           func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// fetcherFor returns the cached [ProxyFetcher] for upstream, building
+// one via the configured factory on first use. Concurrent first-misses
+// for the same upstream race; the loser's value is dropped (cheap —
+// fetchers carry only in-memory caches).
+func (p *proxyState) fetcherFor(upstream string) (ProxyFetcher, error) {
+	if v, ok := p.fetchers.Load(upstream); ok {
+		return v.(ProxyFetcher), nil
+	}
+	u, err := url.Parse(upstream)
+	if err != nil {
+		return nil, fmt.Errorf("parse upstream %q: %w", upstream, err)
+	}
+	f, err := p.factory(u)
+	if err != nil {
+		return nil, fmt.Errorf("build fetcher for %q: %w", upstream, err)
+	}
+	actual, _ := p.fetchers.LoadOrStore(upstream, f)
+	return actual.(ProxyFetcher), nil
+}
+
+// dispatchProxy returns the [namespace.Spec] for the request's
+// namespace and whether the request should be served via the proxy
+// path. When the namespace is unknown or malformed, it writes the
+// matching error response and returns ok=false so the caller stops.
+func (h *Handler) dispatchProxy(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry) (*namespace.Spec, bool, bool) {
+	spec, err := scoped.Spec(req.Context())
+	if err != nil {
+		if handler.WriteNamespaceError(w, err) {
+			return nil, false, false
+		}
+		handler.WriteError(req.Context(), w, http.StatusInternalServerError, err, "namespace lookup failed")
+		return nil, false, false
+	}
+	isProxy := spec != nil && spec.Mode == namespace.ModeProxy
+	return spec, isProxy, true
+}
+
+// handleFileGetProxy is the proxy-mode file path. Order of operations
+// mirrors the design issue:
+//
+//  1. registry hit → serve.
+//  2. cheap filters (name-only). Deny → 404.
+//  3. upstream version metadata; on metadata error, return matching
+//     status.
+//  4. metadata-dependent filters (publish-time delay). Deny → 404.
+//  5. upstream file fetch.
+//  6. tee through AddFile while streaming to client. AddFile error
+//     mid-stream → 502; next request retries.
+//
+// Concurrent first-misses for the same (ns, pkg, version, filename)
+// collapse onto one upstream fetch via the file-singleflight group.
+func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry, spec *namespace.Spec, f *oci.RepoFile) {
+	ctx := req.Context()
+	logger := logging.FromContext(ctx)
+
+	// Cache-hit fast path. ReadFile authorizes for read and serves
+	// from OCI just like the hosted path; on miss we bubble through
+	// to the upstream resolver.
+	if h.tryServeFromRegistry(w, req, scoped, f) {
+		return
+	}
+
+	pkg := pathPackage(f)
+	version := f.OwningTag
+	filename := f.Name
+
+	if h.proxy.negCache != nil {
+		negKey := negativeKey(scoped.Namespace(), pkg, version, filename)
+		if h.proxy.negCache.IsKnownMissing(negKey) {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+	}
+
+	upstream := spec.Proxy.Upstream
+	fetcher, err := h.proxy.fetcherFor(upstream)
+	if err != nil {
+		handler.WriteError(ctx, w, http.StatusInternalServerError, err, "proxy fetcher unavailable")
+		return
+	}
+
+	// Cheap filters first — if a name-only allow/denylist would
+	// reject this package, we don't pay for upstream metadata.
+	ref := filter.Ref{Package: pkg, Version: version}
+	if decision, denyFilter, err := spec.Proxy.Filters.Decide(ctx, ref); err != nil {
+		logger.DebugContext(ctx, "filter chain error", "error", err, "filter", filterKind(denyFilter))
+		http.Error(w, "filter denied", http.StatusNotFound)
+		return
+	} else if decision == filter.DecisionDeny {
+		logger.InfoContext(ctx, "proxy file denied by filter", "package", pkg, "version", version, "filter", filterKind(denyFilter))
+		http.Error(w, "filter denied", http.StatusNotFound)
+		return
+	}
+	// DecisionNeedsMoreData: we'll re-run after metadata. Allow /
+	// abstain both fall through.
+
+	// Singleflight so concurrent cold-miss requests for the same
+	// file pay one upstream fetch + one AddFile across the process.
+	key := scoped.Namespace() + "|" + f.OwningRepo + "|" + version + "|" + filename
+	resultV, err, _ := h.proxy.fileFlight.Do(key, func() (any, error) {
+		// Re-check the registry inside the singleflight — a peer
+		// may have populated the cache while we were waiting.
+		if hit, hitErr := h.peekRegistry(ctx, scoped, f); hitErr == nil && hit {
+			return fileFlightResult{cached: true}, nil
+		}
+
+		meta, ferr := fetcher.GetVersionMetadata(ctx, pkg, version)
+		if ferr != nil {
+			return fileFlightResult{}, ferr
+		}
+		fileMeta, ok := meta.FindFile(filename)
+		if !ok {
+			return fileFlightResult{}, fmt.Errorf("python proxy: file %q not in metadata for %s %s: %w",
+				filename, pkg, version, proxy.ErrNotFound)
+		}
+
+		// Metadata-dependent filter pass. UploadTime is from the
+		// matched file; version-level earliest would also work but
+		// per-file is the most precise signal for a delay filter.
+		metaRef := filter.Ref{Package: pkg, Version: version, UploadTime: fileMeta.UploadTime}
+		if decision, denyFilter, derr := spec.Proxy.Filters.Decide(ctx, metaRef); derr != nil {
+			return fileFlightResult{}, fmt.Errorf("filter error: %w (kind=%s)", derr, filterKind(denyFilter))
+		} else if decision == filter.DecisionDeny {
+			return fileFlightResult{filterDeny: true, filterName: filterKind(denyFilter)}, nil
+		}
+
+		// File fetch + tee. We do the AddFile here while the
+		// singleflight leader holds the in-flight key so peers
+		// observe cache state after the write.
+		fileResp, ferr := fetcher.FetchFile(ctx, fileMeta.URL)
+		if ferr != nil {
+			return fileFlightResult{}, ferr
+		}
+		defer fileResp.Body.Close()
+
+		populated := &oci.RepoFile{
+			OwningRepo: f.OwningRepo,
+			OwningTag:  f.OwningTag,
+			Name:       f.Name,
+			MediaType:  pickMediaType(filename, fileResp.ContentType),
+			Size:       fileMeta.Size,
+		}
+		var buf bytes.Buffer
+		// We buffer to memory before writing AddFile + serving the
+		// client to keep the implementation simple. The serve.go
+		// upload cap (--python-max-upload-bytes) doesn't apply to
+		// proxy fetches; cap upstream-body size at the same default
+		// so a malicious upstream can't fill memory.
+		limit := h.maxUploadBytes
+		if limit <= 0 {
+			limit = DefaultMaxUploadBytes
+		}
+		bodyLimit := io.LimitReader(fileResp.Body, limit+1)
+		n, copyErr := io.Copy(&buf, bodyLimit)
+		if copyErr != nil {
+			return fileFlightResult{}, fmt.Errorf("upstream read: %w", copyErr)
+		}
+		if n > limit {
+			return fileFlightResult{}, fmt.Errorf("upstream body exceeded %d-byte cap", limit)
+		}
+		if populated.Size == 0 {
+			populated.Size = n
+		}
+
+		// AddFile writes blob + file manifest + version anchor;
+		// authorizes for write on the bound namespace policy. An
+		// already-exists error means a concurrent cold-miss raced
+		// us before singleflight could; treat it as a cache hit.
+		if _, addErr := scoped.AddFile(ctx, populated, bytes.NewReader(buf.Bytes())); addErr != nil {
+			if errors.Is(addErr, oci.ErrAlreadyExists) {
+				return fileFlightResult{cached: true, body: buf.Bytes(), contentType: populated.MediaType, size: n}, nil
+			}
+			return fileFlightResult{}, addErr
+		}
+		return fileFlightResult{body: buf.Bytes(), contentType: populated.MediaType, size: n}, nil
+	})
+
+	if err != nil {
+		// Classify and surface upstream errors.
+		switch {
+		case errors.Is(err, proxy.ErrNotFound):
+			if h.proxy.negCache != nil {
+				h.proxy.negCache.RecordMiss(negativeKey(scoped.Namespace(), pkg, version, filename))
+			}
+			http.Error(w, "not found", http.StatusNotFound)
+		case errors.Is(err, proxy.ErrUpstreamMalformed):
+			handler.WriteError(ctx, w, http.StatusBadGateway, err, "upstream malformed")
+		case errors.Is(err, proxy.ErrUpstreamUnavailable):
+			handler.WriteError(ctx, w, http.StatusBadGateway, err, "upstream unavailable")
+		default:
+			if handler.WriteNamespaceError(w, err) {
+				return
+			}
+			handler.WriteError(ctx, w, http.StatusBadGateway, err, "proxy file fetch failed")
+		}
+		return
+	}
+
+	result := resultV.(fileFlightResult)
+	if result.filterDeny {
+		logger.InfoContext(ctx, "proxy file denied by filter", "package", pkg, "version", version, "filter", result.filterName)
+		http.Error(w, "filter denied", http.StatusNotFound)
+		return
+	}
+	if result.cached {
+		// A peer populated the cache while we were waiting. Re-read
+		// and serve normally so the client sees the standard
+		// Content-Type / Content-Length headers we set on hits.
+		if h.tryServeFromRegistry(w, req, scoped, f) {
+			return
+		}
+		// If the re-read fails (e.g. the peer's AddFile failed
+		// after our singleflight returned its "cached" result),
+		// fall through to writing the buffered body we already
+		// have. This is best-effort cleanup of a rare race.
+	}
+
+	w.Header().Set("Content-Type", result.contentType)
+	w.Header().Set("Content-Length", strconv.FormatInt(result.size, 10))
+	if req.Method == http.MethodHead {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	if _, werr := w.Write(result.body); werr != nil {
+		logger.DebugContext(ctx, "write response after proxy fetch", "error", werr)
+	}
+}
+
+// fileFlightResult is the singleflight return value for proxy file
+// fetches. body is non-nil when we performed the fetch; cached==true
+// means a peer (re)populated the registry while we waited, and the
+// caller should re-read from the registry to serve the canonical
+// hit-path response.
+type fileFlightResult struct {
+	body        []byte
+	contentType string
+	size        int64
+	cached      bool
+	filterDeny  bool
+	filterName  string
+}
+
+// peekRegistry probes the registry for a file without consuming the
+// body. Used by the singleflight follower path to decide between
+// "peer wrote the file, re-serve from cache" and "peer failed, do
+// our own fetch". Returns (true, nil) on hit, (false, nil) on miss,
+// non-nil error on backend trouble.
+func (h *Handler) peekRegistry(ctx context.Context, scoped *namespace.ScopedRegistry, f *oci.RepoFile) (bool, error) {
+	desc, rc, err := scoped.ReadFile(ctx, f)
+	if err != nil {
+		if errors.Is(err, errdef.ErrNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	rc.Close()
+	_ = desc
+	return true, nil
+}
+
+// tryServeFromRegistry attempts the hosted-style ReadFile + redirect
+// flow. Returns true on success (response written), false on miss so
+// the caller continues with the proxy fetch. Errors other than
+// not-found are written as the appropriate HTTP status and return true.
+func (h *Handler) tryServeFromRegistry(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry, f *oci.RepoFile) bool {
+	ctx := req.Context()
+	logger := logging.FromContext(ctx)
+
+	if req.Method != http.MethodHead {
+		if redirectURL, err := scoped.BlobRedirectURL(ctx, f); err == nil && redirectURL != "" {
+			http.Redirect(w, req, redirectURL, http.StatusTemporaryRedirect)
+			return true
+		} else if err != nil {
+			logger.DebugContext(ctx, "blob redirect probe failed", "error", err)
+		}
+	}
+
+	desc, r, err := scoped.ReadFile(ctx, f)
+	if err != nil {
+		if errors.Is(err, errdef.ErrNotFound) {
+			return false
+		}
+		if handler.WriteNamespaceError(w, err) {
+			return true
+		}
+		if oci.HasCode(err, http.StatusUnauthorized) {
+			http.Error(w, err.Error(), http.StatusUnauthorized)
+			return true
+		}
+		if oci.HasCode(err, http.StatusForbidden) {
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return true
+		}
+		handler.WriteError(ctx, w, http.StatusInternalServerError, err, "internal error")
+		return true
+	}
+	defer r.Close()
+
+	w.Header().Set("Content-Type", f.MediaType)
+	w.Header().Set("Content-Length", strconv.FormatInt(desc.File.Size, 10))
+	w.Header().Set("X-Checksum-Sha256", desc.File.Digest.String())
+	if req.Method == http.MethodHead {
+		return true
+	}
+	if _, err := io.Copy(w, r); err != nil {
+		logger.DebugContext(ctx, "copy proxy hit body", "error", err)
+	}
+	return true
+}
+
+// handlePackageIndexProxy serves /{ns}/simple/{pkg}/ in proxy mode.
+//
+//  1. L1 in-memory cache hit → serve.
+//  2. indexcache.Get → fresh (within DefaultIndexCacheTTL) → serve +
+//     warm L1.
+//  3. Upstream fetch:
+//     - success → rewrite URLs → indexcache.Put → serve + warm L1.
+//     - upstream error + stale cache → serve stale; log.
+//     - upstream error + no cache → synthesize from
+//     ListFiles("packages/"+pkg) (existing hosted code path).
+//     - synthesis empty → 503.
+//
+// Concurrent refreshes for the same (namespace, pkg) collapse onto
+// one upstream fetch via the index-singleflight group.
+func (h *Handler) handlePackageIndexProxy(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry, spec *namespace.Spec, pkg string) {
+	h.serveProxyIndex(w, req, scoped, spec, pkg)
+}
+
+// handleSimpleIndexProxy serves /{ns}/simple/ in proxy mode. Same
+// flow as the per-package path with cache key pkg="" and synthesis
+// fallback `ListTags("index")`.
+func (h *Handler) handleSimpleIndexProxy(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry, spec *namespace.Spec) {
+	h.serveProxyIndex(w, req, scoped, spec, "")
+}
+
+func (h *Handler) serveProxyIndex(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry, spec *namespace.Spec, pkg string) {
+	ctx := req.Context()
+	logger := logging.FromContext(ctx)
+	ns := scoped.Namespace()
+	cacheKey := ns + "|" + pkg
+
+	// L1 in-memory cache fast path.
+	if e, ok := h.proxy.l1.get(cacheKey); ok {
+		writeIndexBody(w, req, e.body, e.contentType)
+		return
+	}
+
+	// indexcache OCI freshness check. A fresh entry means we don't
+	// fetch upstream; a stale entry remains a fallback if upstream
+	// later goes down inside this same request.
+	var (
+		cachedBody        []byte
+		cachedContentType string
+		cachedFetchedAt   time.Time
+		cachedFound       bool
+	)
+	if h.proxy.indexCache != nil {
+		b, ct, fa, found, err := h.proxy.indexCache.Get(ctx, ns, indexCacheKey(pkg))
+		if err != nil {
+			logger.DebugContext(ctx, "indexcache get failed", "error", err)
+		} else if found {
+			cachedBody, cachedContentType, cachedFetchedAt, cachedFound = b, ct, fa, true
+			if h.proxy.now().Sub(fa) < h.proxy.indexCacheTTL {
+				h.proxy.l1.put(cacheKey, l1IndexEntry{body: b, contentType: ct, fetchedAt: fa})
+				writeIndexBody(w, req, b, ct)
+				return
+			}
+		}
+	}
+
+	upstream := spec.Proxy.Upstream
+	fetcher, err := h.proxy.fetcherFor(upstream)
+	if err != nil {
+		handler.WriteError(ctx, w, http.StatusInternalServerError, err, "proxy fetcher unavailable")
+		return
+	}
+
+	resultV, err, _ := h.proxy.indexFlight.Do(cacheKey, func() (any, error) {
+		// Re-check L1 inside the singleflight in case a peer
+		// populated it while we were queueing.
+		if e, ok := h.proxy.l1.get(cacheKey); ok {
+			return indexFlightResult{body: e.body, contentType: e.contentType}, nil
+		}
+		var (
+			indexResp *pypython.IndexResponse
+			fetchErr  error
+		)
+		if pkg == "" {
+			indexResp, fetchErr = fetcher.GetTopLevelIndex(ctx)
+		} else {
+			indexResp, fetchErr = fetcher.GetSimpleIndex(ctx, pkg)
+		}
+		if fetchErr != nil {
+			return indexFlightResult{}, fetchErr
+		}
+
+		body := indexResp.Body
+		if pkg != "" {
+			// Per-package index: rewrite file URLs back through
+			// ocifactory. The top-level index doesn't need
+			// rewriting (its hrefs are package-relative).
+			rewritten, rerr := pypython.RewriteSimpleIndex(indexResp.Body, ns, pkg)
+			if rerr != nil {
+				return indexFlightResult{}, rerr
+			}
+			body = rewritten
+		}
+
+		if h.proxy.indexCache != nil {
+			if perr := h.proxy.indexCache.Put(ctx, ns, indexCacheKey(pkg), body, indexResp.ContentType); perr != nil {
+				logger.DebugContext(ctx, "indexcache put failed", "error", perr)
+			}
+		}
+		h.proxy.l1.put(cacheKey, l1IndexEntry{body: body, contentType: indexResp.ContentType, fetchedAt: h.proxy.now()})
+		return indexFlightResult{body: body, contentType: indexResp.ContentType}, nil
+	})
+
+	if err == nil {
+		r := resultV.(indexFlightResult)
+		writeIndexBody(w, req, r.body, r.contentType)
+		return
+	}
+
+	// Upstream error path. We try, in order:
+	//   - the stale indexcache entry (still better than the
+	//     synthesized one, since it's the last known canonical
+	//     upstream view).
+	//   - synthesis from local listings — minimal but accurate.
+	//   - 503 when synthesis is empty.
+	if errors.Is(err, proxy.ErrNotFound) {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+
+	if cachedFound {
+		logger.WarnContext(ctx, "serving stale proxy index after upstream error",
+			"namespace", ns, "package", pkg, "age", h.proxy.now().Sub(cachedFetchedAt), "error", err)
+		writeIndexBody(w, req, cachedBody, cachedContentType)
+		return
+	}
+
+	h.synthesizeIndex(w, req, scoped, pkg, err)
+}
+
+type indexFlightResult struct {
+	body        []byte
+	contentType string
+}
+
+// synthesizeIndex serves a minimal but accurate index built from local
+// listings when both the upstream and the cache are unavailable. For
+// per-package: enumerate files in `packages/<pkg>` and render the same
+// HTML/JSON the hosted path would. For top-level: enumerate tags on
+// `index` (hosted handler's existing dedupe list).
+//
+// An empty synthesis result means we have no cached files for this
+// (namespace, package) either — 503, since serving a literal empty
+// index would have pip conclude the package was unyanked, which is
+// worse than a clear "we're degraded" signal.
+func (h *Handler) synthesizeIndex(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry, pkg string, upstreamErr error) {
+	ctx := req.Context()
+	logger := logging.FromContext(ctx)
+	ns := scoped.Namespace()
+
+	if pkg == "" {
+		tags, err := scoped.ListTags(ctx, "index")
+		if err != nil && !errors.Is(err, errdef.ErrNotFound) {
+			handler.WriteError(ctx, w, http.StatusServiceUnavailable, upstreamErr,
+				fmt.Sprintf("upstream unavailable and synthesis failed: %v", err))
+			return
+		}
+		if len(tags) == 0 {
+			handler.WriteError(ctx, w, http.StatusServiceUnavailable, upstreamErr, "upstream unavailable, no cached index")
+			return
+		}
+		logger.WarnContext(ctx, "synthesizing top-level index from local state", "namespace", ns, "count", len(tags), "error", upstreamErr)
+		if pickContentType(req.Header.Get("Accept")) == contentTypeJSONv1 {
+			writeJSONIndexList(w, tags)
+			return
+		}
+		page := indexPage{Title: "Simple Index"}
+		for _, tag := range tags {
+			page.Files = append(page.Files, indexFile{
+				Filename: tag,
+				URL: (&url.URL{
+					Scheme: req.URL.Scheme,
+					Host:   req.URL.Host,
+					Path:   "/" + ns + "/simple/" + tag + "/",
+				}).String(),
+			})
+		}
+		h.renderer.RenderHTML(w, "simple.html", page)
+		return
+	}
+
+	files, err := h.resolvePackageFiles(ctx, scoped, pkg)
+	if err != nil && !errors.Is(err, errdef.ErrNotFound) {
+		handler.WriteError(ctx, w, http.StatusServiceUnavailable, upstreamErr,
+			fmt.Sprintf("upstream unavailable and synthesis failed: %v", err))
+		return
+	}
+	if len(files) == 0 {
+		handler.WriteError(ctx, w, http.StatusServiceUnavailable, upstreamErr, "upstream unavailable, no cached files")
+		return
+	}
+	logger.WarnContext(ctx, "synthesizing package index from local state", "namespace", ns, "package", pkg, "count", len(files), "error", upstreamErr)
+	rendered := make([]indexFile, 0, len(files))
+	for _, f := range files {
+		rendered = append(rendered, indexFile{
+			Filename: f.Filename,
+			URL:      renderedFileURL(req, ns, pkg, f),
+			Sha256:   f.Sha256,
+		})
+	}
+	if pickContentType(req.Header.Get("Accept")) == contentTypeJSONv1 {
+		writeJSONPackageIndex(w, pkg, rendered)
+		return
+	}
+	h.renderer.RenderHTML(w, "simple.html", indexPage{Title: pkg, Files: rendered})
+}
+
+func writeIndexBody(w http.ResponseWriter, req *http.Request, body []byte, contentType string) {
+	if contentType == "" {
+		contentType = "text/html"
+	}
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+	if req.Method == http.MethodHead {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	_, _ = w.Write(body)
+}
+
+// pathPackage extracts the (normalized) package name from a RepoFile's
+// OwningRepo. The python handler stores files under
+// "packages/<pkg>", so we trim the prefix; any other shape is a bug
+// in this package and we surface "" so downstream filter / metadata
+// calls fail loudly.
+func pathPackage(f *oci.RepoFile) string {
+	const prefix = "packages/"
+	if f == nil {
+		return ""
+	}
+	if len(f.OwningRepo) <= len(prefix) {
+		return ""
+	}
+	if f.OwningRepo[:len(prefix)] != prefix {
+		return ""
+	}
+	return f.OwningRepo[len(prefix):]
+}
+
+// negativeKey is the cache key for negative-cache entries on proxy
+// file fetches. Includes namespace so a 404 in one namespace doesn't
+// suppress a probe in another.
+func negativeKey(ns, pkg, version, filename string) string {
+	return "py|" + ns + "|" + pkg + "|" + version + "|" + filename
+}
+
+// indexCacheKey is the indexcache pkg argument for the python proxy.
+// The top-level index uses an underscore prefix that cannot occur in
+// a PEP 503 package name so it can't collide with a per-package
+// entry. (PEP 503 names lowercase ASCII letters / digits / `-` / `_` /
+// `.`, but never start with an underscore in any realistic project —
+// and even if they did, the underscore prefix segment is reserved
+// internal here.)
+func indexCacheKey(pkg string) string {
+	if pkg == "" {
+		return "_toplevel"
+	}
+	return pkg
+}
+
+func filterKind(f filter.Filter) string {
+	if f == nil {
+		return ""
+	}
+	if k, ok := f.(filter.Kinded); ok {
+		return k.Kind()
+	}
+	return fmt.Sprintf("%T", f)
+}
+
+// pickMediaType prefers the handler's filename-derived mime type
+// (detectMediaType) over a noisy upstream value, since the OCI layer
+// descriptor is queried with the filename's media type when pip
+// re-reads the cached file. When detection fails we fall back to the
+// upstream Content-Type, then to application/octet-stream.
+func pickMediaType(filename, upstream string) string {
+	if mt := detectMediaType(filename); mt != "" && mt != "application/octet-stream" {
+		return mt
+	}
+	if upstream != "" {
+		return upstream
+	}
+	return "application/octet-stream"
+}

--- a/pkg/handler/python/proxy.go
+++ b/pkg/handler/python/proxy.go
@@ -268,6 +268,14 @@ func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, s
 	key := scoped.Namespace() + "|" + f.OwningRepo + "|" + version + "|" + filename
 	isHead := req.Method == http.MethodHead
 	amLeader := false
+	// teeRef captures the leader's tee writer so the outer error branch
+	// can tell whether the response body has already been (partially)
+	// committed. Once any write has gone through the tee, http.Error
+	// can no longer change status/headers but WOULD append extra bytes
+	// to the body the client is reading — which silently corrupts what
+	// the client is about to hash (PEP 658 sidecars, wheels, anything
+	// with a known sha256). Suppress the error body in that case.
+	var teeRef *tolerantWriter
 	resultV, err, _ := h.proxy.fileFlight.Do(key, func() (any, error) {
 		amLeader = true
 
@@ -358,7 +366,8 @@ func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, s
 			if fileMeta.Size > 0 {
 				w.Header().Set("Content-Length", strconv.FormatInt(fileMeta.Size, 10))
 			}
-			body = io.TeeReader(body, &tolerantWriter{w: w})
+			teeRef = &tolerantWriter{w: w}
+			body = io.TeeReader(body, teeRef)
 		}
 
 		// AddFile writes blob + file manifest + version anchor;
@@ -377,10 +386,18 @@ func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, s
 	})
 
 	if err != nil {
-		// Classify and surface upstream errors. If we're the leader
-		// and the tee already wrote a 200 + partial body, http.Error
-		// will fail silently — that's fine, the client sees a truncated
-		// response and the next request will retry. Followers haven't
+		// If the leader's tee already started writing the response body,
+		// the 200 + Content-Type / Content-Length are committed. Writing
+		// an error body now would append junk after the bytes the client
+		// is hashing (PEP 658 sidecars, wheels) and turn a clean truncation
+		// into a hash mismatch. Log and bail; the client sees a truncated
+		// response, the next request retries.
+		if amLeader && teeRef != nil && teeRef.used {
+			logger.WarnContext(ctx, "proxy file fetch failed after response body started; suppressing error body",
+				"error", err, "package", pkg, "version", version, "filename", filename)
+			return
+		}
+		// Classify and surface upstream errors. Followers haven't
 		// written anything to their own ResponseWriter yet.
 		switch {
 		case errors.Is(err, proxy.ErrNotFound):
@@ -432,9 +449,16 @@ func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, s
 type tolerantWriter struct {
 	w    io.Writer
 	dead bool
+	// used flips true on the first Write attempt regardless of whether
+	// the underlying Write succeeded. Callers use it to detect that the
+	// HTTP response body has been committed (status + headers flushed,
+	// body bytes possibly buffered) so they don't append error bytes
+	// that would corrupt a content-addressable client response.
+	used bool
 }
 
 func (t *tolerantWriter) Write(p []byte) (int, error) {
+	t.used = true
 	if t.dead {
 		return len(p), nil
 	}

--- a/pkg/handler/python/proxy.go
+++ b/pkg/handler/python/proxy.go
@@ -1,7 +1,6 @@
 package python
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -254,10 +253,23 @@ func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, s
 	// DecisionNeedsMoreData: we'll re-run after metadata. Allow /
 	// abstain both fall through.
 
-	// Singleflight so concurrent cold-miss requests for the same
-	// file pay one upstream fetch + one AddFile across the process.
+	limit := h.maxUploadBytes
+	if limit <= 0 {
+		limit = DefaultMaxUploadBytes
+	}
+
+	// Singleflight so concurrent cold-miss requests for the same file
+	// pay one upstream fetch + one AddFile across the process. The
+	// leader streams upstream → AddFile (which writes the blob to OCI)
+	// and simultaneously tees the bytes onto its own ResponseWriter.
+	// Followers observe a "streamed" outcome and re-read the now-cached
+	// file from OCI to serve their own clients.
 	key := scoped.Namespace() + "|" + f.OwningRepo + "|" + version + "|" + filename
+	isHead := req.Method == http.MethodHead
+	amLeader := false
 	resultV, err, _ := h.proxy.fileFlight.Do(key, func() (any, error) {
+		amLeader = true
+
 		// Re-check the registry inside the singleflight — a peer
 		// may have populated the cache while we were waiting.
 		if hit, hitErr := h.peekRegistry(ctx, scoped, f); hitErr == nil && hit {
@@ -284,9 +296,12 @@ func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, s
 			return fileFlightResult{filterDeny: true, filterName: filterKind(denyFilter)}, nil
 		}
 
-		// File fetch + tee. We do the AddFile here while the
-		// singleflight leader holds the in-flight key so peers
-		// observe cache state after the write.
+		// Refuse upfront when upstream metadata claims a body bigger
+		// than the cap so we don't pay for the upstream fetch.
+		if fileMeta.Size > 0 && fileMeta.Size > limit {
+			return fileFlightResult{}, fmt.Errorf("upstream metadata size %d exceeds %d-byte cap", fileMeta.Size, limit)
+		}
+
 		fileResp, ferr := fetcher.FetchFile(ctx, fileMeta.URL)
 		if ferr != nil {
 			return fileFlightResult{}, ferr
@@ -300,43 +315,52 @@ func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, s
 			MediaType:  pickMediaType(filename, fileResp.ContentType),
 			Size:       fileMeta.Size,
 		}
-		var buf bytes.Buffer
-		// We buffer to memory before writing AddFile + serving the
-		// client to keep the implementation simple. The serve.go
-		// upload cap (--python-max-upload-bytes) doesn't apply to
-		// proxy fetches; cap upstream-body size at the same default
-		// so a malicious upstream can't fill memory.
-		limit := h.maxUploadBytes
-		if limit <= 0 {
-			limit = DefaultMaxUploadBytes
-		}
-		bodyLimit := io.LimitReader(fileResp.Body, limit+1)
-		n, copyErr := io.Copy(&buf, bodyLimit)
-		if copyErr != nil {
-			return fileFlightResult{}, fmt.Errorf("upstream read: %w", copyErr)
-		}
-		if n > limit {
-			return fileFlightResult{}, fmt.Errorf("upstream body exceeded %d-byte cap", limit)
-		}
-		if populated.Size == 0 {
-			populated.Size = n
+
+		// Defense in depth even when fileMeta.Size is 0 / lying:
+		// LimitReader truncates the body at limit+1 so an AddFile that
+		// somehow accepted an unbounded body still can't burn unbounded
+		// memory or disk. AddFile will surface the truncation as a
+		// digest / size mismatch.
+		var body io.Reader = io.LimitReader(fileResp.Body, limit+1)
+
+		// Leader-only tee: set client response headers eagerly and
+		// pipe AddFile's read through a tolerant writer onto our own
+		// ResponseWriter. If our client disconnects mid-stream the
+		// writer swallows the error so AddFile keeps draining upstream
+		// — that's the whole point of the cache fill, and finishing it
+		// makes the byte we paid upstream serve every follower for
+		// free. For HEAD we don't tee; AddFile still drains upstream
+		// to populate the cache, and tryServeFromRegistry serves the
+		// HEAD response after the flight returns.
+		if !isHead {
+			w.Header().Set("Content-Type", populated.MediaType)
+			if fileMeta.Size > 0 {
+				w.Header().Set("Content-Length", strconv.FormatInt(fileMeta.Size, 10))
+			}
+			body = io.TeeReader(body, &tolerantWriter{w: w})
 		}
 
 		// AddFile writes blob + file manifest + version anchor;
 		// authorizes for write on the bound namespace policy. An
-		// already-exists error means a concurrent cold-miss raced
-		// us before singleflight could; treat it as a cache hit.
-		if _, addErr := scoped.AddFile(ctx, populated, bytes.NewReader(buf.Bytes())); addErr != nil {
+		// already-exists error means a concurrent cold-miss raced us
+		// before singleflight could; probeExistingFile reports it
+		// before reading the body, so no client bytes were written and
+		// the follower path can serve from the cache the peer wrote.
+		if _, addErr := scoped.AddFile(ctx, populated, body); addErr != nil {
 			if errors.Is(addErr, oci.ErrAlreadyExists) {
-				return fileFlightResult{cached: true, body: buf.Bytes(), contentType: populated.MediaType, size: n}, nil
+				return fileFlightResult{cached: true}, nil
 			}
 			return fileFlightResult{}, addErr
 		}
-		return fileFlightResult{body: buf.Bytes(), contentType: populated.MediaType, size: n}, nil
+		return fileFlightResult{streamed: true}, nil
 	})
 
 	if err != nil {
-		// Classify and surface upstream errors.
+		// Classify and surface upstream errors. If we're the leader
+		// and the tee already wrote a 200 + partial body, http.Error
+		// will fail silently — that's fine, the client sees a truncated
+		// response and the next request will retry. Followers haven't
+		// written anything to their own ResponseWriter yet.
 		switch {
 		case errors.Is(err, proxy.ErrNotFound):
 			if h.proxy.negCache != nil {
@@ -362,42 +386,61 @@ func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, s
 		http.Error(w, "filter denied", http.StatusNotFound)
 		return
 	}
-	if result.cached {
-		// A peer populated the cache while we were waiting. Re-read
-		// and serve normally so the client sees the standard
-		// Content-Type / Content-Length headers we set on hits.
-		if h.tryServeFromRegistry(w, req, scoped, f) {
-			return
-		}
-		// If the re-read fails (e.g. the peer's AddFile failed
-		// after our singleflight returned its "cached" result),
-		// fall through to writing the buffered body we already
-		// have. This is best-effort cleanup of a rare race.
-	}
-
-	w.Header().Set("Content-Type", result.contentType)
-	w.Header().Set("Content-Length", strconv.FormatInt(result.size, 10))
-	if req.Method == http.MethodHead {
-		w.WriteHeader(http.StatusOK)
+	if result.streamed && amLeader && !isHead {
+		// Bytes were written via the tee during AddFile. Nothing left
+		// to do on the leader's GET response.
 		return
 	}
-	if _, werr := w.Write(result.body); werr != nil {
-		logger.DebugContext(ctx, "write response after proxy fetch", "error", werr)
+	// Either we're a follower waiting on the leader, the leader on a
+	// HEAD that needs the headers written, or we hit ErrAlreadyExists
+	// mid-flight. All three serve the canonical headers + body from
+	// the cache the leader just populated.
+	if h.tryServeFromRegistry(w, req, scoped, f) {
+		return
 	}
+	handler.WriteError(ctx, w, http.StatusBadGateway, nil, "proxy fill reported success but cache miss on re-read")
+}
+
+// tolerantWriter wraps an io.Writer (the proxy leader's
+// http.ResponseWriter) so a client-side write failure stops further
+// writes but doesn't surface as an error to the upstream-side reader.
+// This is what lets AddFile finish populating the OCI cache after the
+// client disconnects mid-stream: subsequent tee Reads keep flowing to
+// AddFile without io.TeeReader propagating the dead client back to the
+// upstream copy.
+type tolerantWriter struct {
+	w    io.Writer
+	dead bool
+}
+
+func (t *tolerantWriter) Write(p []byte) (int, error) {
+	if t.dead {
+		return len(p), nil
+	}
+	if _, err := t.w.Write(p); err != nil {
+		t.dead = true
+	}
+	return len(p), nil
 }
 
 // fileFlightResult is the singleflight return value for proxy file
-// fetches. body is non-nil when we performed the fetch; cached==true
-// means a peer (re)populated the registry while we waited, and the
-// caller should re-read from the registry to serve the canonical
-// hit-path response.
+// fetches. Exactly one of streamed / cached / filterDeny is true on
+// success; an error result returns the zero value.
+//
+//   - streamed: the leader called AddFile, which drained upstream into
+//     the OCI cache (and, for GET, simultaneously teed bytes onto its
+//     own client response). Followers serve from the cache.
+//   - cached: a peer populated the cache while this caller was waiting
+//     (either the re-probe inside the flight hit, or AddFile returned
+//     ErrAlreadyExists before reading any body). Everyone serves from
+//     cache.
+//   - filterDeny: the metadata-dependent filter chain rejected this
+//     version after the upstream metadata call. Everyone returns 404.
 type fileFlightResult struct {
-	body        []byte
-	contentType string
-	size        int64
-	cached      bool
-	filterDeny  bool
-	filterName  string
+	streamed   bool
+	cached     bool
+	filterDeny bool
+	filterName string
 }
 
 // peekRegistry probes the registry for a file without consuming the

--- a/pkg/handler/python/proxy_test.go
+++ b/pkg/handler/python/proxy_test.go
@@ -2,6 +2,7 @@ package python
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -756,6 +757,9 @@ func TestTolerantWriter(t *testing.T) {
 	if !tw.dead {
 		t.Errorf("tolerantWriter not latched dead after underlying failure")
 	}
+	if !tw.used {
+		t.Errorf("tolerantWriter.used = false after Writes attempted, want true")
+	}
 	if got, want := failing.writes, 1; got != want {
 		t.Errorf("underlying Write calls = %d, want %d (subsequent writes should be swallowed)", got, want)
 	}
@@ -813,6 +817,114 @@ func TestProxy_FileClientDisconnectStillFillsCache(t *testing.T) {
 	if _, _, _, fileCalls := fake.calls(); fileCalls != 1 {
 		t.Errorf("fetchFileCalls = %d after second request, want 1 (cache should serve)", fileCalls)
 	}
+}
+
+// TestProxy_FileAddFileFailureAfterTeeDoesNotCorruptBody locks in the
+// fix for the bug where AddFile failures (e.g. zot rejecting a manifest
+// with invalid mediaType) caused us to call http.Error AFTER the tee
+// already wrote 200 + headers + body bytes. http.Error appended its
+// public-message string to the body the client was about to hash,
+// turning a clean truncation into a silent hash mismatch — exactly what
+// pip observed on PEP 658 sidecar fetches when our `.metadata` blobs
+// had a parameterized mediaType.
+func TestProxy_FileAddFileFailureAfterTeeDoesNotCorruptBody(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeFetcher()
+	const fileURL = "https://files.pythonhosted.org/packages/abc/x-1.0.0.whl"
+	const bodyBytes = "body-bytes-exactly"
+	fake.versionMeta["x@1.0.0"] = &pypython.VersionMetadata{
+		Package: "x", Version: "1.0.0",
+		Files: []pypython.FileMetadata{{
+			Filename: "x-1.0.0.whl",
+			URL:      fileURL,
+			Size:     int64(len(bodyBytes)),
+		}},
+	}
+	fake.files[fileURL] = []byte(bodyBytes)
+
+	// Build a namespace.Registry wrapping a backend whose AddFile
+	// reads the full body (so the tee writes through) and then errors.
+	backing := oci.NewFakeRegistry()
+	wrapped := &addFileFailingBackend{
+		inner:          backing,
+		err:            errors.New("simulated manifest invalid"),
+		failRepoSuffix: "/packages/x",
+	}
+	store := namespace.NewStore(wrapped)
+	reg := namespace.NewRegistry(wrapped, store, namespace.WithPolicyCacheTTL(0))
+	if err := store.Put(t.Context(), &namespace.Namespace{Name: testNS, Spec: namespace.Spec{
+		Mode:   namespace.ModeProxy,
+		Proxy:  namespace.Proxy{Upstream: "https://pypi.org"},
+		Policy: allowAllPolicy(),
+	}}); err != nil {
+		t.Fatalf("Put namespace: %v", err)
+	}
+	authMW := auth.Middleware(auth.AlwaysAnonymous)
+	h, err := NewHandler(reg,
+		WithAuthMiddleware(authMW),
+		WithFetcherFactory(func(*url.URL) (ProxyFetcher, error) { return fake, nil }),
+		WithProxyL1IndexCacheTTL(-1),
+	)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet,
+		"/"+testNS+"/packages/x/1.0.0/x-1.0.0.whl", nil)
+	h.Mux().ServeHTTP(w, r)
+
+	// The body must be EXACTLY the upstream bytes — no error text
+	// appended. The status was already committed to 200 by the tee's
+	// first Write; we can't change it, but we MUST NOT corrupt the body.
+	if got, want := w.Body.String(), bodyBytes; got != want {
+		t.Errorf("body = %q, want %q (extra bytes from http.Error would break content-hash verification)",
+			got, want)
+	}
+}
+
+// addFileFailingBackend wraps a real backend so AddFile reads the full
+// body (so any tee gets exercised end-to-end) and then errors — but only
+// for OwningRepos whose suffix matches failRepoSuffix, so namespace-store
+// writes and other infrastructure AddFile calls still succeed.
+type addFileFailingBackend struct {
+	inner          *oci.FakeRegistry
+	err            error
+	failRepoSuffix string
+}
+
+func (b *addFileFailingBackend) AddFile(ctx context.Context, f *oci.RepoFile, ro io.Reader) (*oci.FileDescriptor, error) {
+	if b.failRepoSuffix != "" && strings.HasSuffix(f.OwningRepo, b.failRepoSuffix) {
+		if _, err := io.Copy(io.Discard, ro); err != nil {
+			return nil, err
+		}
+		return nil, b.err
+	}
+	return b.inner.AddFile(ctx, f, ro)
+}
+
+func (b *addFileFailingBackend) ReadFile(ctx context.Context, f *oci.RepoFile) (*oci.FileDescriptor, io.ReadCloser, error) {
+	return b.inner.ReadFile(ctx, f)
+}
+
+func (b *addFileFailingBackend) BlobRedirectURL(ctx context.Context, f *oci.RepoFile) (string, error) {
+	return b.inner.BlobRedirectURL(ctx, f)
+}
+func (b *addFileFailingBackend) ListTags(ctx context.Context, repo string) ([]string, error) {
+	return b.inner.ListTags(ctx, repo)
+}
+func (b *addFileFailingBackend) ListFiles(ctx context.Context, repo string) ([]*oci.RepoFile, error) {
+	return b.inner.ListFiles(ctx, repo)
+}
+func (b *addFileFailingBackend) AppendRefs(ctx context.Context, repo, canonicalTag string, refs ...string) error {
+	return b.inner.AppendRefs(ctx, repo, canonicalTag, refs...)
+}
+func (b *addFileFailingBackend) DeleteRepoFiles(ctx context.Context, repo string) error {
+	return b.inner.DeleteRepoFiles(ctx, repo)
+}
+func (b *addFileFailingBackend) DeleteTagFiles(ctx context.Context, repo, tag string) error {
+	return b.inner.DeleteTagFiles(ctx, repo, tag)
 }
 
 // failOnNthWriter errors on the failAt-th Write (1-indexed) and on

--- a/pkg/handler/python/proxy_test.go
+++ b/pkg/handler/python/proxy_test.go
@@ -680,6 +680,116 @@ func TestProxy_FileFlight_ConcurrentMissDeduped(t *testing.T) {
 	}
 }
 
+// TestTolerantWriter verifies that a client write failure latches the
+// writer into "dead" mode without surfacing the error back to the
+// reader. This is the contract io.TeeReader relies on inside the
+// proxy file path: AddFile keeps draining upstream after the client
+// goes away.
+func TestTolerantWriter(t *testing.T) {
+	t.Parallel()
+
+	failing := &failOnNthWriter{failAt: 1}
+	tw := &tolerantWriter{w: failing}
+
+	for i, chunk := range [][]byte{[]byte("aa"), []byte("bb"), []byte("cc")} {
+		n, err := tw.Write(chunk)
+		if err != nil {
+			t.Errorf("Write[%d] err = %v, want nil", i, err)
+		}
+		if n != len(chunk) {
+			t.Errorf("Write[%d] n = %d, want %d", i, n, len(chunk))
+		}
+	}
+	if !tw.dead {
+		t.Errorf("tolerantWriter not latched dead after underlying failure")
+	}
+	if got, want := failing.writes, 1; got != want {
+		t.Errorf("underlying Write calls = %d, want %d (subsequent writes should be swallowed)", got, want)
+	}
+}
+
+// TestProxy_FileClientDisconnectStillFillsCache simulates a client that
+// gives up partway through the response (httptest.NewRecorder wrapped
+// in a writer that errors immediately). The OCI cache fill must still
+// complete so the next request hits the cache.
+func TestProxy_FileClientDisconnectStillFillsCache(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeFetcher()
+	const fileURL = "https://files.pythonhosted.org/packages/abc/x-1.0.0.whl"
+	fake.versionMeta["x@1.0.0"] = &pypython.VersionMetadata{
+		Package: "x", Version: "1.0.0",
+		Files: []pypython.FileMetadata{{
+			Filename: "x-1.0.0.whl",
+			URL:      fileURL,
+			Size:     int64(len("body-bytes")),
+		}},
+	}
+	fake.files[fileURL] = []byte("body-bytes")
+
+	h, _, backing := newProxyTestHandler(t, fake, namespace.Spec{})
+
+	// First request with a writer that fails every Write, simulating
+	// an immediate client disconnect.
+	dead := &deadClientRecorder{ResponseRecorder: httptest.NewRecorder()}
+	r := httptest.NewRequest(http.MethodGet,
+		"/"+testNS+"/packages/x/1.0.0/x-1.0.0.whl", nil)
+	h.Mux().ServeHTTP(dead, r)
+
+	// The cache fill must have completed regardless of the client
+	// write status.
+	files, err := backing.ListFiles(t.Context(), testNS+"/packages/x")
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("backing has %d files after disconnect, want 1", len(files))
+	}
+
+	// Second request with a normal writer reads the cached file and
+	// must not hit upstream again.
+	w2 := httptest.NewRecorder()
+	h.Mux().ServeHTTP(w2, httptest.NewRequest(http.MethodGet,
+		"/"+testNS+"/packages/x/1.0.0/x-1.0.0.whl", nil))
+	if got, want := w2.Code, http.StatusOK; got != want {
+		t.Fatalf("second request status = %d, want %d (body=%s)", got, want, w2.Body.String())
+	}
+	if got, want := w2.Body.String(), "body-bytes"; got != want {
+		t.Errorf("second request body = %q, want %q", got, want)
+	}
+	if _, _, _, fileCalls := fake.calls(); fileCalls != 1 {
+		t.Errorf("fetchFileCalls = %d after second request, want 1 (cache should serve)", fileCalls)
+	}
+}
+
+// failOnNthWriter errors on the failAt-th Write (1-indexed) and on
+// every Write thereafter. It records the total number of Write calls
+// it received so callers can assert "no further calls after failure".
+type failOnNthWriter struct {
+	failAt int
+	writes int
+}
+
+func (f *failOnNthWriter) Write(p []byte) (int, error) {
+	f.writes++
+	if f.writes >= f.failAt {
+		return 0, io.ErrClosedPipe
+	}
+	return len(p), nil
+}
+
+// deadClientRecorder is an http.ResponseWriter whose Write always
+// fails, simulating a TCP-level client disconnect after headers but
+// before body. It still records headers / status via the embedded
+// httptest.ResponseRecorder so tests can inspect them.
+type deadClientRecorder struct {
+	*httptest.ResponseRecorder
+}
+
+func (d *deadClientRecorder) Write([]byte) (int, error) {
+	return 0, io.ErrClosedPipe
+}
+
 // newOCIIndexCache builds an indexcache.Cache backed by in-memory
 // per-repo stores so tests exercise the real Put/Get code path
 // without standing up a registry server.

--- a/pkg/handler/python/proxy_test.go
+++ b/pkg/handler/python/proxy_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/yolocs/ocifactory/pkg/auth"
 	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
@@ -323,6 +325,57 @@ func TestProxy_FileMissFetchAndCache(t *testing.T) {
 	}
 	if len(files) != 1 {
 		t.Errorf("backing has %d files, want 1", len(files))
+	}
+}
+
+// TestProxy_FileMetadataSidecar exercises the PEP 658 path: when pip
+// asks for `<wheel>.metadata` (because the upstream simple index
+// advertised `data-core-metadata`), the proxy synthesizes the upstream
+// URL from the matching wheel entry instead of 404'ing because PyPI's
+// JSON `urls` list never enumerates `.metadata` files.
+func TestProxy_FileMetadataSidecar(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeFetcher()
+	const wheelURL = "https://files.pythonhosted.org/packages/abc/six-1.16.0-py2.py3-none-any.whl"
+	fake.versionMeta["six@1.16.0"] = &pypython.VersionMetadata{
+		Package: "six",
+		Version: "1.16.0",
+		Files: []pypython.FileMetadata{{
+			Filename:   "six-1.16.0-py2.py3-none-any.whl",
+			URL:        wheelURL,
+			SHA256:     "wheelhash",
+			Size:       11,
+			UploadTime: time.Date(2021, 5, 5, 0, 0, 0, 0, time.UTC),
+		}},
+		UploadTime: time.Date(2021, 5, 5, 0, 0, 0, 0, time.UTC),
+	}
+	fake.files[wheelURL+".metadata"] = []byte("Metadata-Version: 2.1\nName: six\n")
+
+	h, _, backing := newProxyTestHandler(t, fake, namespace.Spec{})
+
+	path := "/" + testNS + "/packages/six/1.16.0/six-1.16.0-py2.py3-none-any.whl.metadata"
+	r := httptest.NewRequest(http.MethodGet, path, nil)
+	w := httptest.NewRecorder()
+	h.Mux().ServeHTTP(w, r)
+	if got, want := w.Code, http.StatusOK; got != want {
+		t.Fatalf("status = %d, want %d (body=%s)", got, want, w.Body.String())
+	}
+	if body := w.Body.String(); body != "Metadata-Version: 2.1\nName: six\n" {
+		t.Errorf("body = %q", body)
+	}
+
+	files, err := backing.ListFiles(t.Context(), testNS+"/packages/six")
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	var names []string
+	for _, f := range files {
+		names = append(names, f.Name)
+	}
+	want := []string{"six-1.16.0-py2.py3-none-any.whl.metadata"}
+	if diff := cmp.Diff(want, names); diff != "" {
+		t.Errorf("cached files (-want +got):\n%s", diff)
 	}
 }
 

--- a/pkg/handler/python/proxy_test.go
+++ b/pkg/handler/python/proxy_test.go
@@ -1,0 +1,693 @@
+package python
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/yolocs/ocifactory/pkg/auth"
+	"github.com/yolocs/ocifactory/pkg/namespace"
+	"github.com/yolocs/ocifactory/pkg/oci"
+	"github.com/yolocs/ocifactory/pkg/proxy"
+	"github.com/yolocs/ocifactory/pkg/proxy/filter"
+	"github.com/yolocs/ocifactory/pkg/proxy/indexcache"
+	pypython "github.com/yolocs/ocifactory/pkg/proxy/python"
+)
+
+// fakeFetcher is the in-test stand-in for pkg/proxy/python.Fetcher. It
+// records call counts and returns operator-supplied responses keyed by
+// (package, version, filename). It is intentionally simple — tests
+// that need richer behaviour set the response field as a function.
+type fakeFetcher struct {
+	mu sync.Mutex
+
+	simpleIndex     map[string]*pypython.IndexResponse
+	simpleIndexErr  map[string]error
+	topLevelIndex   *pypython.IndexResponse
+	topLevelErr     error
+	versionMeta     map[string]*pypython.VersionMetadata // key: pkg + "@" + version
+	versionMetaErr  map[string]error
+	files           map[string][]byte // key: url
+	filesErr        map[string]error
+	fileContentType string
+
+	getSimpleIndexCalls int
+	getTopLevelCalls    int
+	getVersionMetaCalls int
+	fetchFileCalls      int
+}
+
+func newFakeFetcher() *fakeFetcher {
+	return &fakeFetcher{
+		simpleIndex:     map[string]*pypython.IndexResponse{},
+		simpleIndexErr:  map[string]error{},
+		versionMeta:     map[string]*pypython.VersionMetadata{},
+		versionMetaErr:  map[string]error{},
+		files:           map[string][]byte{},
+		filesErr:        map[string]error{},
+		fileContentType: "application/zip",
+	}
+}
+
+func (f *fakeFetcher) GetSimpleIndex(_ context.Context, pkg string) (*pypython.IndexResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.getSimpleIndexCalls++
+	if err, ok := f.simpleIndexErr[pkg]; ok {
+		return nil, err
+	}
+	if r, ok := f.simpleIndex[pkg]; ok {
+		return r, nil
+	}
+	return nil, fmt.Errorf("fake: no index for %q: %w", pkg, proxy.ErrNotFound)
+}
+
+func (f *fakeFetcher) GetTopLevelIndex(_ context.Context) (*pypython.IndexResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.getTopLevelCalls++
+	if f.topLevelErr != nil {
+		return nil, f.topLevelErr
+	}
+	return f.topLevelIndex, nil
+}
+
+func (f *fakeFetcher) GetVersionMetadata(_ context.Context, pkg, version string) (*pypython.VersionMetadata, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.getVersionMetaCalls++
+	key := pkg + "@" + version
+	if err, ok := f.versionMetaErr[key]; ok {
+		return nil, err
+	}
+	if m, ok := f.versionMeta[key]; ok {
+		return m, nil
+	}
+	return nil, fmt.Errorf("fake: no metadata for %s: %w", key, proxy.ErrNotFound)
+}
+
+func (f *fakeFetcher) FetchFile(_ context.Context, rawURL string) (*pypython.FileResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.fetchFileCalls++
+	if err, ok := f.filesErr[rawURL]; ok {
+		return nil, err
+	}
+	if body, ok := f.files[rawURL]; ok {
+		return &pypython.FileResponse{
+			Body:          io.NopCloser(strings.NewReader(string(body))),
+			ContentType:   f.fileContentType,
+			ContentLength: int64(len(body)),
+		}, nil
+	}
+	return nil, fmt.Errorf("fake: no file at %q: %w", rawURL, proxy.ErrNotFound)
+}
+
+func (f *fakeFetcher) calls() (idx, top, meta, file int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.getSimpleIndexCalls, f.getTopLevelCalls, f.getVersionMetaCalls, f.fetchFileCalls
+}
+
+// newProxyTestHandler builds a python handler in proxy mode against
+// the testNS namespace with the supplied fetcher and any extra
+// options. Returns the handler + the underlying fake registry so
+// tests can poke at backend state.
+func newProxyTestHandler(t *testing.T, fetcher ProxyFetcher, extraSpec namespace.Spec, opts ...Option) (*Handler, *namespace.Store, *oci.FakeRegistry) {
+	t.Helper()
+	fake := oci.NewFakeRegistry()
+	store := namespace.NewStore(fake)
+	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+
+	if extraSpec.Mode == "" {
+		extraSpec.Mode = namespace.ModeProxy
+	}
+	if extraSpec.Proxy.Upstream == "" {
+		extraSpec.Proxy.Upstream = "https://pypi.org"
+	}
+	if extraSpec.Policy.Readers == nil && extraSpec.Policy.Writers == nil {
+		extraSpec.Policy = allowAllPolicy()
+	}
+	if err := store.Put(t.Context(), &namespace.Namespace{Name: testNS, Spec: extraSpec}); err != nil {
+		t.Fatalf("Put namespace: %v", err)
+	}
+
+	authMW := auth.Middleware(auth.AlwaysAnonymous)
+	allOpts := []Option{
+		WithAuthMiddleware(authMW),
+		WithFetcherFactory(func(*url.URL) (ProxyFetcher, error) { return fetcher, nil }),
+		// Disable L1 by default so tests that count fetcher calls
+		// don't get fooled by L1 hits. Tests that want L1 set their
+		// own TTL via opts.
+		WithProxyL1IndexCacheTTL(-1),
+	}
+	allOpts = append(allOpts, opts...)
+	h, err := NewHandler(reg, allOpts...)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	return h, store, fake
+}
+
+// TestProxy_AuthGating proves the proxy-mode routes go through the
+// same WithAuthMiddleware chain as the hosted routes. The wider
+// TestMux_AuthGating doesn't exercise proxy mode because it doesn't
+// register a namespace; here we register a proxy namespace and
+// confirm the deny-all middleware still short-circuits.
+func TestProxy_AuthGating(t *testing.T) {
+	t.Parallel()
+
+	denyAll := func(http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "denied", http.StatusUnauthorized)
+		})
+	}
+
+	fake := oci.NewFakeRegistry()
+	store := namespace.NewStore(fake)
+	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	if err := store.Put(t.Context(), &namespace.Namespace{
+		Name: testNS,
+		Spec: namespace.Spec{
+			Mode:   namespace.ModeProxy,
+			Proxy:  namespace.Proxy{Upstream: "https://pypi.org"},
+			Policy: allowAllPolicy(),
+		},
+	}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	h, err := NewHandler(reg, WithAuthMiddleware(denyAll))
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	srv := h.Mux()
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "proxy package index", path: "/" + testNS + "/simple/requests/"},
+		{name: "proxy top-level index", path: "/" + testNS + "/simple/"},
+		{name: "proxy file", path: "/" + testNS + "/packages/requests/2.31.0/requests-2.31.0-py3-none-any.whl"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			w := httptest.NewRecorder()
+			srv.ServeHTTP(w, r)
+			if got, want := w.Code, http.StatusUnauthorized; got != want {
+				t.Errorf("status = %d, want %d (proxy routes must chain auth middleware)", got, want)
+			}
+		})
+	}
+}
+
+func TestProxy_UploadReturns405(t *testing.T) {
+	t.Parallel()
+	h, _, _ := newProxyTestHandler(t, newFakeFetcher(), namespace.Spec{})
+
+	r := httptest.NewRequest(http.MethodPost, "/"+testNS+"/", strings.NewReader(""))
+	r.Header.Set("Content-Type", "multipart/form-data; boundary=xyz")
+	w := httptest.NewRecorder()
+	h.Mux().ServeHTTP(w, r)
+	if got, want := w.Code, http.StatusMethodNotAllowed; got != want {
+		t.Errorf("status = %d, want %d (body=%s)", got, want, w.Body.String())
+	}
+	if got := w.Header().Get("Allow"); got == "" {
+		t.Errorf("Allow header missing on 405 response")
+	}
+}
+
+func TestProxy_FileCacheHit_NoUpstream(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeFetcher()
+	h, _, backing := newProxyTestHandler(t, fake, namespace.Spec{})
+
+	// Seed the registry with a file directly so the proxy path
+	// observes a hit on the first read.
+	rf := &oci.RepoFile{
+		OwningRepo: "packages/requests",
+		OwningTag:  "2.31.0",
+		Name:       "requests-2.31.0-py3-none-any.whl",
+		MediaType:  "application/x-wheel+zip",
+	}
+	scoped := namespace.NewRegistry(backing, namespace.NewStore(backing), namespace.WithPolicyCacheTTL(0))
+	_ = scoped
+	// Use a direct AddFile against the fake; bypasses authz which
+	// is fine because the fake registry doesn't authorize on its
+	// own — namespace.Registry does. We address the fake at the
+	// post-prefix path the namespace wrapper would have produced.
+	if _, err := backing.AddFile(t.Context(), &oci.RepoFile{
+		OwningRepo: testNS + "/packages/requests",
+		OwningTag:  rf.OwningTag,
+		Name:       rf.Name,
+		MediaType:  rf.MediaType,
+	}, strings.NewReader("wheel-bytes")); err != nil {
+		t.Fatalf("seed AddFile: %v", err)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/"+testNS+"/packages/requests/2.31.0/"+rf.Name, nil)
+	w := httptest.NewRecorder()
+	h.Mux().ServeHTTP(w, r)
+	if got, want := w.Code, http.StatusOK; got != want {
+		t.Fatalf("status = %d, want %d (body=%s)", got, want, w.Body.String())
+	}
+	if body := w.Body.String(); body != "wheel-bytes" {
+		t.Errorf("body = %q, want %q", body, "wheel-bytes")
+	}
+	if _, _, _, fileCalls := fake.calls(); fileCalls != 0 {
+		t.Errorf("fetcher.FetchFile called %d times on a registry hit", fileCalls)
+	}
+}
+
+func TestProxy_FileMissFetchAndCache(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeFetcher()
+	const fileURL = "https://files.pythonhosted.org/packages/abc/requests-2.31.0-py3-none-any.whl"
+	fake.versionMeta["requests@2.31.0"] = &pypython.VersionMetadata{
+		Package: "requests",
+		Version: "2.31.0",
+		Files: []pypython.FileMetadata{{
+			Filename:   "requests-2.31.0-py3-none-any.whl",
+			URL:        fileURL,
+			SHA256:     "abc",
+			Size:       11,
+			UploadTime: time.Date(2023, 5, 22, 15, 12, 42, 0, time.UTC),
+		}},
+		UploadTime: time.Date(2023, 5, 22, 15, 12, 42, 0, time.UTC),
+	}
+	fake.files[fileURL] = []byte("wheel-bytes")
+
+	h, _, backing := newProxyTestHandler(t, fake, namespace.Spec{})
+
+	path := "/" + testNS + "/packages/requests/2.31.0/requests-2.31.0-py3-none-any.whl"
+	r := httptest.NewRequest(http.MethodGet, path, nil)
+	w := httptest.NewRecorder()
+	h.Mux().ServeHTTP(w, r)
+	if got, want := w.Code, http.StatusOK; got != want {
+		t.Fatalf("status = %d, want %d (body=%s)", got, want, w.Body.String())
+	}
+	if body := w.Body.String(); body != "wheel-bytes" {
+		t.Errorf("body = %q", body)
+	}
+	if _, _, metaCalls, fileCalls := fake.calls(); metaCalls != 1 || fileCalls != 1 {
+		t.Errorf("calls (meta=%d file=%d), want (1 1)", metaCalls, fileCalls)
+	}
+
+	// Second request hits the registry cache — no fetcher calls.
+	w2 := httptest.NewRecorder()
+	h.Mux().ServeHTTP(w2, httptest.NewRequest(http.MethodGet, path, nil))
+	if got := w2.Code; got != http.StatusOK {
+		t.Fatalf("second request status = %d", got)
+	}
+	if _, _, metaCalls, fileCalls := fake.calls(); metaCalls != 1 || fileCalls != 1 {
+		t.Errorf("after second request: calls (meta=%d file=%d), want (1 1)", metaCalls, fileCalls)
+	}
+
+	// And confirm the backing OCI store actually holds the file at
+	// the namespace-prefixed path.
+	files, err := backing.ListFiles(t.Context(), testNS+"/packages/requests")
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	if len(files) != 1 {
+		t.Errorf("backing has %d files, want 1", len(files))
+	}
+}
+
+func TestProxy_FilterDeny(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeFetcher()
+	const fileURL = "https://files.pythonhosted.org/packages/.../requests-2.31.0-py3-none-any.whl"
+	fake.versionMeta["requests@2.31.0"] = &pypython.VersionMetadata{
+		Files: []pypython.FileMetadata{{
+			Filename: "requests-2.31.0-py3-none-any.whl",
+			URL:      fileURL,
+		}},
+	}
+	fake.files[fileURL] = []byte("wheel-bytes")
+
+	// A denylist matching the package name short-circuits before
+	// upstream metadata is fetched.
+	deny := &filter.Denylist{Rules: []filter.Rule{{Package: "requests"}}}
+
+	h, _, _ := newProxyTestHandler(t, fake, namespace.Spec{
+		Proxy: namespace.Proxy{Upstream: "https://pypi.org", Filters: filter.Filters{deny}},
+	})
+
+	r := httptest.NewRequest(http.MethodGet, "/"+testNS+"/packages/requests/2.31.0/requests-2.31.0-py3-none-any.whl", nil)
+	w := httptest.NewRecorder()
+	h.Mux().ServeHTTP(w, r)
+	if got, want := w.Code, http.StatusNotFound; got != want {
+		t.Errorf("status = %d, want %d (body=%s)", got, want, w.Body.String())
+	}
+	if _, _, metaCalls, fileCalls := fake.calls(); metaCalls != 0 || fileCalls != 0 {
+		t.Errorf("denied request hit upstream: meta=%d file=%d", metaCalls, fileCalls)
+	}
+}
+
+func TestProxy_FilterDelayDeniesAfterMetadata(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeFetcher()
+	const fileURL = "https://files.pythonhosted.org/packages/.../recent-1.0.0-py3-none-any.whl"
+	fake.versionMeta["recent@1.0.0"] = &pypython.VersionMetadata{
+		Files: []pypython.FileMetadata{{
+			Filename:   "recent-1.0.0-py3-none-any.whl",
+			URL:        fileURL,
+			UploadTime: time.Now().Add(-1 * time.Minute), // fresh
+		}},
+	}
+	fake.files[fileURL] = []byte("wheel-bytes")
+
+	// 1-hour delay → 1-minute-old version denies after metadata.
+	delay := &filter.Delay{MinAge: time.Hour}
+
+	h, _, _ := newProxyTestHandler(t, fake, namespace.Spec{
+		Proxy: namespace.Proxy{Upstream: "https://pypi.org", Filters: filter.Filters{delay}},
+	})
+
+	r := httptest.NewRequest(http.MethodGet, "/"+testNS+"/packages/recent/1.0.0/recent-1.0.0-py3-none-any.whl", nil)
+	w := httptest.NewRecorder()
+	h.Mux().ServeHTTP(w, r)
+	if got, want := w.Code, http.StatusNotFound; got != want {
+		t.Errorf("status = %d, want %d (body=%s)", got, want, w.Body.String())
+	}
+	if _, _, metaCalls, fileCalls := fake.calls(); metaCalls != 1 || fileCalls != 0 {
+		t.Errorf("delay filter must fetch metadata but not file: meta=%d file=%d", metaCalls, fileCalls)
+	}
+}
+
+func TestProxy_FileUpstream404Negative(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeFetcher()
+	negCache := indexcache.NewNegativeCache()
+	h, _, _ := newProxyTestHandler(t, fake, namespace.Spec{}, WithProxyNegativeCache(negCache))
+
+	path := "/" + testNS + "/packages/missing/1.0.0/missing-1.0.0-py3-none-any.whl"
+	r := httptest.NewRequest(http.MethodGet, path, nil)
+	w := httptest.NewRecorder()
+	h.Mux().ServeHTTP(w, r)
+	if got, want := w.Code, http.StatusNotFound; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+	// Second request hits the negative cache — no fetcher call.
+	w2 := httptest.NewRecorder()
+	h.Mux().ServeHTTP(w2, httptest.NewRequest(http.MethodGet, path, nil))
+	if got, want := w2.Code, http.StatusNotFound; got != want {
+		t.Errorf("second status = %d, want %d", got, want)
+	}
+	if _, _, metaCalls, fileCalls := fake.calls(); metaCalls != 1 || fileCalls != 0 {
+		t.Errorf("negative cache should suppress second metadata call: meta=%d file=%d", metaCalls, fileCalls)
+	}
+}
+
+func TestProxy_FileUpstreamUnavailable(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeFetcher()
+	fake.versionMetaErr["x@1.0.0"] = fmt.Errorf("upstream boom: %w", proxy.ErrUpstreamUnavailable)
+
+	h, _, _ := newProxyTestHandler(t, fake, namespace.Spec{})
+	r := httptest.NewRequest(http.MethodGet, "/"+testNS+"/packages/x/1.0.0/x-1.0.0.tar.gz", nil)
+	w := httptest.NewRecorder()
+	h.Mux().ServeHTTP(w, r)
+	if got, want := w.Code, http.StatusBadGateway; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+}
+
+func TestProxy_IndexPassthroughAndCache(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeFetcher()
+	const upstreamHTML = `<html><body><a href="https://files.pythonhosted.org/packages/aa/requests-2.31.0-py3-none-any.whl#sha256=abc">requests-2.31.0-py3-none-any.whl</a></body></html>`
+	fake.simpleIndex["requests"] = &pypython.IndexResponse{
+		Body:        []byte(upstreamHTML),
+		ContentType: "application/vnd.pypi.simple.v1+html",
+	}
+
+	// Wire a real OCI-backed index cache against a separate backing
+	// fake so we observe Put/Get behaviour end-to-end.
+	cache, backingURL, cleanup := newOCIIndexCache(t)
+	defer cleanup()
+	_ = backingURL
+
+	h, _, _ := newProxyTestHandler(t, fake, namespace.Spec{}, WithProxyIndexCache(cache))
+
+	r := httptest.NewRequest(http.MethodGet, "/"+testNS+"/simple/requests/", nil)
+	w := httptest.NewRecorder()
+	h.Mux().ServeHTTP(w, r)
+	if got, want := w.Code, http.StatusOK; got != want {
+		t.Fatalf("status = %d, want %d (body=%s)", got, want, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `href="/`+testNS+`/packages/requests/2.31.0/requests-2.31.0-py3-none-any.whl#sha256=abc"`) {
+		t.Errorf("expected rewritten href, got:\n%s", body)
+	}
+	if got := w.Header().Get("Content-Type"); !strings.HasPrefix(got, "application/vnd.pypi.simple.v1+html") {
+		t.Errorf("Content-Type = %q, want PEP 691 html", got)
+	}
+	idxCalls, _, _, _ := fake.calls()
+	if idxCalls != 1 {
+		t.Errorf("expected 1 upstream index call, got %d", idxCalls)
+	}
+
+	// Second request hits the indexcache (OCI) — no upstream call.
+	// We disabled L1 in the test harness so the freshness check
+	// against indexcache is what saves us.
+	w2 := httptest.NewRecorder()
+	h.Mux().ServeHTTP(w2, httptest.NewRequest(http.MethodGet, "/"+testNS+"/simple/requests/", nil))
+	if got := w2.Code; got != http.StatusOK {
+		t.Fatalf("second status = %d", got)
+	}
+	idxCalls, _, _, _ = fake.calls()
+	if idxCalls != 1 {
+		t.Errorf("expected indexcache to suppress second upstream call, got %d", idxCalls)
+	}
+}
+
+func TestProxy_IndexUpstreamErrorWithStaleCache(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeFetcher()
+	const upstreamHTML = `<html><body><a href="https://files.pythonhosted.org/packages/aa/requests-2.31.0-py3-none-any.whl#sha256=abc">requests-2.31.0-py3-none-any.whl</a></body></html>`
+
+	cache, _, cleanup := newOCIIndexCache(t)
+	defer cleanup()
+
+	// Pre-warm the cache directly — simulates "fetched at some
+	// point in the past" without playing wall-clock games.
+	if err := cache.Put(t.Context(), testNS, "requests", []byte(upstreamHTML), "application/vnd.pypi.simple.v1+html"); err != nil {
+		t.Fatalf("cache.Put: %v", err)
+	}
+
+	// Now configure the fetcher to fail upstream.
+	fake.simpleIndexErr["requests"] = fmt.Errorf("upstream: %w", proxy.ErrUpstreamUnavailable)
+
+	// Use a TTL of 0 so the cached entry is "stale" the instant we
+	// look at it; the handler must still fall back to it on
+	// upstream failure.
+	h, _, _ := newProxyTestHandler(t, fake, namespace.Spec{},
+		WithProxyIndexCache(cache),
+		WithProxyIndexCacheTTL(time.Nanosecond),
+	)
+
+	r := httptest.NewRequest(http.MethodGet, "/"+testNS+"/simple/requests/", nil)
+	w := httptest.NewRecorder()
+	h.Mux().ServeHTTP(w, r)
+	if got, want := w.Code, http.StatusOK; got != want {
+		t.Fatalf("status = %d, want %d (body=%s)", got, want, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `<a href="https://files.pythonhosted.org/packages/aa/requests-2.31.0-py3-none-any.whl#sha256=abc">`) &&
+		!strings.Contains(w.Body.String(), upstreamHTML) {
+		t.Errorf("stale cache body not served:\n%s", w.Body.String())
+	}
+}
+
+func TestProxy_IndexUpstreamErrorSynthesizesFromListFiles(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeFetcher()
+	fake.simpleIndexErr["requests"] = fmt.Errorf("upstream: %w", proxy.ErrUpstreamUnavailable)
+
+	h, _, backing := newProxyTestHandler(t, fake, namespace.Spec{})
+
+	// Seed one file in the namespace's packages/requests repo
+	// directly. The hosted code path uses ListFiles for synthesis;
+	// adding a file gives it something to synthesize.
+	if _, err := backing.AddFile(t.Context(), &oci.RepoFile{
+		OwningRepo: testNS + "/packages/requests",
+		OwningTag:  "2.31.0",
+		Name:       "requests-2.31.0-py3-none-any.whl",
+		MediaType:  "application/x-wheel+zip",
+	}, strings.NewReader("wheel-bytes")); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/"+testNS+"/simple/requests/", nil)
+	w := httptest.NewRecorder()
+	h.Mux().ServeHTTP(w, r)
+	if got, want := w.Code, http.StatusOK; got != want {
+		t.Fatalf("status = %d, want %d (body=%s)", got, want, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "requests-2.31.0-py3-none-any.whl") {
+		t.Errorf("synthesized index missing seeded file:\n%s", w.Body.String())
+	}
+}
+
+func TestProxy_IndexUpstreamErrorNoSourceReturns503(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeFetcher()
+	fake.simpleIndexErr["nothing"] = fmt.Errorf("upstream: %w", proxy.ErrUpstreamUnavailable)
+	h, _, _ := newProxyTestHandler(t, fake, namespace.Spec{})
+
+	r := httptest.NewRequest(http.MethodGet, "/"+testNS+"/simple/nothing/", nil)
+	w := httptest.NewRecorder()
+	h.Mux().ServeHTTP(w, r)
+	if got, want := w.Code, http.StatusServiceUnavailable; got != want {
+		t.Errorf("status = %d, want %d (body=%s)", got, want, w.Body.String())
+	}
+}
+
+func TestProxy_IndexUpstream404Returns404(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeFetcher()
+	// No explicit simpleIndex entry → fake returns ErrNotFound.
+	h, _, _ := newProxyTestHandler(t, fake, namespace.Spec{})
+
+	r := httptest.NewRequest(http.MethodGet, "/"+testNS+"/simple/missing/", nil)
+	w := httptest.NewRecorder()
+	h.Mux().ServeHTTP(w, r)
+	if got, want := w.Code, http.StatusNotFound; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+}
+
+func TestProxy_TopLevelIndexPassthrough(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeFetcher()
+	const body = `<html><body><a href="/simple/requests/">requests</a></body></html>`
+	fake.topLevelIndex = &pypython.IndexResponse{Body: []byte(body), ContentType: "text/html"}
+
+	h, _, _ := newProxyTestHandler(t, fake, namespace.Spec{})
+	r := httptest.NewRequest(http.MethodGet, "/"+testNS+"/simple/", nil)
+	w := httptest.NewRecorder()
+	h.Mux().ServeHTTP(w, r)
+	if got, want := w.Code, http.StatusOK; got != want {
+		t.Fatalf("status = %d, want %d (body=%s)", got, want, w.Body.String())
+	}
+	if w.Body.String() != body {
+		t.Errorf("body mismatch: got %q want %q", w.Body.String(), body)
+	}
+	_, top, _, _ := fake.calls()
+	if top != 1 {
+		t.Errorf("top-level index calls = %d, want 1", top)
+	}
+}
+
+func TestProxy_TopLevelUpstreamErrorSynthesizes(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeFetcher()
+	fake.topLevelErr = fmt.Errorf("upstream: %w", proxy.ErrUpstreamUnavailable)
+
+	h, _, backing := newProxyTestHandler(t, fake, namespace.Spec{})
+
+	// Seed the synthesis source — the `index` repo's tag list.
+	if _, err := backing.AddFile(t.Context(), &oci.RepoFile{
+		OwningRepo: testNS + "/index",
+		OwningTag:  "requests",
+		Name:       "present",
+		MediaType:  "text/plain",
+	}, strings.NewReader("1")); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/"+testNS+"/simple/", nil)
+	w := httptest.NewRecorder()
+	h.Mux().ServeHTTP(w, r)
+	if got, want := w.Code, http.StatusOK; got != want {
+		t.Fatalf("status = %d, want %d (body=%s)", got, want, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "requests") {
+		t.Errorf("synthesis missing seeded tag:\n%s", w.Body.String())
+	}
+}
+
+func TestProxy_FileFlight_ConcurrentMissDeduped(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeFetcher()
+	const fileURL = "https://files.pythonhosted.org/packages/abc/x-1.0.0.tar.gz"
+	fake.versionMeta["x@1.0.0"] = &pypython.VersionMetadata{
+		Package: "x", Version: "1.0.0",
+		Files: []pypython.FileMetadata{{Filename: "x-1.0.0.tar.gz", URL: fileURL, Size: 4}},
+	}
+	fake.files[fileURL] = []byte("body")
+
+	h, _, _ := newProxyTestHandler(t, fake, namespace.Spec{})
+
+	const goroutines = 8
+	var wg sync.WaitGroup
+	var ok atomic.Int64
+	wg.Add(goroutines)
+	start := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			r := httptest.NewRequest(http.MethodGet, "/"+testNS+"/packages/x/1.0.0/x-1.0.0.tar.gz", nil)
+			w := httptest.NewRecorder()
+			h.Mux().ServeHTTP(w, r)
+			if w.Code == http.StatusOK {
+				ok.Add(1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := ok.Load(); got != goroutines {
+		t.Errorf("ok responses = %d, want %d", got, goroutines)
+	}
+	_, _, metaCalls, fileCalls := fake.calls()
+	if metaCalls > 1 || fileCalls > 1 {
+		// Some racy interleaving CAN produce 2 calls (the
+		// re-check inside the singleflight only succeeds when
+		// AddFile finished before the next caller arrives), but
+		// we should never see goroutines worth of upstream calls.
+		if metaCalls >= goroutines || fileCalls >= goroutines {
+			t.Errorf("singleflight ineffective: meta=%d file=%d (goroutines=%d)",
+				metaCalls, fileCalls, goroutines)
+		}
+	}
+}
+
+// newOCIIndexCache builds an indexcache.Cache backed by in-memory
+// per-repo stores so tests exercise the real Put/Get code path
+// without standing up a registry server.
+func newOCIIndexCache(t *testing.T) (*indexcache.Cache, *url.URL, func()) {
+	t.Helper()
+	c, err := indexcache.NewInMemoryCache()
+	if err != nil {
+		t.Fatalf("NewInMemoryCache: %v", err)
+	}
+	return c, &url.URL{Scheme: "http", Host: "test.local"}, func() {}
+}

--- a/pkg/handler/python/pypi_upstream_integration_test.go
+++ b/pkg/handler/python/pypi_upstream_integration_test.go
@@ -1,0 +1,196 @@
+//go:build pypiupstream
+
+// Real-PyPI integration test for the python proxy handler. Gated
+// behind a separate `pypiupstream` build tag (NOT `integration`)
+// because the test is intentionally non-hermetic: it talks to
+// https://pypi.org over the public internet. PyPI outages, rate
+// limits, or response-shape changes will turn this test red. Run it
+// on a schedule (nightly), not on every PR.
+//
+// Invoke via `go test -tags=pypiupstream ./pkg/handler/python/...`.
+
+package python_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/yolocs/ocifactory/pkg/auth/backend"
+	"github.com/yolocs/ocifactory/pkg/handler/integrationtest"
+	"github.com/yolocs/ocifactory/pkg/namespace"
+	"github.com/yolocs/ocifactory/pkg/oci"
+)
+
+// TestPythonIntegration_LivePypiProxy proves the proxy mode works end
+// to end against real PyPI: a real pip install through a real
+// ocifactory subprocess that fetches, caches, and re-serves real
+// package bytes. The unit tests cover the same flow with stubs; this
+// test catches PyPI response-shape drift that stubs can't.
+//
+// Test package: `six==1.16.0`. Tiny (~11 KB), depless, frozen for
+// years. If this ever bit-rots we replace it; we do NOT pick something
+// big like requests or numpy because nightly bandwidth adds up.
+func TestPythonIntegration_LivePypiProxy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping live-pypi integration test in -short mode")
+	}
+	t.Parallel()
+
+	integrationtest.SkipIfMissing(t, "python3", "pip")
+
+	h := integrationtest.Start(t, "python")
+	seedPyPIProxyNamespace(t, h.ZotURL, h.BackendRepo, "pypi-cache", "https://pypi.org")
+
+	const (
+		pkgName = "six"
+		version = "1.16.0"
+	)
+	indexURL := h.OcifactoryURL.String() + "/pypi-cache/simple/"
+	trustedHost := h.OcifactoryURL.Host
+
+	t.Run("simple_index_rewrites_pypi_hrefs", func(t *testing.T) {
+		// A raw GET to /pypi-cache/simple/six/ should return the
+		// PEP 503 index with hrefs rewritten back through ocifactory.
+		// If PyPI changed the JSON / HTML shape in a way pkg/proxy/python
+		// no longer parses, the response either misses the package or
+		// contains absolute files.pythonhosted.org links — both are bugs.
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		defer cancel()
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, indexURL+pkgName+"/", nil)
+		if err != nil {
+			t.Fatalf("build request: %v", err)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET /simple/%s/: %v", pkgName, err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+		buf := make([]byte, 256*1024)
+		n, _ := resp.Body.Read(buf)
+		body := string(buf[:n])
+		if !strings.Contains(body, "/pypi-cache/packages/"+pkgName+"/") {
+			t.Errorf("simple index did not contain rewritten href for %s; body excerpt:\n%s", pkgName, body)
+		}
+		if strings.Contains(body, "files.pythonhosted.org") {
+			t.Errorf("simple index leaked an unrewritten upstream href; body excerpt:\n%s", body)
+		}
+	})
+
+	t.Run("pip_install_through_proxy", func(t *testing.T) {
+		// Fresh venv → cold-miss install. ocifactory fetches from PyPI,
+		// AddFile streams the wheel into zot, tees to pip. After this
+		// finishes the package + version exist under
+		// pypi-cache/packages/<pkgName>/<version>/ in the OCI backend.
+		venv := t.TempDir()
+		runOK(t, "python3", "-m", "venv", venv)
+		pip := pipBin(venv)
+
+		runOK(t, pip,
+			"install",
+			"--no-cache-dir",
+			"--no-deps",
+			"--index-url", indexURL,
+			"--trusted-host", trustedHost,
+			fmt.Sprintf("%s==%s", pkgName, version),
+		)
+
+		// A second fresh venv proves the cache survives a client
+		// restart. We can't observe upstream traffic from this side,
+		// but if pip still gets a working wheel we've at least proven
+		// the cached blob roundtrips through ReadFile correctly.
+		venv2 := t.TempDir()
+		runOK(t, "python3", "-m", "venv", venv2)
+		pip2 := pipBin(venv2)
+		runOK(t, pip2,
+			"install",
+			"--no-cache-dir",
+			"--no-deps",
+			"--index-url", indexURL,
+			"--trusted-host", trustedHost,
+			fmt.Sprintf("%s==%s", pkgName, version),
+		)
+
+		// Import six in the second venv to prove the wheel is
+		// structurally valid (extractable, not corrupted on the
+		// stream). `six` exposes a __version__ string we can compare.
+		py := pythonBin(venv2)
+		cmd := exec.Command(py, "-c", "import six; print(six.__version__)")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("import six: %v\n%s", err, out)
+		}
+		got := strings.TrimSpace(string(out))
+		if got != version {
+			t.Fatalf("six.__version__ = %q, want %q", got, version)
+		}
+	})
+}
+
+// seedPyPIProxyNamespace writes a proxy-mode namespace into the OCI
+// backend the ocifactory subprocess reads from. Mirrors
+// integrationtest.seedDefaultNamespace but with Mode=proxy and an
+// anonymous Writers list so the data-plane AddFile during cache
+// fill is authorized.
+func seedPyPIProxyNamespace(t *testing.T, zotURL *url.URL, backendRepo, name, upstream string) {
+	t.Helper()
+	regURL := &url.URL{Scheme: zotURL.Scheme, Host: zotURL.Host, Path: "/" + backendRepo}
+	inner, err := oci.NewRegistry(regURL,
+		oci.WithBackendAuth(backend.Anonymous()),
+		oci.WithArtifactType(namespace.ArtifactType),
+	)
+	if err != nil {
+		t.Fatalf("oci.NewRegistry: %v", err)
+	}
+	store := namespace.NewStore(inner)
+	spec := namespace.Spec{
+		Mode:  namespace.ModeProxy,
+		Proxy: namespace.Proxy{Upstream: upstream},
+		Policy: namespace.Policy{
+			Readers: []namespace.SubjectMatcher{{Issuer: "anonymous"}},
+			Writers: []namespace.SubjectMatcher{{Issuer: "anonymous"}},
+		},
+	}
+	if err := store.Put(t.Context(), &namespace.Namespace{Name: name, Spec: spec}); err != nil {
+		t.Fatalf("seed proxy namespace %q: %v", name, err)
+	}
+}
+
+func pipBin(venv string) string {
+	bin := filepath.Join(venv, "bin", "pip")
+	if _, err := os.Stat(bin); err == nil {
+		return bin
+	}
+	return filepath.Join(venv, "Scripts", "pip.exe")
+}
+
+func pythonBin(venv string) string {
+	bin := filepath.Join(venv, "bin", "python")
+	if _, err := os.Stat(bin); err == nil {
+		return bin
+	}
+	return filepath.Join(venv, "Scripts", "python.exe")
+}
+
+// runOK runs cmd and t.Fatals with the combined output on a non-zero
+// exit. Same helper as integration_test.go; duplicated rather than
+// widening that file's build tag so `pypiupstream` and `integration`
+// stay independent test suites.
+func runOK(t *testing.T, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s: %v\n%s", name, strings.Join(args, " "), err, out)
+	}
+}

--- a/pkg/namespace/cache.go
+++ b/pkg/namespace/cache.go
@@ -12,8 +12,16 @@ import (
 // cache. notFound carries a negative result from [Store.Get] so a
 // burst of requests against a missing namespace doesn't repeatedly
 // hit the metadata backend.
+//
+// spec is the raw [Spec] body the authorizer was compiled from. It is
+// held alongside the authorizer so format handlers can dispatch on
+// [Spec.Mode] / read [Spec.Proxy] without paying a second
+// [Store.Get]; spec and authorizer always reflect the same point-in-time
+// document. The cache value is treated as immutable — callers receive
+// the pointer for free read access and must not mutate it.
 type cachedPolicy struct {
 	authorizer auth.Authorizer
+	spec       *Spec
 	notFound   bool
 }
 

--- a/pkg/namespace/registry.go
+++ b/pkg/namespace/registry.go
@@ -230,22 +230,25 @@ func (r *Registry) authorize(ctx context.Context, namespace string, op auth.Op) 
 	return az.Authorize(ctx, ac, op)
 }
 
-func (r *Registry) authorizerFor(ctx context.Context, namespace string) (auth.Authorizer, error) {
+// specFor is the cache-aware single-namespace lookup that
+// [Registry.authorizerFor] and [ScopedRegistry.Spec] funnel through.
+// On a hit it returns the cached entry without any I/O; on a miss it
+// resolves through the shared singleflight so concurrent callers
+// observe one [Store.Get] + authorizer compile.
+//
+// A namespace that doesn't exist returns an error wrapping
+// [ErrNotFound] with notFound=true on the cached entry — callers that
+// only need the spec must inspect the notFound flag rather than the
+// returned error so they can produce the expected 404 mapping without
+// re-running the load.
+func (r *Registry) specFor(ctx context.Context, namespace string) (cachedPolicy, error) {
 	if v, ok := r.cache.get(namespace); ok {
 		if v.notFound {
-			return nil, fmt.Errorf("%w: %s", ErrNotFound, namespace)
+			return v, fmt.Errorf("%w: %s", ErrNotFound, namespace)
 		}
-		return v.authorizer, nil
+		return v, nil
 	}
-
-	// singleflight collapses concurrent misses for the same namespace
-	// onto one Store.Get + factory(...) compile. The closure return
-	// value is the cachedPolicy we then cache locally; the follower
-	// goroutines all observe the same value via singleflight.
 	v, err, _ := r.flight.Do(namespace, func() (any, error) {
-		// Re-check the cache inside the singleflight: another
-		// goroutine may have populated it between our first miss
-		// and our turn at the leader spot.
 		if v, ok := r.cache.get(namespace); ok {
 			return v, nil
 		}
@@ -260,22 +263,27 @@ func (r *Registry) authorizerFor(ctx context.Context, namespace string) (auth.Au
 		}
 		az, ferr := r.factory(ns.Spec.Policy)
 		if ferr != nil {
-			// Compile errors signal misconfiguration the operator
-			// must fix (e.g. an admin Put that bypassed validation).
-			// Don't cache — repeat requests should keep surfacing
-			// the error until the spec is corrected.
 			return cachedPolicy{}, fmt.Errorf("compile authorizer for %q: %w", namespace, ferr)
 		}
-		entry := cachedPolicy{authorizer: az}
+		specCopy := ns.Spec
+		entry := cachedPolicy{authorizer: az, spec: &specCopy}
 		r.cache.put(namespace, entry)
 		return entry, nil
 	})
 	if err != nil {
-		return nil, err
+		return cachedPolicy{}, err
 	}
 	cp := v.(cachedPolicy)
 	if cp.notFound {
-		return nil, fmt.Errorf("%w: %s", ErrNotFound, namespace)
+		return cp, fmt.Errorf("%w: %s", ErrNotFound, namespace)
+	}
+	return cp, nil
+}
+
+func (r *Registry) authorizerFor(ctx context.Context, namespace string) (auth.Authorizer, error) {
+	cp, err := r.specFor(ctx, namespace)
+	if err != nil {
+		return nil, err
 	}
 	return cp.authorizer, nil
 }
@@ -344,6 +352,25 @@ type ScopedRegistry struct {
 
 // Namespace returns the bound namespace name.
 func (s *ScopedRegistry) Namespace() string { return s.namespace }
+
+// Spec returns the namespace's current [Spec], used by per-format
+// handlers to dispatch on [Spec.Mode] / read [Spec.Proxy] before
+// committing to a code path.
+//
+// The returned pointer references the cached entry; callers must not
+// mutate the value. An unknown namespace returns an error wrapping
+// [ErrNotFound] so [handler.WriteNamespaceError] maps it to 404.
+//
+// Spec does not authorize: the namespace's compiled authorizer still
+// runs on downstream [AddFile] / [ReadFile] / [ListFiles] / etc., so
+// the dispatch primitive does not become an auth bypass.
+func (s *ScopedRegistry) Spec(ctx context.Context) (*Spec, error) {
+	cp, err := s.parent.specFor(ctx, s.namespace)
+	if err != nil {
+		return nil, err
+	}
+	return cp.spec, nil
+}
 
 // AddFile authorizes the bound namespace for write, prefixes
 // f.OwningRepo with the namespace, forwards to the inner registry,

--- a/pkg/oci/stream_push_test.go
+++ b/pkg/oci/stream_push_test.go
@@ -170,7 +170,12 @@ func newPusherFor(t *testing.T, fr *fakeRegistry, repo string, chunkSize int) *s
 		Registry:   base.Host,
 		Repository: repo,
 	}
-	p := newStreamPusher(http.DefaultClient, ref, true /* plainHTTP */)
+	// httptest.Server.Close calls CloseIdleConnections on
+	// http.DefaultTransport, which would race parallel sibling tests
+	// sharing http.DefaultClient. Give each pusher its own transport.
+	client := &http.Client{Transport: &http.Transport{}}
+	t.Cleanup(func() { client.Transport.(*http.Transport).CloseIdleConnections() })
+	p := newStreamPusher(client, ref, true /* plainHTTP */)
 	if chunkSize > 0 {
 		p.chunkSize = chunkSize
 	}

--- a/pkg/proxy/indexcache/indexcache.go
+++ b/pkg/proxy/indexcache/indexcache.go
@@ -146,6 +146,54 @@ func WithBackendAuth(p backend.Provider) Option {
 	}
 }
 
+// TargetFactory opens an [oras.Target] for the given repo path. The
+// path is already namespace- and prefix-qualified by [Cache.repoPath].
+// Implementations may construct a real remote target or an in-memory
+// one — used by tests in other packages that need a working [Cache]
+// without standing up a real OCI backend.
+type TargetFactory func(ctx context.Context, repoPath string) (oras.Target, error)
+
+// NewCacheWithTargets constructs a [Cache] that opens targets via fn
+// instead of the package's default remote-target factory. This is the
+// extension point tests in other packages use to wire an in-memory
+// backend; production code calls [NewCache] and gets the remote
+// factory automatically.
+//
+// The supplied factory must return a target safe for concurrent
+// [Get] / [Put] calls; the package-supplied in-memory factory
+// satisfies this. The clock used to stamp
+// [FetchedAtAnnotation] defaults to [time.Now] in UTC and can be
+// overridden via [WithClock] when callers need deterministic values.
+func NewCacheWithTargets(fn TargetFactory, opts ...Option) (*Cache, error) {
+	if fn == nil {
+		return nil, errors.New("indexcache: target factory is required")
+	}
+	c := &Cache{
+		now: func() time.Time { return time.Now().UTC() },
+	}
+	for _, o := range opts {
+		if err := o(c); err != nil {
+			return nil, err
+		}
+	}
+	c.newTargetFunc = fn
+	return c, nil
+}
+
+// WithClock overrides the wall clock the cache stamps onto
+// [FetchedAtAnnotation]. Tests use it for deterministic timestamps;
+// production passes nothing and the default ([time.Now] UTC)
+// applies.
+func WithClock(now func() time.Time) Option {
+	return func(c *Cache) error {
+		if now == nil {
+			return errors.New("indexcache: clock function must not be nil")
+		}
+		c.now = now
+		return nil
+	}
+}
+
 // NewCache constructs a [Cache] that reads and writes against
 // baseURL. baseURL is the OCI registry's HTTPS endpoint plus any
 // shared path prefix (matching [pkg/oci.NewRegistry]); an

--- a/pkg/proxy/indexcache/inmemory.go
+++ b/pkg/proxy/indexcache/inmemory.go
@@ -1,0 +1,51 @@
+package indexcache
+
+import (
+	"context"
+	"sync"
+
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content/memory"
+)
+
+// InMemoryTargets is a [TargetFactory] backed by per-repo
+// [memory.Store] instances. One store is created on first access for
+// each unique repoPath, so namespace and package isolation surface
+// naturally — two cache entries in different namespaces (or in the
+// same namespace but different packages) live in different stores,
+// exactly like they would on a real OCI backend.
+//
+// It exists for tests in other packages that need a working [Cache]
+// without standing up a real OCI server. Production wiring uses
+// [NewCache] with a real registry URL.
+//
+// A zero value is not usable; construct via [NewInMemoryTargets].
+type InMemoryTargets struct {
+	mu     sync.Mutex
+	stores map[string]*memory.Store
+}
+
+// NewInMemoryTargets returns an [InMemoryTargets] ready for use.
+func NewInMemoryTargets() *InMemoryTargets {
+	return &InMemoryTargets{stores: map[string]*memory.Store{}}
+}
+
+// Open is the [TargetFactory] entry point. It is safe for concurrent
+// use; the same repoPath always returns the same underlying store.
+func (f *InMemoryTargets) Open(_ context.Context, repoPath string) (oras.Target, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if s, ok := f.stores[repoPath]; ok {
+		return s, nil
+	}
+	s := memory.New()
+	f.stores[repoPath] = s
+	return s, nil
+}
+
+// NewInMemoryCache returns a [Cache] wired to a fresh
+// [InMemoryTargets]. Convenient one-liner for tests that don't care
+// about reusing the target factory across multiple caches.
+func NewInMemoryCache(opts ...Option) (*Cache, error) {
+	return NewCacheWithTargets(NewInMemoryTargets().Open, opts...)
+}

--- a/pkg/proxy/python/metadata.go
+++ b/pkg/proxy/python/metadata.go
@@ -1,0 +1,98 @@
+package python
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/yolocs/ocifactory/pkg/proxy"
+)
+
+// pypiJSON is the subset of the PyPI JSON API response we read. The
+// upstream response is much richer; we only capture what the proxy
+// actually consumes (file URLs, hashes, sizes, upload times).
+//
+// Decoding tolerates missing fields — PyPI sometimes omits
+// `upload_time_iso_8601` for very old packages — but rejects bodies
+// that don't even carry a `urls` array, which is the shape every
+// per-version response must have.
+type pypiJSON struct {
+	Info struct {
+		Name string `json:"name"`
+	} `json:"info"`
+	URLs []pypiJSONFile `json:"urls"`
+}
+
+type pypiJSONFile struct {
+	Filename          string            `json:"filename"`
+	URL               string            `json:"url"`
+	Digests           map[string]string `json:"digests"`
+	Size              int64             `json:"size"`
+	UploadTimeISO8601 string            `json:"upload_time_iso_8601"`
+}
+
+func decodeVersionMetadata(body []byte, pkg, version string) (*VersionMetadata, error) {
+	if len(body) == 0 {
+		return nil, fmt.Errorf("python proxy: metadata %s %s: empty body: %w",
+			pkg, version, proxy.ErrUpstreamMalformed)
+	}
+	var raw pypiJSON
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("python proxy: metadata %s %s: decode: %v: %w",
+			pkg, version, err, proxy.ErrUpstreamMalformed)
+	}
+	// PyPI returns 200 with an empty urls array when a version
+	// exists but has no published files — treat that the same as
+	// a 404 from the caller's perspective so the proxy short-circuits
+	// instead of streaming nothing.
+	if len(raw.URLs) == 0 {
+		return nil, fmt.Errorf("python proxy: metadata %s %s: no files in response: %w",
+			pkg, version, proxy.ErrNotFound)
+	}
+
+	meta := &VersionMetadata{
+		Package: raw.Info.Name,
+		Version: version,
+		Files:   make([]FileMetadata, 0, len(raw.URLs)),
+	}
+	if meta.Package == "" {
+		meta.Package = pkg
+	}
+
+	var earliest time.Time
+	for _, u := range raw.URLs {
+		fm := FileMetadata{
+			Filename: u.Filename,
+			URL:      u.URL,
+			SHA256:   u.Digests["sha256"],
+			Size:     u.Size,
+		}
+		if u.UploadTimeISO8601 != "" {
+			if t, perr := time.Parse(time.RFC3339Nano, u.UploadTimeISO8601); perr == nil {
+				fm.UploadTime = t
+				if earliest.IsZero() || t.Before(earliest) {
+					earliest = t
+				}
+			}
+		}
+		meta.Files = append(meta.Files, fm)
+	}
+	meta.UploadTime = earliest
+	return meta, nil
+}
+
+// FindFile returns the [FileMetadata] entry whose Filename matches the
+// requested name, or false when no entry matches. Comparison is
+// case-sensitive — PyPI distribution filenames are canonical and
+// case-changes are not equivalent on the wire.
+func (m *VersionMetadata) FindFile(filename string) (FileMetadata, bool) {
+	if m == nil {
+		return FileMetadata{}, false
+	}
+	for _, f := range m.Files {
+		if f.Filename == filename {
+			return f, true
+		}
+	}
+	return FileMetadata{}, false
+}

--- a/pkg/proxy/python/python.go
+++ b/pkg/proxy/python/python.go
@@ -1,0 +1,348 @@
+// Package python is the per-format proxy fetcher for PyPI. It speaks
+// two upstream APIs:
+//
+//   - PEP 503 simple HTML index — passthrough for /simple/ and
+//     /simple/<pkg>/ requests, with absolute file URLs rewritten so
+//     pip routes file downloads back through ocifactory.
+//   - PyPI JSON API (/pypi/<pkg>/<version>/json) — used on a file
+//     cache miss to resolve the upstream file URL and upload_time
+//     before committing to the upstream byte transfer.
+//
+// File downloads themselves stream straight from the URL the JSON API
+// pointed at (typically files.pythonhosted.org). The fetcher does not
+// know about OCI: it returns response bodies and the caller (the
+// python handler's proxy path) tees them through
+// [pkg/namespace.ScopedRegistry.AddFile] while serving the client.
+//
+// There is no shared Fetcher interface — see the design issue
+// (#118) for why. The handler holds a concrete *Fetcher and calls the
+// methods this package exposes.
+package python
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/golang-lru/v2/expirable"
+
+	"github.com/yolocs/ocifactory/pkg/proxy"
+	"github.com/yolocs/ocifactory/pkg/proxy/httpclient"
+)
+
+const (
+	// DefaultVersionMetadataCacheTTL is how long a successful
+	// [Fetcher.GetVersionMetadata] result stays in the per-fetcher
+	// in-memory cache. Sized for pip's typical resolution burst —
+	// when a single install lands several files of the same version
+	// in quick succession, only the first call hits upstream.
+	DefaultVersionMetadataCacheTTL = 60 * time.Second
+
+	// DefaultVersionMetadataCacheSize bounds the number of
+	// (package, version) metadata entries the per-fetcher cache
+	// retains. Generous so a heavy resolution burst doesn't evict
+	// itself; bounded so memory is predictable.
+	DefaultVersionMetadataCacheSize = 4096
+)
+
+// IndexResponse is the result of a successful index fetch.
+//
+// Body is the raw upstream payload — callers rewrite it before
+// serving and (typically) hand the same bytes to
+// [pkg/proxy/indexcache.Cache.Put] for the on-OCI cache. ContentType
+// is the upstream Content-Type header verbatim so the cache and the
+// client see the same value (PyPI emits both
+// `text/html; charset=utf-8` and
+// `application/vnd.pypi.simple.v1+html`).
+type IndexResponse struct {
+	Body        []byte
+	ContentType string
+}
+
+// VersionMetadata is the subset of PyPI's JSON API response the file
+// proxy needs.
+type VersionMetadata struct {
+	// Package is the upstream-canonical (not necessarily PEP 503
+	// normalized) package name from the JSON API's `info.name`. The
+	// caller uses it as the source of truth when assembling the
+	// version manifest's owning repo segment.
+	Package string
+
+	// Version is the version this metadata describes. Echoed back
+	// from the request so callers don't need to re-thread it.
+	Version string
+
+	// Files lists every distribution PyPI advertises for this
+	// version (wheel, sdist, .whl.metadata sidecars when present).
+	// The order is whatever PyPI returned; callers match on
+	// Filename to find the one the client requested.
+	Files []FileMetadata
+
+	// UploadTime is the publication time of the version, picked as
+	// the earliest upload_time across [Files]. Zero when none of
+	// the upstream entries carried a parseable timestamp.
+	UploadTime time.Time
+}
+
+// FileMetadata identifies one distribution file under a version.
+type FileMetadata struct {
+	Filename string
+	URL      string
+	SHA256   string
+	Size     int64
+
+	// UploadTime is the per-file publication timestamp from PyPI's
+	// JSON `upload_time_iso_8601`. Zero when missing or unparseable.
+	UploadTime time.Time
+}
+
+// FileResponse is the result of a successful [Fetcher.FetchFile] call.
+// Body is the upstream stream the caller MUST close.
+type FileResponse struct {
+	Body          io.ReadCloser
+	ContentType   string
+	ContentLength int64
+}
+
+// Fetcher is the PyPI-shaped upstream client.
+//
+// A Fetcher is safe for concurrent use. One per upstream URL is the
+// typical wiring; the python handler caches Fetchers keyed by
+// (namespace, upstream) when different namespaces point at different
+// upstreams.
+type Fetcher struct {
+	upstream *url.URL
+	client   *httpclient.Client
+	metaTTL  time.Duration
+	metaLRU  *expirable.LRU[string, *VersionMetadata]
+	now      func() time.Time
+}
+
+// Option configures a [Fetcher].
+type Option func(*config)
+
+type config struct {
+	client        *httpclient.Client
+	metaCacheSize int
+	metaCacheTTL  time.Duration
+	now           func() time.Time
+}
+
+// WithClient overrides the shared HTTP client. Defaults to a fresh
+// [httpclient.New] with the package defaults.
+func WithClient(c *httpclient.Client) Option {
+	return func(o *config) { o.client = c }
+}
+
+// WithVersionMetadataCache tunes the in-memory cache size and TTL the
+// fetcher uses to memoise successful [Fetcher.GetVersionMetadata]
+// results. A non-positive size or TTL falls back to the defaults.
+func WithVersionMetadataCache(size int, ttl time.Duration) Option {
+	return func(o *config) {
+		o.metaCacheSize = size
+		o.metaCacheTTL = ttl
+	}
+}
+
+// withNow overrides the wall clock used to stamp cache-miss decisions.
+// Test seam; not exported.
+func withNow(now func() time.Time) Option {
+	return func(o *config) { o.now = now }
+}
+
+// New constructs a [Fetcher] that talks to upstream. upstream must be
+// an absolute http or https URL — the PyPI canonical value is
+// `https://pypi.org`.
+func New(upstream *url.URL, opts ...Option) (*Fetcher, error) {
+	if upstream == nil {
+		return nil, errors.New("python proxy: upstream URL is required")
+	}
+	if !upstream.IsAbs() || upstream.Host == "" {
+		return nil, fmt.Errorf("python proxy: upstream %q must be absolute", upstream)
+	}
+	if upstream.Scheme != "http" && upstream.Scheme != "https" {
+		return nil, fmt.Errorf("python proxy: upstream %q scheme must be http or https", upstream)
+	}
+
+	cfg := config{
+		metaCacheSize: DefaultVersionMetadataCacheSize,
+		metaCacheTTL:  DefaultVersionMetadataCacheTTL,
+		now:           func() time.Time { return time.Now().UTC() },
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	if cfg.client == nil {
+		cfg.client = httpclient.New(httpclient.Options{UserAgent: "ocifactory-pypi-proxy"})
+	}
+	if cfg.metaCacheSize <= 0 {
+		cfg.metaCacheSize = DefaultVersionMetadataCacheSize
+	}
+	if cfg.metaCacheTTL <= 0 {
+		cfg.metaCacheTTL = DefaultVersionMetadataCacheTTL
+	}
+	// Strip a trailing slash on the upstream so path joins don't
+	// double-slash when the operator wrote "https://pypi.org/".
+	u := *upstream
+	u.Path = strings.TrimRight(u.Path, "/")
+
+	return &Fetcher{
+		upstream: &u,
+		client:   cfg.client,
+		metaTTL:  cfg.metaCacheTTL,
+		metaLRU:  expirable.NewLRU[string, *VersionMetadata](cfg.metaCacheSize, nil, cfg.metaCacheTTL),
+		now:      cfg.now,
+	}, nil
+}
+
+// Upstream returns the canonical upstream URL the fetcher talks to.
+// Useful for log lines and caching keys.
+func (f *Fetcher) Upstream() *url.URL { return f.upstream }
+
+// GetTopLevelIndex fetches the upstream `/simple/` index. The response
+// body is PEP 503 HTML listing every project on the upstream — for
+// real PyPI this is megabytes, so callers are expected to cache it.
+func (f *Fetcher) GetTopLevelIndex(ctx context.Context) (*IndexResponse, error) {
+	u := f.upstream.JoinPath("simple").String() + "/"
+	return f.getIndex(ctx, u)
+}
+
+// GetSimpleIndex fetches the per-package simple index. pkg is the
+// PEP 503 normalized name (lowercased, runs of `-_.` collapsed to a
+// single `-`); upstream redirects from the un-normalized name are
+// followed by the shared HTTP client.
+func (f *Fetcher) GetSimpleIndex(ctx context.Context, pkg string) (*IndexResponse, error) {
+	if pkg == "" {
+		return nil, fmt.Errorf("python proxy: GetSimpleIndex: package is required")
+	}
+	u := f.upstream.JoinPath("simple", pkg).String() + "/"
+	return f.getIndex(ctx, u)
+}
+
+func (f *Fetcher) getIndex(ctx context.Context, rawURL string) (*IndexResponse, error) {
+	resp, err := f.client.Get(ctx, rawURL, httpclient.GetOptions{
+		// Accept HTML — PyPI honours both legacy and PEP 691 media
+		// types. We pass them all and take whatever the upstream
+		// chose, since we just relay bytes downstream.
+		Header: http.Header{
+			"Accept": []string{
+				"application/vnd.pypi.simple.v1+html, text/html;q=0.9, */*;q=0.1",
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("python proxy: index %s: %w", rawURL, proxy.ErrNotFound)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("python proxy: index %s: unexpected status %d: %w",
+			rawURL, resp.StatusCode, proxy.ErrUpstreamUnavailable)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("python proxy: read index %s: %w", rawURL, proxy.ErrUpstreamUnavailable)
+	}
+	ct := resp.Header.Get("Content-Type")
+	if ct == "" {
+		ct = "text/html"
+	}
+	return &IndexResponse{Body: body, ContentType: ct}, nil
+}
+
+// GetVersionMetadata fetches PyPI's JSON metadata for a specific
+// version. Results are memoised in-process for
+// [DefaultVersionMetadataCacheTTL] so a resolution burst hitting
+// several files of the same version pays for one upstream call.
+//
+// Returns [proxy.ErrNotFound] when upstream reports the package or
+// version doesn't exist; [proxy.ErrUpstreamUnavailable] for retries
+// exhausted; [proxy.ErrUpstreamMalformed] when the response can't be
+// decoded against the expected shape.
+func (f *Fetcher) GetVersionMetadata(ctx context.Context, pkg, version string) (*VersionMetadata, error) {
+	if pkg == "" || version == "" {
+		return nil, fmt.Errorf("python proxy: GetVersionMetadata: package and version are required")
+	}
+	key := pkg + "@" + version
+	if v, ok := f.metaLRU.Get(key); ok {
+		return v, nil
+	}
+
+	u := f.upstream.JoinPath("pypi", pkg, version, "json").String()
+	resp, err := f.client.Get(ctx, u, httpclient.GetOptions{
+		Header: http.Header{"Accept": []string{"application/json"}},
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("python proxy: metadata %s %s: %w", pkg, version, proxy.ErrNotFound)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("python proxy: metadata %s %s: status %d: %w",
+			pkg, version, resp.StatusCode, proxy.ErrUpstreamUnavailable)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("python proxy: metadata %s %s: read: %w", pkg, version, proxy.ErrUpstreamUnavailable)
+	}
+
+	meta, err := decodeVersionMetadata(body, pkg, version)
+	if err != nil {
+		return nil, err
+	}
+	f.metaLRU.Add(key, meta)
+	return meta, nil
+}
+
+// FetchFile opens a streaming GET against rawURL. The caller is
+// expected to have obtained rawURL from a prior
+// [Fetcher.GetVersionMetadata] response (or a rewritten simple-index
+// anchor) so the URL has already been validated against the upstream
+// surface.
+//
+// The returned [FileResponse.Body] MUST be closed by the caller —
+// closing also releases the underlying per-request timeout.
+func (f *Fetcher) FetchFile(ctx context.Context, rawURL string) (*FileResponse, error) {
+	if rawURL == "" {
+		return nil, fmt.Errorf("python proxy: FetchFile: url is required")
+	}
+	resp, err := f.client.Get(ctx, rawURL, httpclient.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		resp.Body.Close()
+		return nil, fmt.Errorf("python proxy: file %s: %w", rawURL, proxy.ErrNotFound)
+	}
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		return nil, fmt.Errorf("python proxy: file %s: status %d: %w",
+			rawURL, resp.StatusCode, proxy.ErrUpstreamUnavailable)
+	}
+	contentType := resp.Header.Get("Content-Type")
+	contentLength := int64(-1)
+	if cl := resp.Header.Get("Content-Length"); cl != "" {
+		// Best-effort: a missing or malformed Content-Length isn't
+		// fatal — the OCI streaming push will measure as it goes.
+		// proxy.ErrUpstreamMalformed is reserved for shape errors
+		// the caller couldn't recover from.
+		var n int64
+		if _, scanErr := fmt.Sscanf(cl, "%d", &n); scanErr == nil && n >= 0 {
+			contentLength = n
+		}
+	}
+	return &FileResponse{
+		Body:          resp.Body,
+		ContentType:   contentType,
+		ContentLength: contentLength,
+	}, nil
+}

--- a/pkg/proxy/python/python_test.go
+++ b/pkg/proxy/python/python_test.go
@@ -1,0 +1,340 @@
+package python
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/yolocs/ocifactory/pkg/proxy"
+	"github.com/yolocs/ocifactory/pkg/proxy/httpclient"
+)
+
+// stubUpstream is a tiny PyPI emulator built around an
+// [http.ServeMux] so individual tests can plug in just the routes
+// they exercise.
+type stubUpstream struct {
+	*httptest.Server
+	mux *http.ServeMux
+
+	indexHits    atomic.Int64
+	metadataHits atomic.Int64
+	fileHits     atomic.Int64
+	topLevelHits atomic.Int64
+}
+
+func newStubUpstream(t *testing.T) *stubUpstream {
+	t.Helper()
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return &stubUpstream{Server: srv, mux: mux}
+}
+
+// newFetcher returns a Fetcher wired to a stub upstream with a tight
+// httpclient timeout so test latency stays predictable.
+func (s *stubUpstream) newFetcher(t *testing.T, opts ...Option) *Fetcher {
+	t.Helper()
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		t.Fatalf("parse stub URL: %v", err)
+	}
+	allOpts := []Option{
+		WithClient(httpclient.New(httpclient.Options{
+			Timeout:        500 * time.Millisecond,
+			MaxRetries:     -1,
+			InitialBackoff: time.Millisecond,
+		})),
+	}
+	allOpts = append(allOpts, opts...)
+	f, err := New(u, allOpts...)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return f
+}
+
+func TestNew_Validation(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		urlStr  string
+		wantErr bool
+	}{
+		{name: "empty url", urlStr: "", wantErr: true},
+		{name: "relative", urlStr: "/foo", wantErr: true},
+		{name: "missing scheme", urlStr: "//pypi.org", wantErr: true},
+		{name: "ftp scheme", urlStr: "ftp://pypi.org", wantErr: true},
+		{name: "https ok", urlStr: "https://pypi.org", wantErr: false},
+		{name: "http ok", urlStr: "http://localhost:8080", wantErr: false},
+		{name: "trailing slash stripped", urlStr: "https://pypi.org/", wantErr: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var u *url.URL
+			if tc.urlStr != "" {
+				var err error
+				u, err = url.Parse(tc.urlStr)
+				if err != nil {
+					t.Fatalf("parse: %v", err)
+				}
+			}
+			_, err := New(u)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("New(%q) err=%v, wantErr=%v", tc.urlStr, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestGetSimpleIndex(t *testing.T) {
+	t.Parallel()
+	s := newStubUpstream(t)
+	body := `<html><body><a href="https://files.pythonhosted.org/packages/aa/requests-2.31.0-py3-none-any.whl#sha256=abc">requests-2.31.0-py3-none-any.whl</a></body></html>`
+	s.mux.HandleFunc("/simple/requests/", func(w http.ResponseWriter, r *http.Request) {
+		s.indexHits.Add(1)
+		w.Header().Set("Content-Type", "application/vnd.pypi.simple.v1+html")
+		_, _ = io.WriteString(w, body)
+	})
+	s.mux.HandleFunc("/simple/missing/", func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+
+	f := s.newFetcher(t)
+	got, err := f.GetSimpleIndex(t.Context(), "requests")
+	if err != nil {
+		t.Fatalf("GetSimpleIndex: %v", err)
+	}
+	if string(got.Body) != body {
+		t.Errorf("body mismatch:\nwant: %q\ngot:  %q", body, string(got.Body))
+	}
+	if got.ContentType != "application/vnd.pypi.simple.v1+html" {
+		t.Errorf("ContentType = %q, want PEP 691 html", got.ContentType)
+	}
+
+	if _, err := f.GetSimpleIndex(t.Context(), "missing"); !errors.Is(err, proxy.ErrNotFound) {
+		t.Errorf("missing package: got %v, want ErrNotFound", err)
+	}
+
+	if _, err := f.GetSimpleIndex(t.Context(), ""); err == nil {
+		t.Errorf("empty pkg: want error")
+	}
+}
+
+func TestGetTopLevelIndex(t *testing.T) {
+	t.Parallel()
+	s := newStubUpstream(t)
+	body := `<html><body><a href="/simple/requests/">requests</a></body></html>`
+	s.mux.HandleFunc("/simple/", func(w http.ResponseWriter, r *http.Request) {
+		s.topLevelHits.Add(1)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = io.WriteString(w, body)
+	})
+
+	f := s.newFetcher(t)
+	got, err := f.GetTopLevelIndex(t.Context())
+	if err != nil {
+		t.Fatalf("GetTopLevelIndex: %v", err)
+	}
+	if string(got.Body) != body {
+		t.Errorf("body mismatch: got %q want %q", string(got.Body), body)
+	}
+	if got.ContentType != "text/html; charset=utf-8" {
+		t.Errorf("ContentType = %q", got.ContentType)
+	}
+	if s.topLevelHits.Load() != 1 {
+		t.Errorf("topLevelHits = %d, want 1", s.topLevelHits.Load())
+	}
+}
+
+func TestGetVersionMetadata(t *testing.T) {
+	t.Parallel()
+	s := newStubUpstream(t)
+	pypi := `{
+		"info": {"name": "requests"},
+		"urls": [
+			{
+				"filename": "requests-2.31.0-py3-none-any.whl",
+				"url": "https://files.pythonhosted.org/packages/.../requests-2.31.0-py3-none-any.whl",
+				"digests": {"sha256": "abc123"},
+				"size": 64909,
+				"upload_time_iso_8601": "2023-05-22T15:12:44.123456Z"
+			},
+			{
+				"filename": "requests-2.31.0.tar.gz",
+				"url": "https://files.pythonhosted.org/packages/.../requests-2.31.0.tar.gz",
+				"digests": {"sha256": "def456"},
+				"size": 110586,
+				"upload_time_iso_8601": "2023-05-22T15:12:42.123456Z"
+			}
+		]
+	}`
+	s.mux.HandleFunc("/pypi/requests/2.31.0/json", func(w http.ResponseWriter, r *http.Request) {
+		s.metadataHits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, pypi)
+	})
+	s.mux.HandleFunc("/pypi/requests/9.9.9/json", func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+	s.mux.HandleFunc("/pypi/empty/1.0.0/json", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"info":{"name":"empty"},"urls":[]}`)
+	})
+	s.mux.HandleFunc("/pypi/bad/1.0.0/json", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{not json`)
+	})
+
+	f := s.newFetcher(t)
+
+	meta, err := f.GetVersionMetadata(t.Context(), "requests", "2.31.0")
+	if err != nil {
+		t.Fatalf("GetVersionMetadata: %v", err)
+	}
+	if meta.Package != "requests" || meta.Version != "2.31.0" || len(meta.Files) != 2 {
+		t.Errorf("unexpected meta: %+v", meta)
+	}
+	if meta.UploadTime.IsZero() {
+		t.Errorf("UploadTime is zero")
+	}
+	// Earliest among the file timestamps.
+	wantUpload, _ := time.Parse(time.RFC3339Nano, "2023-05-22T15:12:42.123456Z")
+	if !meta.UploadTime.Equal(wantUpload) {
+		t.Errorf("UploadTime = %v, want %v", meta.UploadTime, wantUpload)
+	}
+
+	// In-memory cache: second call shouldn't touch upstream.
+	if _, err := f.GetVersionMetadata(t.Context(), "requests", "2.31.0"); err != nil {
+		t.Fatalf("second GetVersionMetadata: %v", err)
+	}
+	if got := s.metadataHits.Load(); got != 1 {
+		t.Errorf("metadataHits = %d, want 1 (cache should suppress second call)", got)
+	}
+
+	if _, err := f.GetVersionMetadata(t.Context(), "requests", "9.9.9"); !errors.Is(err, proxy.ErrNotFound) {
+		t.Errorf("missing version: got %v, want ErrNotFound", err)
+	}
+	if _, err := f.GetVersionMetadata(t.Context(), "empty", "1.0.0"); !errors.Is(err, proxy.ErrNotFound) {
+		t.Errorf("empty urls: got %v, want ErrNotFound", err)
+	}
+	if _, err := f.GetVersionMetadata(t.Context(), "bad", "1.0.0"); !errors.Is(err, proxy.ErrUpstreamMalformed) {
+		t.Errorf("malformed json: got %v, want ErrUpstreamMalformed", err)
+	}
+}
+
+func TestFetchFile(t *testing.T) {
+	t.Parallel()
+	s := newStubUpstream(t)
+	const want = "wheel-body-bytes"
+	s.mux.HandleFunc("/files/requests-2.31.0-py3-none-any.whl", func(w http.ResponseWriter, r *http.Request) {
+		s.fileHits.Add(1)
+		w.Header().Set("Content-Type", "application/zip")
+		w.Header().Set("Content-Length", "16")
+		_, _ = io.WriteString(w, want)
+	})
+	s.mux.HandleFunc("/files/missing.whl", func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+
+	f := s.newFetcher(t)
+	resp, err := f.FetchFile(t.Context(), s.URL+"/files/requests-2.31.0-py3-none-any.whl")
+	if err != nil {
+		t.Fatalf("FetchFile: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.ContentType != "application/zip" {
+		t.Errorf("ContentType = %q", resp.ContentType)
+	}
+	if resp.ContentLength != 16 {
+		t.Errorf("ContentLength = %d, want 16", resp.ContentLength)
+	}
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if string(got) != want {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+
+	if _, err := f.FetchFile(t.Context(), s.URL+"/files/missing.whl"); !errors.Is(err, proxy.ErrNotFound) {
+		t.Errorf("missing file: got %v, want ErrNotFound", err)
+	}
+	if _, err := f.FetchFile(t.Context(), ""); err == nil {
+		t.Errorf("empty url: want error")
+	}
+}
+
+func TestGetIndex_UpstreamErrorClassification(t *testing.T) {
+	t.Parallel()
+	s := newStubUpstream(t)
+	s.mux.HandleFunc("/simple/serverboom/", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusBadGateway)
+	})
+	s.mux.HandleFunc("/simple/teapot/", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "teapot", http.StatusTeapot)
+	})
+
+	f := s.newFetcher(t)
+	if _, err := f.GetSimpleIndex(t.Context(), "serverboom"); !errors.Is(err, proxy.ErrUpstreamUnavailable) {
+		t.Errorf("5xx: got %v, want ErrUpstreamUnavailable", err)
+	}
+	// Unexpected 4xx (other than 404) classifies as unavailable —
+	// the response shape isn't useful and the caller would just
+	// repeat the request.
+	if _, err := f.GetSimpleIndex(t.Context(), "teapot"); !errors.Is(err, proxy.ErrUpstreamUnavailable) {
+		t.Errorf("unexpected 4xx: got %v, want ErrUpstreamUnavailable", err)
+	}
+}
+
+func TestGetSimpleIndex_DefaultContentType(t *testing.T) {
+	t.Parallel()
+	s := newStubUpstream(t)
+	s.mux.HandleFunc("/simple/nctype/", func(w http.ResponseWriter, r *http.Request) {
+		// Clear the default Content-Type that net/http sniffs.
+		w.Header()["Content-Type"] = nil
+		_, _ = io.WriteString(w, "<html></html>")
+	})
+	f := s.newFetcher(t)
+	resp, err := f.GetSimpleIndex(t.Context(), "nctype")
+	if err != nil {
+		t.Fatalf("GetSimpleIndex: %v", err)
+	}
+	if resp.ContentType != "text/html" {
+		t.Errorf("ContentType = %q, want default text/html", resp.ContentType)
+	}
+}
+
+func TestFetcher_UpstreamGetter(t *testing.T) {
+	t.Parallel()
+	u, _ := url.Parse("https://pypi.org/")
+	f, err := New(u)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if got := f.Upstream().String(); got != "https://pypi.org" {
+		t.Errorf("Upstream() = %q, want trailing-slash stripped form", got)
+	}
+}
+
+// guard against accidental dependency on a global default client.
+func TestFetcher_UsesProvidedClient(t *testing.T) {
+	t.Parallel()
+	s := newStubUpstream(t)
+	s.mux.HandleFunc("/simple/x/", func(w http.ResponseWriter, r *http.Request) {
+		ua := r.Header.Get("User-Agent")
+		if !strings.Contains(ua, "custom-ua-for-test") {
+			t.Errorf("User-Agent = %q, want substring custom-ua-for-test", ua)
+		}
+		_, _ = io.WriteString(w, "<html></html>")
+	})
+	client := httpclient.New(httpclient.Options{UserAgent: "custom-ua-for-test"})
+	f := s.newFetcher(t, WithClient(client))
+	if _, err := f.GetSimpleIndex(t.Context(), "x"); err != nil {
+		t.Fatalf("GetSimpleIndex: %v", err)
+	}
+}

--- a/pkg/proxy/python/rewrite.go
+++ b/pkg/proxy/python/rewrite.go
@@ -1,0 +1,186 @@
+package python
+
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+	"path"
+	"strings"
+
+	"github.com/yolocs/ocifactory/pkg/proxy"
+	"golang.org/x/net/html"
+)
+
+// RewriteSimpleIndex parses an upstream PEP 503 simple-index HTML body
+// for one package and rewrites every <a href="..."> file URL to
+// "/{namespace}/packages/{pkg}/{version}/{filename}#sha256=...".
+//
+// pkg is the PEP 503 normalized package name as the upstream knows it
+// (used to extract version segments from filenames). namespace is the
+// ocifactory namespace the request landed in.
+//
+// The fragment (`#sha256=...`) is preserved if upstream included one,
+// since pip checks it for integrity. The data-* attributes
+// (`data-requires-python`, `data-dist-info-metadata`,
+// `data-core-metadata`, `data-yanked`) are passed through unchanged.
+//
+// Anchors that don't carry a parseable distribution filename are
+// preserved as-is rather than dropped: the simple index occasionally
+// carries non-file links (e.g. PEP 658 metadata sidecars share the
+// same anchor shape and parse fine, but the goal is to fail soft if
+// upstream adds a future shape we don't recognise yet).
+//
+// On a fundamentally unparseable body (HTML parser returns an error,
+// which html.Parse essentially never does) the call surfaces
+// [proxy.ErrUpstreamMalformed].
+func RewriteSimpleIndex(body []byte, namespace, pkg string) ([]byte, error) {
+	if namespace == "" || pkg == "" {
+		return nil, fmt.Errorf("python proxy: rewrite: namespace and pkg are required")
+	}
+	doc, err := html.Parse(bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("python proxy: parse simple index: %v: %w", err, proxy.ErrUpstreamMalformed)
+	}
+	rewriteAnchors(doc, namespace, pkg)
+	var buf bytes.Buffer
+	if err := html.Render(&buf, doc); err != nil {
+		return nil, fmt.Errorf("python proxy: render simple index: %v: %w", err, proxy.ErrUpstreamMalformed)
+	}
+	return buf.Bytes(), nil
+}
+
+func rewriteAnchors(n *html.Node, namespace, pkg string) {
+	if n.Type == html.ElementNode && n.Data == "a" {
+		for i, attr := range n.Attr {
+			if attr.Key != "href" {
+				continue
+			}
+			rewritten, ok := rewriteHref(attr.Val, namespace, pkg)
+			if ok {
+				n.Attr[i].Val = rewritten
+			}
+		}
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		rewriteAnchors(c, namespace, pkg)
+	}
+}
+
+// rewriteHref returns the namespace-prefixed URL for a single anchor
+// href and reports whether the rewrite succeeded. When the upstream
+// href doesn't look like a distribution download (no extractable
+// filename or no parseable version), the original value is returned
+// with ok=false so the caller leaves the attribute untouched — a
+// malformed entry has no good replacement and dropping it would hide
+// the upstream problem from the client.
+func rewriteHref(href, namespace, pkg string) (string, bool) {
+	if href == "" {
+		return href, false
+	}
+	parsed, err := url.Parse(href)
+	if err != nil {
+		return href, false
+	}
+	filename := path.Base(parsed.Path)
+	if filename == "" || filename == "." || filename == "/" {
+		return href, false
+	}
+	version, err := parseFilenameVersion(filename, pkg)
+	if err != nil {
+		return href, false
+	}
+	// Construct a relative URL so the rewrite plays nicely behind
+	// any reverse proxy / hostname the client is talking to. pip
+	// resolves the relative path against the index URL it requested.
+	rewritten := url.URL{Path: path.Join("/", namespace, "packages", pkg, version, filename)}
+	if parsed.Fragment != "" {
+		rewritten.Fragment = parsed.Fragment
+	}
+	if parsed.RawQuery != "" {
+		// PyPI doesn't put query params on file URLs today, but
+		// future hash-in-query schemes (the long-discussed PEP)
+		// might. Pass through so the client gets to see them.
+		rewritten.RawQuery = parsed.RawQuery
+	}
+	return rewritten.String(), true
+}
+
+// parseFilenameVersion extracts the version segment from a PyPI
+// distribution filename, given the package's PEP 503 normalized name.
+// Wheels follow PEP 427:
+//
+//	{distribution}-{version}(-{build tag})?-{python tag}-{abi tag}-{platform tag}.whl
+//
+// Sdists follow no formal PEP but conventionally:
+//
+//	{distribution}-{version}.{tar.gz | zip | tar.bz2}
+//
+// PEP 658 metadata sidecars append `.metadata` to the wheel filename.
+// PyPI also accepts an older `.egg` shape we tolerate for completeness.
+//
+// The distribution segment may use either `-` or `_` in place of `-`
+// in the canonical name (PyPI's filename convention). We match both
+// candidates; the comparison is case-insensitive because PEP 503
+// normalization lower-cases the canonical name but historical
+// filenames preserve original casing.
+func parseFilenameVersion(filename, normalizedPkg string) (string, error) {
+	if filename == "" {
+		return "", fmt.Errorf("empty filename")
+	}
+	if normalizedPkg == "" {
+		return "", fmt.Errorf("empty package name")
+	}
+	lowerFilename := strings.ToLower(filename)
+	candidates := []string{normalizedPkg}
+	if strings.Contains(normalizedPkg, "-") {
+		candidates = append(candidates, strings.ReplaceAll(normalizedPkg, "-", "_"))
+	}
+
+	for _, c := range candidates {
+		prefix := strings.ToLower(c) + "-"
+		if !strings.HasPrefix(lowerFilename, prefix) {
+			continue
+		}
+		rest := filename[len(prefix):]
+
+		switch {
+		case strings.HasSuffix(lowerFilename, ".whl.metadata"):
+			stem := rest[:len(rest)-len(".whl.metadata")]
+			return wheelVersion(stem)
+		case strings.HasSuffix(lowerFilename, ".whl"):
+			stem := rest[:len(rest)-len(".whl")]
+			return wheelVersion(stem)
+		case strings.HasSuffix(lowerFilename, ".tar.gz"):
+			return rest[:len(rest)-len(".tar.gz")], nil
+		case strings.HasSuffix(lowerFilename, ".tar.bz2"):
+			return rest[:len(rest)-len(".tar.bz2")], nil
+		case strings.HasSuffix(lowerFilename, ".zip"):
+			return rest[:len(rest)-len(".zip")], nil
+		case strings.HasSuffix(lowerFilename, ".egg"):
+			return rest[:len(rest)-len(".egg")], nil
+		}
+	}
+	return "", fmt.Errorf("filename %q does not match package %q", filename, normalizedPkg)
+}
+
+// wheelVersion pulls the version segment from a wheel stem
+// (`<version>-<py>-<abi>-<plat>` or
+// `<version>-<build>-<py>-<abi>-<plat>`). PEP 427 specifies at least
+// three trailing segments (py/abi/platform); a build tag adds a fourth.
+// We split and pull the segment before the last three.
+func wheelVersion(stem string) (string, error) {
+	parts := strings.Split(stem, "-")
+	if len(parts) < 4 {
+		return "", fmt.Errorf("wheel stem %q has too few segments", stem)
+	}
+	// version is everything before the last three segments
+	// (py-abi-platform). Build tag (if present) lives between
+	// version and python-tag and is rolled into the version-slot
+	// when len(parts) == 5, which would mis-attribute it; PEP 427
+	// disambiguates by requiring the build tag to start with a
+	// digit, but practically wheels with build tags are rare and we
+	// don't need to support them to route pip — we'd just store
+	// under a slightly wider version key. Keep this simple.
+	versionSegments := parts[:len(parts)-3]
+	return strings.Join(versionSegments, "-"), nil
+}

--- a/pkg/proxy/python/rewrite_test.go
+++ b/pkg/proxy/python/rewrite_test.go
@@ -1,0 +1,234 @@
+package python
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseFilenameVersion(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		filename string
+		pkg      string
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "wheel basic",
+			filename: "requests-2.31.0-py3-none-any.whl",
+			pkg:      "requests",
+			want:     "2.31.0",
+		},
+		{
+			name:     "wheel with hyphenated version",
+			filename: "requests-2.31.0a1-py3-none-any.whl",
+			pkg:      "requests",
+			want:     "2.31.0a1",
+		},
+		{
+			name:     "sdist tar.gz",
+			filename: "requests-2.31.0.tar.gz",
+			pkg:      "requests",
+			want:     "2.31.0",
+		},
+		{
+			name:     "sdist zip",
+			filename: "requests-2.31.0.zip",
+			pkg:      "requests",
+			want:     "2.31.0",
+		},
+		{
+			name:     "sdist tar.bz2",
+			filename: "requests-2.31.0.tar.bz2",
+			pkg:      "requests",
+			want:     "2.31.0",
+		},
+		{
+			name:     "wheel metadata sidecar",
+			filename: "requests-2.31.0-py3-none-any.whl.metadata",
+			pkg:      "requests",
+			want:     "2.31.0",
+		},
+		{
+			name:     "hyphen-to-underscore in distribution",
+			filename: "python_dateutil-2.8.2-py2.py3-none-any.whl",
+			pkg:      "python-dateutil",
+			want:     "2.8.2",
+		},
+		{
+			name:     "egg",
+			filename: "foo-1.0.0-py3.10.egg",
+			pkg:      "foo",
+			want:     "1.0.0-py3.10",
+		},
+		{
+			name:     "case-insensitive distribution match",
+			filename: "Pillow-10.0.0-cp311-cp311-manylinux_2_28_x86_64.whl",
+			pkg:      "pillow",
+			want:     "10.0.0",
+		},
+		{
+			name:     "unrelated filename",
+			filename: "other-1.0.0-py3-none-any.whl",
+			pkg:      "requests",
+			wantErr:  true,
+		},
+		{
+			name:     "wheel too few segments",
+			filename: "requests-2.31.0.whl",
+			pkg:      "requests",
+			wantErr:  true,
+		},
+		{
+			name:     "empty filename",
+			filename: "",
+			pkg:      "requests",
+			wantErr:  true,
+		},
+		{
+			name:     "empty pkg",
+			filename: "requests-2.31.0.tar.gz",
+			pkg:      "",
+			wantErr:  true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseFilenameVersion(tc.filename, tc.pkg)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("parseFilenameVersion(%q, %q) err=%v, wantErr=%v",
+					tc.filename, tc.pkg, err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Errorf("parseFilenameVersion(%q, %q) = %q, want %q",
+					tc.filename, tc.pkg, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRewriteSimpleIndex(t *testing.T) {
+	t.Parallel()
+
+	const upstreamHTML = `<!DOCTYPE html>
+<html>
+<head><title>Links for requests</title></head>
+<body>
+<h1>Links for requests</h1>
+<a href="https://files.pythonhosted.org/packages/aa/47/cf/requests-2.31.0-py3-none-any.whl#sha256=abc123" data-requires-python="&gt;=3.7">requests-2.31.0-py3-none-any.whl</a><br>
+<a href="https://files.pythonhosted.org/packages/aa/47/cf/requests-2.31.0.tar.gz#sha256=def456">requests-2.31.0.tar.gz</a><br>
+<a href="https://files.pythonhosted.org/packages/aa/47/cf/requests-2.31.0-py3-none-any.whl.metadata#sha256=meta789" data-dist-info-metadata="sha256=meta789">requests-2.31.0-py3-none-any.whl.metadata</a><br>
+</body>
+</html>
+`
+	out, err := RewriteSimpleIndex([]byte(upstreamHTML), "myns", "requests")
+	if err != nil {
+		t.Fatalf("RewriteSimpleIndex: %v", err)
+	}
+	s := string(out)
+	wantHrefs := []string{
+		`href="/myns/packages/requests/2.31.0/requests-2.31.0-py3-none-any.whl#sha256=abc123"`,
+		`href="/myns/packages/requests/2.31.0/requests-2.31.0.tar.gz#sha256=def456"`,
+		`href="/myns/packages/requests/2.31.0/requests-2.31.0-py3-none-any.whl.metadata#sha256=meta789"`,
+	}
+	for _, want := range wantHrefs {
+		if !strings.Contains(s, want) {
+			t.Errorf("rewritten body missing %q\ngot:\n%s", want, s)
+		}
+	}
+	// Pre-existing data-* attributes survive the rewrite.
+	if !strings.Contains(s, `data-requires-python="&gt;=3.7"`) {
+		t.Errorf("rewritten body lost data-requires-python attribute:\n%s", s)
+	}
+	if !strings.Contains(s, `data-dist-info-metadata="sha256=meta789"`) {
+		t.Errorf("rewritten body lost data-dist-info-metadata attribute:\n%s", s)
+	}
+}
+
+func TestRewriteSimpleIndex_LeavesUnparseableAnchors(t *testing.T) {
+	t.Parallel()
+
+	in := `<html><body>` +
+		`<a href="https://files.pythonhosted.org/somewhere/unknown-archive.bin">unknown</a>` +
+		`<a href="https://files.pythonhosted.org/packages/aa/requests-2.31.0-py3-none-any.whl#sha256=abc">requests-2.31.0-py3-none-any.whl</a>` +
+		`</body></html>`
+	out, err := RewriteSimpleIndex([]byte(in), "myns", "requests")
+	if err != nil {
+		t.Fatalf("RewriteSimpleIndex: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, `href="https://files.pythonhosted.org/somewhere/unknown-archive.bin"`) {
+		t.Errorf("unparseable anchor should pass through unchanged\ngot: %s", s)
+	}
+	if !strings.Contains(s, `href="/myns/packages/requests/2.31.0/requests-2.31.0-py3-none-any.whl#sha256=abc"`) {
+		t.Errorf("parseable anchor should be rewritten\ngot: %s", s)
+	}
+}
+
+func TestRewriteSimpleIndex_Errors(t *testing.T) {
+	t.Parallel()
+	if _, err := RewriteSimpleIndex([]byte("<html></html>"), "", "requests"); err == nil {
+		t.Errorf("expected error for empty namespace")
+	}
+	if _, err := RewriteSimpleIndex([]byte("<html></html>"), "myns", ""); err == nil {
+		t.Errorf("expected error for empty pkg")
+	}
+}
+
+func TestVersionMetadata_FindFile(t *testing.T) {
+	t.Parallel()
+	meta := &VersionMetadata{
+		Files: []FileMetadata{
+			{Filename: "requests-2.31.0-py3-none-any.whl", URL: "u1"},
+			{Filename: "requests-2.31.0.tar.gz", URL: "u2"},
+		},
+	}
+	tests := []struct {
+		name     string
+		filename string
+		want     FileMetadata
+		wantOK   bool
+	}{
+		{
+			name:     "wheel hit",
+			filename: "requests-2.31.0-py3-none-any.whl",
+			want:     meta.Files[0],
+			wantOK:   true,
+		},
+		{
+			name:     "sdist hit",
+			filename: "requests-2.31.0.tar.gz",
+			want:     meta.Files[1],
+			wantOK:   true,
+		},
+		{
+			name:     "miss",
+			filename: "requests-2.31.0.zip",
+			wantOK:   false,
+		},
+		{
+			name:     "case-sensitive miss",
+			filename: "Requests-2.31.0-py3-none-any.whl",
+			wantOK:   false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := meta.FindFile(tc.filename)
+			if ok != tc.wantOK {
+				t.Fatalf("FindFile(%q) ok=%v, want %v", tc.filename, ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("FindFile(%q) mismatch (-want +got):\n%s", tc.filename, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Per-format handlers serving a proxy namespace need to read Spec.Mode
and Spec.Proxy on every request without paying a second Store.Get.
Extend cachedPolicy to hold the raw spec alongside the compiled
authorizer (identical lifetime, identical TTL, identical mutation
hook), then expose ScopedRegistry.Spec(ctx) that reuses the same
singleflight + cache path authorizerFor walks.

Spec lookup does not authorize: dispatch happens before the actual
read/write op runs, and the wrapper still authorizes the downstream
AddFile/ReadFile/etc. so the dispatch primitive does not become an
auth bypass.

Refactors authorizerFor to delegate through the new specFor so there
is exactly one place that talks to the store.