### PR TITLE
Add Maven proxy mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
           fi
 
   # client-integration runs the per-format real-client tests: pip /
-  # twine / mvn driving an ocifactory subprocess against a zot
+  # twine / mvn / npm driving an ocifactory subprocess against a zot
   # registry started by testcontainers-go.
   #
   # The shared go-test job above runs the same tests but skips them

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,16 +217,33 @@ jobs:
       - name: 'Install maven'
         run: 'sudo apt-get update && sudo apt-get install -y --no-install-recommends maven'
 
-      - name: 'Run client integration tests'
+      - name: 'Run Python client integration test'
         # -tags=integration compiles the integration_test.go files
-        # the shared go-test job skips. The shared job runs the
-        # rest of the suite under the same Go version so we don't
-        # need to repeat it here.
+        # the shared go-test job skips. The -run filter keeps each
+        # step focused on one format's real-client test so failures
+        # point at the artifact format that broke.
         run: |
           go test -race -count=1 \
             -tags=integration \
             -timeout=10m \
             -v \
-            ./pkg/handler/python/... \
-            ./pkg/handler/maven/... \
+            -run '^TestPythonIntegration_RealClients$' \
+            ./pkg/handler/python/...
+
+      - name: 'Run Maven client integration test'
+        run: |
+          go test -race -count=1 \
+            -tags=integration \
+            -timeout=10m \
+            -v \
+            -run '^TestMavenIntegration_RealClients$' \
+            ./pkg/handler/maven/...
+
+      - name: 'Run npm client integration test'
+        run: |
+          go test -race -count=1 \
+            -tags=integration \
+            -timeout=10m \
+            -v \
+            -run '^TestNpmIntegration_RealClients$' \
             ./pkg/handler/npm/...

--- a/.github/workflows/live-upstream.yml
+++ b/.github/workflows/live-upstream.yml
@@ -52,6 +52,9 @@ jobs:
           java-version: '21'
           cache: 'maven'
 
+      - name: 'Install maven'
+        run: 'sudo apt-get update && sudo apt-get install -y --no-install-recommends maven'
+
       - name: 'Run live PyPI proxy integration test'
         # Distinct build tags from the hermetic `integration` suite.
         # The -run filter keeps this workflow focused on the live

--- a/.github/workflows/live-upstream.yml
+++ b/.github/workflows/live-upstream.yml
@@ -46,15 +46,6 @@ jobs:
         with:
           node-version: '22'
 
-      - uses: 'actions/setup-java@v4' # ratchet:exclude
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-          cache: 'maven'
-
-      - name: 'Install maven'
-        run: 'sudo apt-get update && sudo apt-get install -y --no-install-recommends maven'
-
       - name: 'Run live PyPI proxy integration test'
         # Distinct build tags from the hermetic `integration` suite.
         # The -run filter keeps this workflow focused on the live

--- a/.github/workflows/live-upstream.yml
+++ b/.github/workflows/live-upstream.yml
@@ -1,11 +1,10 @@
 name: 'live-upstream'
 
 # Non-hermetic integration tests: they talk to real upstream
-# registries (PyPI, npm today; Maven Central later) over the public
-# internet. Outages, rate limits, or response-shape changes on the
-# upstream side will turn this workflow red. When that happens, read
-# the failure and decide whether it's our regression or theirs before
-# reverting.
+# registries (PyPI, npm, Maven Central) over the public internet.
+# Outages, rate limits, or response-shape changes on the upstream side
+# will turn this workflow red. When that happens, read the failure and
+# decide whether it's our regression or theirs before reverting.
 #
 # Runs on every PR + manual dispatch. PR runs catch regressions in
 # pkg/proxy/* and proxy-mode handlers before merge.
@@ -47,6 +46,12 @@ jobs:
         with:
           node-version: '22'
 
+      - uses: 'actions/setup-java@v4' # ratchet:exclude
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+
       - name: 'Run live upstream integration tests'
         # Distinct build tags from the hermetic `integration` suite.
         # Keep all live upstream packages in this single invocation so
@@ -55,8 +60,9 @@ jobs:
         # testcontainers.
         run: |
           go test -race -count=1 \
-            -tags=pypiupstream,npmupstream \
+            -tags=pypiupstream,npmupstream,mavenupstream \
             -timeout=10m \
             -v \
             ./pkg/handler/python/... \
-            ./pkg/handler/npm/...
+            ./pkg/handler/npm/... \
+            ./pkg/handler/maven/...

--- a/.github/workflows/live-upstream.yml
+++ b/.github/workflows/live-upstream.yml
@@ -52,17 +52,34 @@ jobs:
           java-version: '21'
           cache: 'maven'
 
-      - name: 'Run live upstream integration tests'
+      - name: 'Run live PyPI proxy integration test'
         # Distinct build tags from the hermetic `integration` suite.
-        # Keep all live upstream packages in this single invocation so
-        # one PR check always exercises the full non-hermetic surface.
+        # The -run filter keeps this workflow focused on the live
+        # proxy test instead of re-running package unit tests.
         # ubuntu-latest ships Docker; the harness spins up zot via
         # testcontainers.
         run: |
           go test -race -count=1 \
-            -tags=pypiupstream,npmupstream,mavenupstream \
+            -tags=pypiupstream \
             -timeout=10m \
             -v \
-            ./pkg/handler/python/... \
-            ./pkg/handler/npm/... \
+            -run '^TestPythonIntegration_LivePypiProxy$' \
+            ./pkg/handler/python/...
+
+      - name: 'Run live npm proxy integration test'
+        run: |
+          go test -race -count=1 \
+            -tags=npmupstream \
+            -timeout=10m \
+            -v \
+            -run '^TestNpmIntegration_LiveRegistryProxy$' \
+            ./pkg/handler/npm/...
+
+      - name: 'Run live Maven proxy integration test'
+        run: |
+          go test -race -count=1 \
+            -tags=mavenupstream \
+            -timeout=10m \
+            -v \
+            -run '^TestMavenIntegration_LiveCentralProxy$' \
             ./pkg/handler/maven/...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Design pillars (in priority order):
 | `pkg/handler/python` — PEP 503 simple index, twine upload, pip download, per-package simple-index cache | Done, tested (incl. real-client integration tests). Operator docs: [`docs/repos/python.md`](docs/repos/python.md). |
 | `pkg/proxy/python` + python proxy mode (registry hit → filter → PyPI JSON metadata → file fetch → tee to OCI; pull-through indexes with stale-OK + synthesis fallback; uploads → 405) | Done, tested. Wired into `pkg/handler/python` for namespaces with `mode: proxy`. Operator docs: [`docs/repos/python.md`](docs/repos/python.md#proxy-mode-pull-through-pypi). |
 | `pkg/handler/maven` — Maven 2 layout (releases, snapshots, metadata, archetype catalog), checksum verification, snapshot-always-overwrite | Done, tested (incl. real-client integration tests). Operator docs: [`docs/repos/maven.md`](docs/repos/maven.md). |
+| `pkg/proxy/maven` + maven proxy mode (registry hit → filter → Maven metadata fetch → file fetch → tee to OCI; live metadata passthrough; writes → 405) | Done, tested. Wired into `pkg/handler/maven` for namespaces with `mode: proxy`. Operator docs: [`docs/repos/maven.md`](docs/repos/maven.md#proxy-mode-pull-through-maven). |
 | `pkg/handler/npm` — npm registry HTTP protocol (`npm publish`, `npm install`, `npm dist-tag add\|ls`), scoped + unscoped packages | Done, tested (incl. real-client integration tests). Operator docs: [`docs/repos/npm.md`](docs/repos/npm.md). |
 | `pkg/proxy/npm` + npm proxy mode (registry hit → filter → packument fetch/rewrite/cache → tarball fetch → tee to OCI; stale-OK + synthesis fallback; writes → 405) | Done, tested. Wired into `pkg/handler/npm` for namespaces with `mode: proxy`. Operator docs: [`docs/repos/npm.md`](docs/repos/npm.md#proxy-mode-pull-through-npm). |
 | `pkg/handler` — `Server`, `Logger`, `MetricsMiddleware`, `ObservabilityHandler` (intercepts `/healthz` / `/readyz` / `/metrics` before format mux) | Done |
@@ -42,7 +43,7 @@ Design pillars (in priority order):
 | `internal/version` — build-time version stamping via `-ldflags="-X .../internal/version.Version=..."`, fallbacks to `runtime/debug.ReadBuildInfo()` for dev builds | Done. `--version` surfaces it; `/readyz` includes it in the JSON body. |
 | Go module proxy support | Not started |
 | Debian/apt support | Not started |
-| Pull-through proxy / caching | Python and npm done; Maven/Go/apt and cross-format hardening remain Phase 4 work. |
+| Pull-through proxy / caching | Python, npm, and Maven done; Go/apt and cross-format hardening remain Phase 4 work. |
 | Vulnerability scanning | Not started |
 | Authorization extensibility — multiple backends (OPA / Cedar / Casbin) | Pluggable via `namespace.AuthzFactory`; only the matcher-based built-in ships in-tree. |
 | Cloud Run / Cloudflare deployment guides | Not started |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ Design pillars (in priority order):
 | Cloud Run / Cloudflare deployment guides | Not started |
 | Structured request logging | Not started (debug-level request log via `pkg/handler.Loggeer` is present) |
 | Rate limiting | Not started |
-| CI: lint, test, build, image publish | `go-test` from `abcxyz/pkg`; `oidc-e2e` job mints a real GitHub OIDC token and exercises the auth chain against `--repo-type=echo`; `client-integration` job runs the `-tags=integration` real-client tests (`twine`, `mvn`, `npm`). A separate `live-upstream` workflow runs one combined `-tags=pypiupstream,npmupstream` job against real PyPI / npm on every PR (intentionally non-hermetic; upstream outages will turn it red). Image publish runs on the release workflow, not per-PR. |
+| CI: lint, test, build, image publish | `go-test` from `abcxyz/pkg`; `oidc-e2e` job mints a real GitHub OIDC token and exercises the auth chain against `--repo-type=echo`; `client-integration` runs separate Python / Maven / npm steps for the `-tags=integration` real-client tests (`twine`, `mvn`, `npm`). A separate `live-upstream` workflow runs separate Python / Maven / npm proxy steps against real PyPI / Maven Central / npm on every PR (intentionally non-hermetic; upstream outages will turn it red). Image publish runs on the release workflow, not per-PR. |
 
 ## Architecture (read this before changing things)
 
@@ -231,6 +231,10 @@ These are non-negotiable. Apply them to every test in the repo:
    ```
    Don't compare field-by-field with `==` or `reflect.DeepEqual` when `cmp.Diff` will work — the diff output is what makes failures debuggable. The argument order is `(want, got)` so the diff legend reads correctly.
 5. **Fakes, not mocks.** No `gomock`, no `testify/mock`, no codegen mock libraries. Write a small fake of the interface in a `_test.go` file (or `pkg/<x>/fake.go` if reused across packages). For handler tests, don't mock `handler.Registry` — exercise the real `pkg/oci` code on top of the in-memory backend in `pkg/oci/fake.go`, so the layers are tested together.
+
+### CI integration workflow rules
+
+- Keep GitHub Actions integration jobs split by artifact format when a job can fail for Python, Maven, npm, or future repo types independently. `client-integration` should have one step per real-client test with an exact `-run` filter, and `live-upstream` should have one step per live proxy upstream test with the format-specific build tag. This makes CI failures point at the broken artifact format immediately instead of hiding it inside one combined `go test` invocation.
 
 ## Adding a new repo type — checklist
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -100,8 +100,8 @@ scoped-token issuance.
 
 Turn ocifactory into a caching mirror in front of upstream registries.
 
-- [ ] Per-format upstream client (npm registry, PyPI JSON API, Maven Central,
-  `proxy.golang.org`, Debian mirrors).
+- [ ] Per-format upstream client (npm registry, PyPI JSON API, and Maven
+  Central are done; `proxy.golang.org` and Debian mirrors remain).
 - [ ] Cache semantics:
   - Immutable artifacts (specific versions): cache forever.
   - Mutable indexes (npm package doc, PyPI simple index): TTL.

--- a/docs/repos/maven.md
+++ b/docs/repos/maven.md
@@ -158,12 +158,17 @@ What changes on the wire:
 - **Writes** (`PUT` / `POST`) return `405 Method Not Allowed` on proxy
   namespaces. Publish to a hosted namespace when ocifactory should be
   the source of truth.
+- **Archetype catalogs** (`/archetype-catalog.xml`) are not pulled
+  through from upstream in proxy mode yet. Reads only check the local
+  OCI cache, and writes return `405 Method Not Allowed`.
 
 Degraded operation is intentionally simpler than PyPI/npm: upstream
-metadata errors return `503 Service Unavailable`, and file fetch errors
-return `404` for upstream not found or `502 Bad Gateway` for malformed /
-unavailable upstream responses. There is a short in-memory negative
-cache for repeated file 404s, but no stale metadata fallback in v1.
+metadata returns `404 Not Found` when upstream has no metadata, `502 Bad
+Gateway` when the metadata is malformed, and `503 Service Unavailable`
+when upstream cannot be reached. File fetch errors return `404` for
+upstream not found or `502 Bad Gateway` for malformed, unavailable, or
+oversized upstream responses. There is a short in-memory negative cache
+for repeated file 404s, but no stale metadata fallback in v1.
 
 Filters use Maven package refs in `groupId:artifactId` form:
 
@@ -183,7 +188,10 @@ The filter chain is the same one documented in
 [`docs/proxy/filter-policy.md`](../proxy/filter-policy.md): name
 allowlist / denylist filters run before any upstream call, and the
 publish-time `delay` filter runs after `maven-metadata.xml` is fetched
-using `<versioning><lastUpdated>` as Maven's upload-time proxy.
+using artifact-level `<versioning><lastUpdated>` as Maven's upload-time
+proxy. Maven metadata does not carry per-version upload times; if
+`<lastUpdated>` is missing or unparsable, ocifactory fails closed and
+does not fetch the artifact.
 
 ## URL layout
 

--- a/docs/repos/maven.md
+++ b/docs/repos/maven.md
@@ -117,6 +117,74 @@ And in `pom.xml`:
 recognises; see [`docs/auth.md`](../auth.md#how-clients-send-credentials).
 The `password` is an OIDC ID token — there is no static-password path.
 
+## Proxy mode (pull-through Maven)
+
+Set the namespace's `mode` to `"proxy"` and point `proxy.upstream` at
+the Maven 2 repository you want to mirror. For Maven Central, use
+`https://repo.maven.apache.org/maven2`:
+
+```bash
+curl -X PUT https://ocifactory-admin.your-domain/admin/v1/namespaces/maven-central \
+  -H 'content-type: application/json' \
+  -d '{"mode":"proxy",
+       "proxy":{"upstream":"https://repo.maven.apache.org/maven2"},
+       "policy":{"readers":[{"issuer":"https://accounts.google.com"}]}}'
+```
+
+Point Maven at the proxy namespace exactly like a hosted namespace:
+
+```xml
+<repository>
+  <id>ocifactory-maven-central</id>
+  <url>https://ocifactory.your-domain/maven-central/maven2/</url>
+</repository>
+```
+
+What changes on the wire:
+
+- **Artifact metadata** (`/{namespace}/maven2/<group>/<artifact>/maven-metadata.xml`)
+  and **snapshot-version metadata**
+  (`/{namespace}/maven2/<group>/<artifact>/<version>-SNAPSHOT/maven-metadata.xml`)
+  are always fetched live from upstream and served byte-for-byte. Maven
+  metadata is small and contains no absolute URLs, so ocifactory does
+  not use the OCI index cache for Maven.
+- **Artifact files** (`.jar`, `.pom`, sources, javadoc, and checksum
+  siblings such as `.sha1` / `.md5`) check OCI first. On a miss,
+  ocifactory runs the namespace's filter chain, fetches upstream
+  metadata to confirm the version and get `<lastUpdated>` for delay
+  filters, streams the file from upstream to the client, and tees the
+  same bytes into OCI. The second request for the same file serves from
+  the OCI cache.
+- **Writes** (`PUT` / `POST`) return `405 Method Not Allowed` on proxy
+  namespaces. Publish to a hosted namespace when ocifactory should be
+  the source of truth.
+
+Degraded operation is intentionally simpler than PyPI/npm: upstream
+metadata errors return `503 Service Unavailable`, and file fetch errors
+return `404` for upstream not found or `502 Bad Gateway` for malformed /
+unavailable upstream responses. There is a short in-memory negative
+cache for repeated file 404s, but no stale metadata fallback in v1.
+
+Filters use Maven package refs in `groupId:artifactId` form:
+
+```json
+{
+  "mode": "proxy",
+  "proxy": {
+    "upstream": "https://repo.maven.apache.org/maven2",
+    "filters": [
+      {"kind": "deny", "patterns": ["com.example.bad:*"]}
+    ]
+  }
+}
+```
+
+The filter chain is the same one documented in
+[`docs/proxy/filter-policy.md`](../proxy/filter-policy.md): name
+allowlist / denylist filters run before any upstream call, and the
+publish-time `delay` filter runs after `maven-metadata.xml` is fetched
+using `<versioning><lastUpdated>` as Maven's upload-time proxy.
+
 ## URL layout
 
 Every route lives under `/{namespace}/maven2/...`. The `maven2/`
@@ -362,8 +430,10 @@ are documented in [`docs/auth.md`](../auth.md) and
   generating the indirection will not get it.
 - **No staging / promotion workflow.** Every deploy is final. There is
   no "stage to a sandbox repo, then promote to releases" feature.
-- **No pull-through caching of Maven Central.** Tracked under Phase 4
-  of [`docs/ROADMAP.md`](../ROADMAP.md).
+- **Proxy mode has live metadata only.** `maven-metadata.xml` is
+  fetched from upstream on every proxy metadata request. If upstream is
+  unavailable, ocifactory returns `503` rather than serving stale or
+  synthesizing Maven metadata.
 - **`--allow-overwrite=true` loosens immutability for every release
   file type.** Snapshot versions are always overwritable by design,
   independent of the flag. Operators who want immutable release jars

--- a/pkg/commands/serve.go
+++ b/pkg/commands/serve.go
@@ -392,9 +392,11 @@ func runServe(ctx context.Context, cfg *serveConfig) error {
 			return fmt.Errorf("failed to create namespace registry: %w", err)
 		}
 		nsReg := namespace.NewRegistry(r, namespace.NewStore(storeReg))
+		negCache := indexcache.NewNegativeCache()
 		mh, err := maven.NewHandler(nsReg,
 			maven.WithAuthMiddleware(authMW),
 			maven.WithMaxUploadBytes(cfg.MavenMaxUploadBytes),
+			maven.WithProxyNegativeCache(negCache),
 		)
 		if err != nil {
 			return fmt.Errorf("failed to create maven handler: %w", err)

--- a/pkg/handler/maven/handler.go
+++ b/pkg/handler/maven/handler.go
@@ -133,15 +133,26 @@ func (h *Handler) Mux() http.Handler {
 	nsr.HandleFunc("/archetype-catalog.xml", h.handleArchetypeCatalog).Methods(readMethods...).Name("read")
 	nsr.HandleFunc("/archetype-catalog.xml", h.handleArchetypeCatalog).Methods(writeMethods...).Name("write")
 
-	// 2. Snapshot Metadata (e.g., group/artifact/1.0-SNAPSHOT/maven-metadata.xml)
+	// 2. Metadata checksum sidecars. These must be registered before
+	// the metadata and generic artifact routes so maven-metadata.xml.sha1
+	// is owned by the metadata object, not by a fake artifact version.
+	for _, ext := range []string{"md5", "sha1", "sha256", "sha512"} {
+		filename := "maven-metadata.xml." + ext
+		nsr.HandleFunc("/{repoParts:.+}/{versionSnapshot:.+-SNAPSHOT}/"+filename, h.handleSnapshotMetadataSidecar).Methods(readMethods...).Name("read")
+		nsr.HandleFunc("/{repoParts:.+}/{versionSnapshot:.+-SNAPSHOT}/"+filename, h.handleSnapshotMetadataSidecar).Methods(writeMethods...).Name("write")
+		nsr.HandleFunc("/{repoParts:.+}/"+filename, h.handleArtifactMetadataSidecar).Methods(readMethods...).Name("read")
+		nsr.HandleFunc("/{repoParts:.+}/"+filename, h.handleArtifactMetadataSidecar).Methods(writeMethods...).Name("write")
+	}
+
+	// 3. Snapshot Metadata (e.g., group/artifact/1.0-SNAPSHOT/maven-metadata.xml)
 	nsr.HandleFunc("/{repoParts:.+}/{versionSnapshot:.+-SNAPSHOT}/maven-metadata.xml", h.handleSnapshotMetadata).Methods(readMethods...).Name("read")
 	nsr.HandleFunc("/{repoParts:.+}/{versionSnapshot:.+-SNAPSHOT}/maven-metadata.xml", h.handleSnapshotMetadata).Methods(writeMethods...).Name("write")
 
-	// 3. Artifact Metadata (release; must be registered after snapshot).
+	// 4. Artifact Metadata (release; must be registered after snapshot).
 	nsr.HandleFunc("/{repoParts:.+}/maven-metadata.xml", h.handleArtifactMetadata).Methods(readMethods...).Name("read")
 	nsr.HandleFunc("/{repoParts:.+}/maven-metadata.xml", h.handleArtifactMetadata).Methods(writeMethods...).Name("write")
 
-	// 4. Regular Artifact Files. Most general; must be last.
+	// 5. Regular Artifact Files. Most general; must be last.
 	nsr.HandleFunc("/{repoParts:.+}/{version:.+}/{filename:.+}", h.handleRegularArtifact).Methods(readMethods...).Name("read")
 	nsr.HandleFunc("/{repoParts:.+}/{version:.+}/{filename:.+}", h.handleRegularArtifact).Methods(writeMethods...).Name("write")
 
@@ -216,6 +227,42 @@ func (h *Handler) handleSnapshotMetadata(w http.ResponseWriter, req *http.Reques
 	}
 }
 
+func (h *Handler) handleSnapshotMetadataSidecar(w http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	repoParts := vars["repoParts"]
+	versionSnapshot := vars["versionSnapshot"]
+	filename := path.Base(req.URL.Path)
+
+	if err := validatePath(repoParts, versionSnapshot, filename); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	scoped := h.scopedFor(req)
+	f := &oci.RepoFile{
+		OwningRepo:     repoParts,
+		OwningTag:      versionSnapshot + "-metadata",
+		Name:           filename,
+		MediaType:      detectMediaType(filename),
+		AllowOverwrite: true,
+	}
+	if spec, isProxy, ok := h.dispatchProxy(w, req, scoped); !ok {
+		return
+	} else if isProxy {
+		if req.Method == http.MethodPut || req.Method == http.MethodPost {
+			http.Error(w, "uploads disabled on proxy namespaces", http.StatusMethodNotAllowed)
+			return
+		}
+		h.handleMetadataSidecarProxy(w, req, scoped, spec, f, repoParts+"/"+versionSnapshot)
+		return
+	}
+	if req.Method == http.MethodPut || req.Method == http.MethodPost {
+		h.handlePut(w, req, scoped, f)
+	} else {
+		h.handleGet(w, req, scoped, f)
+	}
+}
+
 // handleArtifactMetadata handles requests for non-snapshot maven-metadata.xml files.
 func (h *Handler) handleArtifactMetadata(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
@@ -246,6 +293,40 @@ func (h *Handler) handleArtifactMetadata(w http.ResponseWriter, req *http.Reques
 	if req.Method == http.MethodPut || req.Method == http.MethodPost {
 		h.handlePut(w, req, scoped, f)
 	} else { // GET, HEAD
+		h.handleGet(w, req, scoped, f)
+	}
+}
+
+func (h *Handler) handleArtifactMetadataSidecar(w http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	repoParts := vars["repoParts"]
+	filename := path.Base(req.URL.Path)
+
+	if err := validatePath(repoParts, "", filename); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	scoped := h.scopedFor(req)
+	f := &oci.RepoFile{
+		OwningRepo: repoParts,
+		OwningTag:  "metadata",
+		Name:       filename,
+		MediaType:  detectMediaType(filename),
+	}
+	if spec, isProxy, ok := h.dispatchProxy(w, req, scoped); !ok {
+		return
+	} else if isProxy {
+		if req.Method == http.MethodPut || req.Method == http.MethodPost {
+			http.Error(w, "uploads disabled on proxy namespaces", http.StatusMethodNotAllowed)
+			return
+		}
+		h.handleMetadataSidecarProxy(w, req, scoped, spec, f, repoParts)
+		return
+	}
+	if req.Method == http.MethodPut || req.Method == http.MethodPost {
+		h.handlePut(w, req, scoped, f)
+	} else {
 		h.handleGet(w, req, scoped, f)
 	}
 }

--- a/pkg/handler/maven/handler.go
+++ b/pkg/handler/maven/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/yolocs/ocifactory/pkg/logging"
 	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
+	"github.com/yolocs/ocifactory/pkg/proxy/indexcache"
 	"oras.land/oras-go/v2/errdef"
 )
 
@@ -57,6 +58,7 @@ type Handler struct {
 	registry       *namespace.Registry
 	authMW         func(http.Handler) http.Handler
 	maxUploadBytes int64
+	proxy          *proxyState
 }
 
 // Option configures optional Handler behaviour.
@@ -65,6 +67,8 @@ type Option func(*handlerConfig)
 type handlerConfig struct {
 	authMW         func(http.Handler) http.Handler
 	maxUploadBytes int64
+	fetcherFactory FetcherFactory
+	negCache       *indexcache.NegativeCache
 }
 
 // WithAuthMiddleware installs an authentication middleware on
@@ -98,11 +102,13 @@ func NewHandler(registry *namespace.Registry, opts ...Option) (*Handler, error) 
 	for _, opt := range opts {
 		opt(&cfg)
 	}
-	return &Handler{
+	h := &Handler{
 		registry:       registry,
 		authMW:         cfg.authMW,
 		maxUploadBytes: cfg.maxUploadBytes,
-	}, nil
+	}
+	h.proxy = newProxyState(cfg)
+	return h, nil
 }
 
 // Mux returns the maven handler's router. Every route lives under
@@ -151,6 +157,12 @@ func (h *Handler) scopedFor(req *http.Request) *namespace.ScopedRegistry {
 // handleArchetypeCatalog handles requests for archetype-catalog.xml.
 func (h *Handler) handleArchetypeCatalog(w http.ResponseWriter, req *http.Request) {
 	scoped := h.scopedFor(req)
+	if _, isProxy, ok := h.dispatchProxy(w, req, scoped); !ok {
+		return
+	} else if isProxy && (req.Method == http.MethodPut || req.Method == http.MethodPost) {
+		http.Error(w, "uploads disabled on proxy namespaces", http.StatusMethodNotAllowed)
+		return
+	}
 	f := &oci.RepoFile{
 		OwningRepo: "archetype",
 		OwningTag:  "latest",
@@ -187,6 +199,16 @@ func (h *Handler) handleSnapshotMetadata(w http.ResponseWriter, req *http.Reques
 		// snapshot doesn't 409 on the metadata write.
 		AllowOverwrite: true,
 	}
+	if spec, isProxy, ok := h.dispatchProxy(w, req, scoped); !ok {
+		return
+	} else if isProxy {
+		if req.Method == http.MethodPut || req.Method == http.MethodPost {
+			http.Error(w, "uploads disabled on proxy namespaces", http.StatusMethodNotAllowed)
+			return
+		}
+		h.handleMetadataProxy(w, req, scoped, spec, repoParts+"/"+versionSnapshot)
+		return
+	}
 	if req.Method == http.MethodPut || req.Method == http.MethodPost {
 		h.handlePut(w, req, scoped, f)
 	} else { // GET, HEAD
@@ -210,6 +232,16 @@ func (h *Handler) handleArtifactMetadata(w http.ResponseWriter, req *http.Reques
 		OwningTag:  "metadata", // For release artifact or version metadata
 		Name:       "maven-metadata.xml",
 		MediaType:  "text/xml",
+	}
+	if spec, isProxy, ok := h.dispatchProxy(w, req, scoped); !ok {
+		return
+	} else if isProxy {
+		if req.Method == http.MethodPut || req.Method == http.MethodPost {
+			http.Error(w, "uploads disabled on proxy namespaces", http.StatusMethodNotAllowed)
+			return
+		}
+		h.handleMetadataProxy(w, req, scoped, spec, repoParts)
+		return
 	}
 	if req.Method == http.MethodPut || req.Method == http.MethodPost {
 		h.handlePut(w, req, scoped, f)
@@ -243,6 +275,16 @@ func (h *Handler) handleRegularArtifact(w http.ResponseWriter, req *http.Request
 		// rewrites. Release versions stay immutable and respect the
 		// registry-level --allow-overwrite default.
 		AllowOverwrite: isSnapshotVersion(version),
+	}
+	if spec, isProxy, ok := h.dispatchProxy(w, req, scoped); !ok {
+		return
+	} else if isProxy {
+		if req.Method == http.MethodPut || req.Method == http.MethodPost {
+			http.Error(w, "uploads disabled on proxy namespaces", http.StatusMethodNotAllowed)
+			return
+		}
+		h.handleFileGetProxy(w, req, scoped, spec, f)
+		return
 	}
 	if req.Method == http.MethodPut || req.Method == http.MethodPost {
 		h.handlePut(w, req, scoped, f)

--- a/pkg/handler/maven/handler_test.go
+++ b/pkg/handler/maven/handler_test.go
@@ -224,6 +224,20 @@ func TestHandleGet(t *testing.T) {
 			wantBody:   "<metadata></metadata>",
 		},
 		{
+			name: "get snapshot metadata checksum",
+			setupFile: &oci.RepoFile{
+				OwningRepo: testNS + "/com/example/project",
+				OwningTag:  "1.0-SNAPSHOT-metadata",
+				Name:       "maven-metadata.xml.sha1",
+				MediaType:  "text/plain",
+			},
+			setupData:  "snapshot-sha1",
+			path:       nsPath("/com/example/project/1.0-SNAPSHOT/maven-metadata.xml.sha1"),
+			method:     http.MethodGet,
+			wantStatus: http.StatusOK,
+			wantBody:   "snapshot-sha1",
+		},
+		{
 			name: "get release metadata",
 			setupFile: &oci.RepoFile{
 				OwningRepo: testNS + "/com/example/project",
@@ -236,6 +250,20 @@ func TestHandleGet(t *testing.T) {
 			method:     http.MethodGet,
 			wantStatus: http.StatusOK,
 			wantBody:   "<metadata></metadata>",
+		},
+		{
+			name: "get release metadata checksum",
+			setupFile: &oci.RepoFile{
+				OwningRepo: testNS + "/com/example/project",
+				OwningTag:  "metadata",
+				Name:       "maven-metadata.xml.sha1",
+				MediaType:  "text/plain",
+			},
+			setupData:  "release-sha1",
+			path:       nsPath("/com/example/project/maven-metadata.xml.sha1"),
+			method:     http.MethodGet,
+			wantStatus: http.StatusOK,
+			wantBody:   "release-sha1",
 		},
 	}
 

--- a/pkg/handler/maven/maven_upstream_integration_test.go
+++ b/pkg/handler/maven/maven_upstream_integration_test.go
@@ -136,7 +136,7 @@ func seedMavenProxyNamespace(t *testing.T, zotURL *url.URL, backendRepo, name, u
 
 func runLiveMavenGet(t *testing.T, repoURL, localRepo, coordinate string) {
 	t.Helper()
-	settings := liveMavenSettings(t, localRepo)
+	settings := liveMavenSettings(t, repoURL, localRepo)
 	cmd := exec.Command("mvn",
 		"-B",
 		"-s", settings,
@@ -153,13 +153,20 @@ func runLiveMavenGet(t *testing.T, repoURL, localRepo, coordinate string) {
 	}
 }
 
-func liveMavenSettings(t *testing.T, localRepo string) string {
+func liveMavenSettings(t *testing.T, repoURL, localRepo string) string {
 	t.Helper()
 	settings := fmt.Sprintf(`<settings>
   <localRepository>%s</localRepository>
   <interactiveMode>false</interactiveMode>
+  <mirrors>
+    <mirror>
+      <id>ocifactory-all</id>
+      <url>%s</url>
+      <mirrorOf>*</mirrorOf>
+    </mirror>
+  </mirrors>
 </settings>
-`, localRepo)
+`, localRepo, repoURL)
 	path := filepath.Join(t.TempDir(), "settings.xml")
 	if err := os.WriteFile(path, []byte(settings), 0o600); err != nil {
 		t.Fatalf("write settings.xml: %v", err)

--- a/pkg/handler/maven/maven_upstream_integration_test.go
+++ b/pkg/handler/maven/maven_upstream_integration_test.go
@@ -1,0 +1,185 @@
+//go:build mavenupstream
+
+// Real-Maven-Central integration test for the Maven proxy handler.
+// Gated behind a separate `mavenupstream` build tag (NOT `integration`)
+// because the test is intentionally non-hermetic: it talks to
+// https://repo.maven.apache.org/maven2 over the public internet. Maven
+// Central outages, rate limits, or response-shape changes will turn
+// this test red.
+//
+// Invoke via `go test -tags=mavenupstream ./pkg/handler/maven/...`.
+
+package maven_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/yolocs/ocifactory/pkg/auth/backend"
+	"github.com/yolocs/ocifactory/pkg/handler/integrationtest"
+	"github.com/yolocs/ocifactory/pkg/namespace"
+	"github.com/yolocs/ocifactory/pkg/oci"
+)
+
+// TestMavenIntegration_LiveCentralProxy proves Maven proxy mode works
+// end to end against real Maven Central: a real mvn dependency:get
+// through a real ocifactory subprocess fetches, caches, and re-serves
+// real Maven artifact bytes.
+//
+// Test artifact: org.slf4j:slf4j-api:1.7.36. Tiny, dependency-free
+// for our purposes when resolved with -Dtransitive=false, and stable.
+func TestMavenIntegration_LiveCentralProxy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping live-maven integration test in -short mode")
+	}
+	t.Parallel()
+
+	integrationtest.SkipIfMissing(t, "mvn", "java")
+
+	h := integrationtest.Start(t, "maven")
+	seedMavenProxyNamespace(t, h.ZotURL, h.BackendRepo, "maven-central", "https://repo.maven.apache.org/maven2")
+
+	const (
+		groupID    = "org.slf4j"
+		artifactID = "slf4j-api"
+		version    = "1.7.36"
+	)
+	repoURL := h.OcifactoryURL.String() + "/maven-central/maven2/"
+
+	t.Run("metadata_passthrough", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		defer cancel()
+		mdURL := repoURL + strings.ReplaceAll(groupID, ".", "/") + "/" + artifactID + "/maven-metadata.xml"
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, mdURL, nil)
+		if err != nil {
+			t.Fatalf("build metadata request: %v", err)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET metadata: %v", err)
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(io.LimitReader(resp.Body, 512*1024))
+		if err != nil {
+			t.Fatalf("read metadata: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("metadata status = %d, want 200; body:\n%s", resp.StatusCode, body)
+		}
+		text := string(body)
+		for _, want := range []string{
+			"<groupId>" + groupID + "</groupId>",
+			"<artifactId>" + artifactID + "</artifactId>",
+			"<version>" + version + "</version>",
+			"<lastUpdated>",
+		} {
+			if !strings.Contains(text, want) {
+				t.Errorf("metadata missing %q; body excerpt:\n%s", want, text)
+			}
+		}
+	})
+
+	t.Run("mvn_dependency_get_through_proxy", func(t *testing.T) {
+		t.Parallel()
+
+		coordinate := fmt.Sprintf("%s:%s:%s", groupID, artifactID, version)
+
+		localRepo := t.TempDir()
+		runLiveMavenGet(t, repoURL, localRepo, coordinate)
+		assertMavenArtifactCached(t, localRepo, groupID, artifactID, version)
+
+		// A second fresh local repo proves the cached artifact can be
+		// served back through OCI to a new Maven client invocation.
+		localRepo2 := t.TempDir()
+		runLiveMavenGet(t, repoURL, localRepo2, coordinate)
+		assertMavenArtifactCached(t, localRepo2, groupID, artifactID, version)
+	})
+}
+
+// seedMavenProxyNamespace writes a proxy-mode namespace into the OCI
+// backend the ocifactory subprocess reads from. Mirrors
+// integrationtest.seedDefaultNamespace but with Mode=proxy.
+func seedMavenProxyNamespace(t *testing.T, zotURL *url.URL, backendRepo, name, upstream string) {
+	t.Helper()
+	regURL := &url.URL{Scheme: zotURL.Scheme, Host: zotURL.Host, Path: "/" + backendRepo}
+	inner, err := oci.NewRegistry(regURL,
+		oci.WithBackendAuth(backend.Anonymous()),
+		oci.WithArtifactType(namespace.ArtifactType),
+	)
+	if err != nil {
+		t.Fatalf("oci.NewRegistry: %v", err)
+	}
+	store := namespace.NewStore(inner)
+	spec := namespace.Spec{
+		Mode:  namespace.ModeProxy,
+		Proxy: namespace.Proxy{Upstream: upstream},
+		Policy: namespace.Policy{
+			Readers: []namespace.SubjectMatcher{{Issuer: "anonymous"}},
+			Writers: []namespace.SubjectMatcher{{Issuer: "anonymous"}},
+		},
+	}
+	if err := store.Put(t.Context(), &namespace.Namespace{Name: name, Spec: spec}); err != nil {
+		t.Fatalf("seed proxy namespace %q: %v", name, err)
+	}
+}
+
+func runLiveMavenGet(t *testing.T, repoURL, localRepo, coordinate string) {
+	t.Helper()
+	settings := liveMavenSettings(t, localRepo)
+	cmd := exec.Command("mvn",
+		"-B",
+		"-s", settings,
+		"-Dmaven.repo.local="+localRepo,
+		"-DremoteRepositories=ocifactory::default::"+repoURL,
+		"-Dartifact="+coordinate,
+		"-Dtransitive=false",
+		"org.apache.maven.plugins:maven-dependency-plugin:3.6.1:get",
+	)
+	cmd.Env = append(os.Environ(), "HOME="+t.TempDir())
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("mvn dependency:get %s: %v\n%s", coordinate, err, out)
+	}
+}
+
+func liveMavenSettings(t *testing.T, localRepo string) string {
+	t.Helper()
+	settings := fmt.Sprintf(`<settings>
+  <localRepository>%s</localRepository>
+  <interactiveMode>false</interactiveMode>
+</settings>
+`, localRepo)
+	path := filepath.Join(t.TempDir(), "settings.xml")
+	if err := os.WriteFile(path, []byte(settings), 0o600); err != nil {
+		t.Fatalf("write settings.xml: %v", err)
+	}
+	return path
+}
+
+func assertMavenArtifactCached(t *testing.T, localRepo, groupID, artifactID, version string) {
+	t.Helper()
+	jarPath := filepath.Join(localRepo,
+		strings.ReplaceAll(groupID, ".", string(filepath.Separator)),
+		artifactID,
+		version,
+		fmt.Sprintf("%s-%s.jar", artifactID, version),
+	)
+	info, err := os.Stat(jarPath)
+	if err != nil {
+		t.Fatalf("stat resolved jar %s: %v", jarPath, err)
+	}
+	if info.Size() == 0 {
+		t.Fatalf("resolved jar %s is empty", jarPath)
+	}
+}

--- a/pkg/handler/maven/maven_upstream_integration_test.go
+++ b/pkg/handler/maven/maven_upstream_integration_test.go
@@ -136,6 +136,8 @@ func seedMavenProxyNamespace(t *testing.T, zotURL *url.URL, backendRepo, name, u
 
 func runLiveMavenGet(t *testing.T, repoURL, localRepo, coordinate string) {
 	t.Helper()
+	warmLiveMavenDependencyPlugin(t, localRepo)
+
 	settings := liveMavenSettings(t, repoURL, localRepo)
 	cmd := exec.Command("mvn",
 		"-B",
@@ -150,6 +152,20 @@ func runLiveMavenGet(t *testing.T, repoURL, localRepo, coordinate string) {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("mvn dependency:get %s: %v\n%s", coordinate, err, out)
+	}
+}
+
+func warmLiveMavenDependencyPlugin(t *testing.T, localRepo string) {
+	t.Helper()
+	cmd := exec.Command("mvn",
+		"-B",
+		"-Dmaven.repo.local="+localRepo,
+		"org.apache.maven.plugins:maven-dependency-plugin:3.6.1:help",
+	)
+	cmd.Env = append(os.Environ(), "HOME="+t.TempDir())
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("warm maven dependency plugin: %v\n%s", err, out)
 	}
 }
 

--- a/pkg/handler/maven/maven_upstream_integration_test.go
+++ b/pkg/handler/maven/maven_upstream_integration_test.go
@@ -13,37 +13,34 @@ package maven_test
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/yolocs/ocifactory/pkg/auth/backend"
 	"github.com/yolocs/ocifactory/pkg/handler/integrationtest"
+	mavenhandler "github.com/yolocs/ocifactory/pkg/handler/maven"
 	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
 )
 
 // TestMavenIntegration_LiveCentralProxy proves Maven proxy mode works
-// end to end against real Maven Central: a real mvn dependency:get
-// through a real ocifactory subprocess fetches, caches, and re-serves
-// real Maven artifact bytes.
+// end to end against real Maven Central: a real ocifactory subprocess
+// fetches, caches, and re-serves real Maven artifact bytes. Real Maven
+// client behaviour is covered by the hermetic `integration` test; this
+// live test intentionally keeps Maven Central traffic small and focused
+// on the proxy path.
 //
-// Test artifact: org.slf4j:slf4j-api:1.7.36. Tiny, dependency-free
-// for our purposes when resolved with -Dtransitive=false, and stable.
+// Test artifact: org.slf4j:slf4j-api:1.7.36. Tiny, stable, and widely
+// cached by Maven Central.
 func TestMavenIntegration_LiveCentralProxy(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping live-maven integration test in -short mode")
 	}
 	t.Parallel()
-
-	integrationtest.SkipIfMissing(t, "mvn", "java")
 
 	h := integrationtest.Start(t, "maven")
 	seedMavenProxyNamespace(t, h.ZotURL, h.BackendRepo, "maven-central", "https://repo.maven.apache.org/maven2")
@@ -90,21 +87,45 @@ func TestMavenIntegration_LiveCentralProxy(t *testing.T) {
 		}
 	})
 
-	t.Run("mvn_dependency_get_through_proxy", func(t *testing.T) {
+	t.Run("artifact_fetch_through_proxy", func(t *testing.T) {
 		t.Parallel()
 
-		coordinate := fmt.Sprintf("%s:%s:%s", groupID, artifactID, version)
+		artifactPath := strings.ReplaceAll(groupID, ".", "/") + "/" + artifactID + "/" + version + "/" + artifactID + "-" + version + ".jar"
+		artifactURL := repoURL + artifactPath
+		body := getLiveMavenURL(t, artifactURL, 2*1024*1024)
+		if len(body) == 0 {
+			t.Fatalf("artifact body from %s is empty", artifactURL)
+		}
+		assertMavenArtifactCached(t, h.ZotURL, h.BackendRepo, "maven-central", groupID, artifactID, version)
 
-		localRepo := t.TempDir()
-		runLiveMavenGet(t, repoURL, localRepo, coordinate)
-		assertMavenArtifactCached(t, localRepo, groupID, artifactID, version)
-
-		// A second fresh local repo proves the cached artifact can be
-		// served back through OCI to a new Maven client invocation.
-		localRepo2 := t.TempDir()
-		runLiveMavenGet(t, repoURL, localRepo2, coordinate)
-		assertMavenArtifactCached(t, localRepo2, groupID, artifactID, version)
+		body2 := getLiveMavenURL(t, artifactURL, 2*1024*1024)
+		if len(body2) != len(body) {
+			t.Fatalf("cached artifact size = %d, want %d", len(body2), len(body))
+		}
 	})
+}
+
+func getLiveMavenURL(t *testing.T, url string, limit int64) []byte {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, limit))
+	if err != nil {
+		t.Fatalf("read %s: %v", url, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s status = %d, want 200; body:\n%s", url, resp.StatusCode, body)
+	}
+	return body
 }
 
 // seedMavenProxyNamespace writes a proxy-mode namespace into the OCI
@@ -134,75 +155,31 @@ func seedMavenProxyNamespace(t *testing.T, zotURL *url.URL, backendRepo, name, u
 	}
 }
 
-func runLiveMavenGet(t *testing.T, repoURL, localRepo, coordinate string) {
+func assertMavenArtifactCached(t *testing.T, zotURL *url.URL, backendRepo, namespaceName, groupID, artifactID, version string) {
 	t.Helper()
-	warmLiveMavenDependencyPlugin(t, localRepo)
-
-	settings := liveMavenSettings(t, repoURL, localRepo)
-	cmd := exec.Command("mvn",
-		"-B",
-		"-s", settings,
-		"-Dmaven.repo.local="+localRepo,
-		"-DremoteRepositories=ocifactory::default::"+repoURL,
-		"-Dartifact="+coordinate,
-		"-Dtransitive=false",
-		"org.apache.maven.plugins:maven-dependency-plugin:3.6.1:get",
+	regURL := &url.URL{Scheme: zotURL.Scheme, Host: zotURL.Host, Path: "/" + backendRepo}
+	inner, err := oci.NewRegistry(regURL,
+		oci.WithBackendAuth(backend.Anonymous()),
+		oci.WithArtifactType(mavenhandler.ArtifactType),
 	)
-	cmd.Env = append(os.Environ(), "HOME="+t.TempDir())
-	out, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("mvn dependency:get %s: %v\n%s", coordinate, err, out)
+		t.Fatalf("oci.NewRegistry: %v", err)
 	}
-}
-
-func warmLiveMavenDependencyPlugin(t *testing.T, localRepo string) {
-	t.Helper()
-	cmd := exec.Command("mvn",
-		"-B",
-		"-Dmaven.repo.local="+localRepo,
-		"org.apache.maven.plugins:maven-dependency-plugin:3.6.1:help",
-	)
-	cmd.Env = append(os.Environ(), "HOME="+t.TempDir())
-	out, err := cmd.CombinedOutput()
+	f := &oci.RepoFile{
+		OwningRepo: namespaceName + "/" + strings.ReplaceAll(groupID, ".", "/") + "/" + artifactID,
+		OwningTag:  version,
+		Name:       artifactID + "-" + version + ".jar",
+		MediaType:  "application/java-archive",
+	}
+	desc, rc, err := inner.ReadFile(t.Context(), f)
 	if err != nil {
-		t.Fatalf("warm maven dependency plugin: %v\n%s", err, out)
+		t.Fatalf("read cached artifact from OCI: %v", err)
 	}
-}
-
-func liveMavenSettings(t *testing.T, repoURL, localRepo string) string {
-	t.Helper()
-	settings := fmt.Sprintf(`<settings>
-  <localRepository>%s</localRepository>
-  <interactiveMode>false</interactiveMode>
-  <mirrors>
-    <mirror>
-      <id>ocifactory-all</id>
-      <url>%s</url>
-      <mirrorOf>*</mirrorOf>
-    </mirror>
-  </mirrors>
-</settings>
-`, localRepo, repoURL)
-	path := filepath.Join(t.TempDir(), "settings.xml")
-	if err := os.WriteFile(path, []byte(settings), 0o600); err != nil {
-		t.Fatalf("write settings.xml: %v", err)
+	defer rc.Close()
+	if desc.File.Size == 0 {
+		t.Fatalf("cached artifact has zero size")
 	}
-	return path
-}
-
-func assertMavenArtifactCached(t *testing.T, localRepo, groupID, artifactID, version string) {
-	t.Helper()
-	jarPath := filepath.Join(localRepo,
-		strings.ReplaceAll(groupID, ".", string(filepath.Separator)),
-		artifactID,
-		version,
-		fmt.Sprintf("%s-%s.jar", artifactID, version),
-	)
-	info, err := os.Stat(jarPath)
-	if err != nil {
-		t.Fatalf("stat resolved jar %s: %v", jarPath, err)
-	}
-	if info.Size() == 0 {
-		t.Fatalf("resolved jar %s is empty", jarPath)
+	if _, err := io.Copy(io.Discard, rc); err != nil {
+		t.Fatalf("read cached artifact body: %v", err)
 	}
 }

--- a/pkg/handler/maven/proxy.go
+++ b/pkg/handler/maven/proxy.go
@@ -25,12 +25,15 @@ import (
 	proxymaven "github.com/yolocs/ocifactory/pkg/proxy/maven"
 )
 
+var errProxyBodyTooLarge = errors.New("maven proxy body exceeds size cap")
+
 // ProxyFetcher is the subset of [*pkg/proxy/maven.Fetcher] methods
 // the handler depends on. It exists so tests can inject a fake upstream
 // boundary; it is not an out-of-tree extension surface.
 type ProxyFetcher interface {
 	GetMetadata(ctx context.Context, repoPath string) (*proxymaven.MetadataResponse, error)
 	FetchFile(ctx context.Context, repoPath, version, filename string) (*proxymaven.FileResponse, error)
+	FetchPath(ctx context.Context, repoPath, filename string) (*proxymaven.FileResponse, error)
 }
 
 // FetcherFactory builds a [ProxyFetcher] for a namespace upstream URL.
@@ -128,6 +131,76 @@ func (h *Handler) handleMetadataProxy(w http.ResponseWriter, req *http.Request, 
 	writeProxyBytes(w, req, resp.Body, resp.ContentType)
 }
 
+func (h *Handler) handleMetadataSidecarProxy(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry, spec *namespace.Spec, f *oci.RepoFile, repoPath string) {
+	ctx := req.Context()
+
+	if h.tryServeFromRegistry(w, req, scoped, f) {
+		return
+	}
+	fetcher, err := h.proxy.fetcherFor(spec.Proxy.Upstream)
+	if err != nil {
+		handler.WriteError(ctx, w, http.StatusInternalServerError, err, "proxy fetcher unavailable")
+		return
+	}
+
+	key := scoped.Namespace() + "|" + f.OwningRepo + "|" + f.OwningTag + "|" + f.Name
+	isHead := req.Method == http.MethodHead
+	amLeader := false
+	var teeRef *tolerantWriter
+	resultV, err, _ := h.proxy.fileFlight.Do(key, func() (any, error) {
+		amLeader = true
+		if hit, hitErr := h.peekRegistry(ctx, scoped, f); hitErr == nil && hit {
+			return fileFlightResult{cached: true}, nil
+		}
+		fileResp, ferr := fetcher.FetchPath(ctx, repoPath, f.Name)
+		if ferr != nil {
+			return fileFlightResult{}, ferr
+		}
+		defer fileResp.Body.Close()
+
+		populated := &oci.RepoFile{
+			OwningRepo:     f.OwningRepo,
+			OwningTag:      f.OwningTag,
+			Name:           f.Name,
+			MediaType:      pickMediaType(f.Name, fileResp.ContentType),
+			Size:           fileResp.ContentLength,
+			AllowOverwrite: f.AllowOverwrite,
+		}
+		body, err := h.limitedProxyBody(fileResp.Body, fileResp.ContentLength)
+		if err != nil {
+			return fileFlightResult{}, err
+		}
+		if !isHead {
+			w.Header().Set("Content-Type", populated.MediaType)
+			if fileResp.ContentLength > 0 {
+				w.Header().Set("Content-Length", strconv.FormatInt(fileResp.ContentLength, 10))
+			}
+			teeRef = &tolerantWriter{w: w}
+			body = io.TeeReader(body, teeRef)
+		}
+		if _, addErr := scoped.AddCachedFile(ctx, populated, body); addErr != nil {
+			if errors.Is(addErr, oci.ErrAlreadyExists) {
+				return fileFlightResult{cached: true}, nil
+			}
+			return fileFlightResult{}, addErr
+		}
+		return fileFlightResult{streamed: true}, nil
+	})
+	if err != nil {
+		h.writeProxyFileError(w, req, err, amLeader, teeRef, packageRef(f.OwningRepo), f.OwningTag, f.Name)
+		return
+	}
+
+	result := resultV.(fileFlightResult)
+	if result.streamed && amLeader && !isHead {
+		return
+	}
+	if h.tryServeFromRegistry(w, req, scoped, f) {
+		return
+	}
+	handler.WriteError(ctx, w, http.StatusBadGateway, nil, "proxy fill reported success but cache miss on re-read")
+}
+
 func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry, spec *namespace.Spec, f *oci.RepoFile) {
 	ctx := req.Context()
 	logger := logging.FromContext(ctx)
@@ -188,6 +261,8 @@ func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, s
 			return fileFlightResult{}, fmt.Errorf("filter error: %w (kind=%s)", derr, filterKind(denyFilter))
 		} else if decision == filter.DecisionDeny {
 			return fileFlightResult{filterDeny: true, filterName: filterKind(denyFilter)}, nil
+		} else if decision == filter.DecisionNeedsMoreData {
+			return fileFlightResult{filterDeny: true, filterName: filterKind(denyFilter)}, nil
 		}
 
 		fileResp, ferr := fetcher.FetchFile(ctx, f.OwningRepo, version, filename)
@@ -195,6 +270,10 @@ func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, s
 			return fileFlightResult{}, ferr
 		}
 		defer fileResp.Body.Close()
+		body, berr := h.limitedProxyBody(fileResp.Body, fileResp.ContentLength)
+		if berr != nil {
+			return fileFlightResult{}, berr
+		}
 
 		populated := &oci.RepoFile{
 			OwningRepo: f.OwningRepo,
@@ -208,7 +287,6 @@ func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, s
 			// backend overwrites globally.
 			AllowOverwrite: false,
 		}
-		var body io.Reader = fileResp.Body
 		if !isHead {
 			w.Header().Set("Content-Type", populated.MediaType)
 			if fileResp.ContentLength > 0 {
@@ -241,6 +319,8 @@ func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, s
 			handler.WriteError(ctx, w, http.StatusBadGateway, err, "upstream malformed")
 		case errors.Is(err, proxy.ErrUpstreamUnavailable):
 			handler.WriteError(ctx, w, http.StatusBadGateway, err, "upstream unavailable")
+		case errors.Is(err, errProxyBodyTooLarge):
+			handler.WriteError(ctx, w, http.StatusBadGateway, err, "upstream body too large")
 		default:
 			if handler.WriteNamespaceError(w, err) {
 				return
@@ -287,6 +367,64 @@ type fileFlightResult struct {
 	cached     bool
 	filterDeny bool
 	filterName string
+}
+
+func (h *Handler) limitedProxyBody(r io.Reader, contentLength int64) (io.Reader, error) {
+	limit := h.maxUploadBytes
+	if limit <= 0 {
+		limit = DefaultMaxUploadBytes
+	}
+	if contentLength > limit {
+		return nil, fmt.Errorf("upstream content length %d exceeds %d-byte cap: %w", contentLength, limit, errProxyBodyTooLarge)
+	}
+	return &proxyLimitReader{r: r, remaining: limit}, nil
+}
+
+type proxyLimitReader struct {
+	r         io.Reader
+	remaining int64
+}
+
+func (r *proxyLimitReader) Read(p []byte) (int, error) {
+	if r.remaining <= 0 {
+		var one [1]byte
+		n, err := r.r.Read(one[:])
+		if n > 0 {
+			return 0, errProxyBodyTooLarge
+		}
+		return 0, err
+	}
+	if int64(len(p)) > r.remaining {
+		p = p[:int(r.remaining)]
+	}
+	n, err := r.r.Read(p)
+	r.remaining -= int64(n)
+	return n, err
+}
+
+func (h *Handler) writeProxyFileError(w http.ResponseWriter, req *http.Request, err error, amLeader bool, teeRef *tolerantWriter, pkg, version, filename string) {
+	ctx := req.Context()
+	logger := logging.FromContext(ctx)
+	if amLeader && teeRef != nil && teeRef.used {
+		logger.WarnContext(ctx, "maven proxy file fetch failed after response body started; suppressing error body",
+			"error", err, "package", pkg, "version", version, "filename", filename)
+		return
+	}
+	switch {
+	case errors.Is(err, proxy.ErrNotFound):
+		http.Error(w, "not found", http.StatusNotFound)
+	case errors.Is(err, proxy.ErrUpstreamMalformed):
+		handler.WriteError(ctx, w, http.StatusBadGateway, err, "upstream malformed")
+	case errors.Is(err, proxy.ErrUpstreamUnavailable):
+		handler.WriteError(ctx, w, http.StatusBadGateway, err, "upstream unavailable")
+	case errors.Is(err, errProxyBodyTooLarge):
+		handler.WriteError(ctx, w, http.StatusBadGateway, err, "upstream body too large")
+	default:
+		if handler.WriteNamespaceError(w, err) {
+			return
+		}
+		handler.WriteError(ctx, w, http.StatusBadGateway, err, "proxy file fetch failed")
+	}
 }
 
 func (h *Handler) peekRegistry(ctx context.Context, scoped *namespace.ScopedRegistry, f *oci.RepoFile) (bool, error) {

--- a/pkg/handler/maven/proxy.go
+++ b/pkg/handler/maven/proxy.go
@@ -1,0 +1,399 @@
+package maven
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+
+	"golang.org/x/sync/singleflight"
+	"oras.land/oras-go/v2/errdef"
+
+	"github.com/yolocs/ocifactory/pkg/auth"
+	"github.com/yolocs/ocifactory/pkg/handler"
+	"github.com/yolocs/ocifactory/pkg/logging"
+	"github.com/yolocs/ocifactory/pkg/namespace"
+	"github.com/yolocs/ocifactory/pkg/oci"
+	"github.com/yolocs/ocifactory/pkg/proxy"
+	"github.com/yolocs/ocifactory/pkg/proxy/filter"
+	"github.com/yolocs/ocifactory/pkg/proxy/indexcache"
+	proxymaven "github.com/yolocs/ocifactory/pkg/proxy/maven"
+)
+
+// ProxyFetcher is the subset of [*pkg/proxy/maven.Fetcher] methods
+// the handler depends on. It exists so tests can inject a fake upstream
+// boundary; it is not an out-of-tree extension surface.
+type ProxyFetcher interface {
+	GetMetadata(ctx context.Context, repoPath string) (*proxymaven.MetadataResponse, error)
+	FetchFile(ctx context.Context, repoPath, version, filename string) (*proxymaven.FileResponse, error)
+}
+
+// FetcherFactory builds a [ProxyFetcher] for a namespace upstream URL.
+type FetcherFactory func(upstream *url.URL) (ProxyFetcher, error)
+
+// DefaultFetcherFactory builds the production Maven proxy fetcher.
+func DefaultFetcherFactory(upstream *url.URL) (ProxyFetcher, error) {
+	return proxymaven.New(upstream)
+}
+
+// WithFetcherFactory installs a custom Maven proxy fetcher factory.
+func WithFetcherFactory(f FetcherFactory) Option {
+	return func(c *handlerConfig) { c.fetcherFactory = f }
+}
+
+// WithProxyNegativeCache wires the in-memory negative cache for
+// repeated artifact misses.
+func WithProxyNegativeCache(c *indexcache.NegativeCache) Option {
+	return func(cg *handlerConfig) { cg.negCache = c }
+}
+
+type proxyState struct {
+	factory    FetcherFactory
+	negCache   *indexcache.NegativeCache
+	fetchers   sync.Map
+	fileFlight singleflight.Group
+}
+
+func newProxyState(cfg handlerConfig) *proxyState {
+	factory := cfg.fetcherFactory
+	if factory == nil {
+		factory = DefaultFetcherFactory
+	}
+	return &proxyState{factory: factory, negCache: cfg.negCache}
+}
+
+func (p *proxyState) fetcherFor(upstream string) (ProxyFetcher, error) {
+	if v, ok := p.fetchers.Load(upstream); ok {
+		return v.(ProxyFetcher), nil
+	}
+	u, err := url.Parse(upstream)
+	if err != nil {
+		return nil, fmt.Errorf("parse upstream %q: %w", upstream, err)
+	}
+	f, err := p.factory(u)
+	if err != nil {
+		return nil, fmt.Errorf("build fetcher for %q: %w", upstream, err)
+	}
+	actual, _ := p.fetchers.LoadOrStore(upstream, f)
+	return actual.(ProxyFetcher), nil
+}
+
+func (h *Handler) dispatchProxy(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry) (*namespace.Spec, bool, bool) {
+	spec, err := scoped.Spec(req.Context())
+	if err != nil {
+		if handler.WriteNamespaceError(w, err) {
+			return nil, false, false
+		}
+		handler.WriteError(req.Context(), w, http.StatusInternalServerError, err, "namespace lookup failed")
+		return nil, false, false
+	}
+	isProxy := spec != nil && spec.Mode == namespace.ModeProxy
+	return spec, isProxy, true
+}
+
+func (h *Handler) handleMetadataProxy(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry, spec *namespace.Spec, repoPath string) {
+	ctx := req.Context()
+	if err := scoped.Authorize(ctx, auth.OpRead); err != nil {
+		if handler.WriteNamespaceError(w, err) {
+			return
+		}
+		handler.WriteError(ctx, w, http.StatusInternalServerError, err, "namespace authorization failed")
+		return
+	}
+
+	fetcher, err := h.proxy.fetcherFor(spec.Proxy.Upstream)
+	if err != nil {
+		handler.WriteError(ctx, w, http.StatusInternalServerError, err, "proxy fetcher unavailable")
+		return
+	}
+	resp, err := fetcher.GetMetadata(ctx, repoPath)
+	if err != nil {
+		switch {
+		case errors.Is(err, proxy.ErrNotFound):
+			http.Error(w, "metadata not found", http.StatusNotFound)
+		case errors.Is(err, proxy.ErrUpstreamMalformed):
+			handler.WriteError(ctx, w, http.StatusBadGateway, err, "upstream malformed")
+		case errors.Is(err, proxy.ErrUpstreamUnavailable):
+			handler.WriteError(ctx, w, http.StatusServiceUnavailable, err, "upstream unavailable")
+		default:
+			handler.WriteError(ctx, w, http.StatusInternalServerError, err, "proxy metadata fetch failed")
+		}
+		return
+	}
+	writeProxyBytes(w, req, resp.Body, resp.ContentType)
+}
+
+func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry, spec *namespace.Spec, f *oci.RepoFile) {
+	ctx := req.Context()
+	logger := logging.FromContext(ctx)
+
+	if h.tryServeFromRegistry(w, req, scoped, f) {
+		return
+	}
+
+	pkg := packageRef(f.OwningRepo)
+	version := f.OwningTag
+	filename := f.Name
+	if h.proxy.negCache != nil {
+		key := negativeKey(scoped.Namespace(), f.OwningRepo, version, filename)
+		if h.proxy.negCache.IsKnownMissing(key) {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+	}
+
+	ref := filter.Ref{Package: pkg, Version: version}
+	if decision, denyFilter, err := spec.Proxy.Filters.Decide(ctx, ref); err != nil {
+		logger.DebugContext(ctx, "maven proxy filter chain error", "error", err, "filter", filterKind(denyFilter))
+		http.Error(w, "filter denied", http.StatusNotFound)
+		return
+	} else if decision == filter.DecisionDeny {
+		logger.InfoContext(ctx, "maven proxy file denied by filter", "package", pkg, "version", version, "filter", filterKind(denyFilter))
+		http.Error(w, "filter denied", http.StatusNotFound)
+		return
+	}
+
+	fetcher, err := h.proxy.fetcherFor(spec.Proxy.Upstream)
+	if err != nil {
+		handler.WriteError(ctx, w, http.StatusInternalServerError, err, "proxy fetcher unavailable")
+		return
+	}
+
+	key := scoped.Namespace() + "|" + f.OwningRepo + "|" + version + "|" + filename
+	isHead := req.Method == http.MethodHead
+	amLeader := false
+	var teeRef *tolerantWriter
+	resultV, err, _ := h.proxy.fileFlight.Do(key, func() (any, error) {
+		amLeader = true
+		if hit, hitErr := h.peekRegistry(ctx, scoped, f); hitErr == nil && hit {
+			return fileFlightResult{cached: true}, nil
+		}
+
+		meta, ferr := fetcher.GetMetadata(ctx, f.OwningRepo)
+		if ferr != nil {
+			return fileFlightResult{}, ferr
+		}
+		if len(meta.Versions) > 0 && !contains(meta.Versions, version) {
+			return fileFlightResult{}, fmt.Errorf("maven proxy: version %s missing from metadata for %s: %w",
+				version, f.OwningRepo, proxy.ErrNotFound)
+		}
+		if decision, denyFilter, derr := spec.Proxy.Filters.Decide(ctx, filter.Ref{
+			Package: pkg, Version: version, UploadTime: meta.LastUpdated,
+		}); derr != nil {
+			return fileFlightResult{}, fmt.Errorf("filter error: %w (kind=%s)", derr, filterKind(denyFilter))
+		} else if decision == filter.DecisionDeny {
+			return fileFlightResult{filterDeny: true, filterName: filterKind(denyFilter)}, nil
+		}
+
+		fileResp, ferr := fetcher.FetchFile(ctx, f.OwningRepo, version, filename)
+		if ferr != nil {
+			return fileFlightResult{}, ferr
+		}
+		defer fileResp.Body.Close()
+
+		populated := &oci.RepoFile{
+			OwningRepo: f.OwningRepo,
+			OwningTag:  f.OwningTag,
+			Name:       f.Name,
+			MediaType:  pickMediaType(filename, fileResp.ContentType),
+			Size:       fileResp.ContentLength,
+			// Snapshot artifacts are mutable in hosted mode, but a
+			// pull-through cache fill should keep the exact upstream
+			// bytes it first observed unless the operator enables
+			// backend overwrites globally.
+			AllowOverwrite: false,
+		}
+		var body io.Reader = fileResp.Body
+		if !isHead {
+			w.Header().Set("Content-Type", populated.MediaType)
+			if fileResp.ContentLength > 0 {
+				w.Header().Set("Content-Length", strconv.FormatInt(fileResp.ContentLength, 10))
+			}
+			teeRef = &tolerantWriter{w: w}
+			body = io.TeeReader(body, teeRef)
+		}
+		if _, addErr := scoped.AddCachedFile(ctx, populated, body); addErr != nil {
+			if errors.Is(addErr, oci.ErrAlreadyExists) {
+				return fileFlightResult{cached: true}, nil
+			}
+			return fileFlightResult{}, addErr
+		}
+		return fileFlightResult{streamed: true}, nil
+	})
+	if err != nil {
+		if amLeader && teeRef != nil && teeRef.used {
+			logger.WarnContext(ctx, "maven proxy file fetch failed after response body started; suppressing error body",
+				"error", err, "package", pkg, "version", version, "filename", filename)
+			return
+		}
+		switch {
+		case errors.Is(err, proxy.ErrNotFound):
+			if h.proxy.negCache != nil {
+				h.proxy.negCache.RecordMiss(negativeKey(scoped.Namespace(), f.OwningRepo, version, filename))
+			}
+			http.Error(w, "not found", http.StatusNotFound)
+		case errors.Is(err, proxy.ErrUpstreamMalformed):
+			handler.WriteError(ctx, w, http.StatusBadGateway, err, "upstream malformed")
+		case errors.Is(err, proxy.ErrUpstreamUnavailable):
+			handler.WriteError(ctx, w, http.StatusBadGateway, err, "upstream unavailable")
+		default:
+			if handler.WriteNamespaceError(w, err) {
+				return
+			}
+			handler.WriteError(ctx, w, http.StatusBadGateway, err, "proxy file fetch failed")
+		}
+		return
+	}
+
+	result := resultV.(fileFlightResult)
+	if result.filterDeny {
+		logger.InfoContext(ctx, "maven proxy file denied by filter", "package", pkg, "version", version, "filter", result.filterName)
+		http.Error(w, "filter denied", http.StatusNotFound)
+		return
+	}
+	if result.streamed && amLeader && !isHead {
+		return
+	}
+	if h.tryServeFromRegistry(w, req, scoped, f) {
+		return
+	}
+	handler.WriteError(ctx, w, http.StatusBadGateway, nil, "proxy fill reported success but cache miss on re-read")
+}
+
+type tolerantWriter struct {
+	w    io.Writer
+	dead bool
+	used bool
+}
+
+func (t *tolerantWriter) Write(p []byte) (int, error) {
+	t.used = true
+	if t.dead {
+		return len(p), nil
+	}
+	if _, err := t.w.Write(p); err != nil {
+		t.dead = true
+	}
+	return len(p), nil
+}
+
+type fileFlightResult struct {
+	streamed   bool
+	cached     bool
+	filterDeny bool
+	filterName string
+}
+
+func (h *Handler) peekRegistry(ctx context.Context, scoped *namespace.ScopedRegistry, f *oci.RepoFile) (bool, error) {
+	_, rc, err := scoped.ReadFile(ctx, f)
+	if err != nil {
+		if errors.Is(err, errdef.ErrNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	rc.Close()
+	return true, nil
+}
+
+func (h *Handler) tryServeFromRegistry(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry, f *oci.RepoFile) bool {
+	ctx := req.Context()
+	logger := logging.FromContext(ctx)
+
+	if req.Method != http.MethodHead {
+		if redirectURL, err := scoped.BlobRedirectURL(ctx, f); err == nil && redirectURL != "" {
+			http.Redirect(w, req, redirectURL, http.StatusTemporaryRedirect)
+			return true
+		} else if err != nil {
+			logger.DebugContext(ctx, "maven proxy redirect probe failed; streaming", "error", err)
+		}
+	}
+	desc, rc, err := scoped.ReadFile(ctx, f)
+	if err != nil {
+		if errors.Is(err, errdef.ErrNotFound) {
+			return false
+		}
+		if handler.WriteNamespaceError(w, err) {
+			return true
+		}
+		if oci.HasCode(err, http.StatusUnauthorized) {
+			http.Error(w, err.Error(), http.StatusUnauthorized)
+			return true
+		}
+		if oci.HasCode(err, http.StatusForbidden) {
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return true
+		}
+		handler.WriteError(ctx, w, http.StatusInternalServerError, err, "internal error")
+		return true
+	}
+	defer rc.Close()
+
+	w.Header().Set("Content-Type", f.MediaType)
+	w.Header().Set("Content-Length", strconv.FormatInt(desc.File.Size, 10))
+	w.Header().Set("X-Checksum-Sha256", desc.File.Digest.String())
+	if req.Method == http.MethodHead {
+		return true
+	}
+	if _, err := io.Copy(w, rc); err != nil {
+		logger.DebugContext(ctx, "copy maven proxy hit body", "error", err)
+	}
+	return true
+}
+
+func writeProxyBytes(w http.ResponseWriter, req *http.Request, body []byte, contentType string) {
+	if contentType == "" {
+		contentType = "text/xml"
+	}
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+	if req.Method == http.MethodHead {
+		return
+	}
+	_, _ = w.Write(body)
+}
+
+func contains(values []string, want string) bool {
+	for _, v := range values {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}
+
+func pickMediaType(filename, upstream string) string {
+	if upstream != "" {
+		return upstream
+	}
+	return detectMediaType(filename)
+}
+
+func negativeKey(ns, repo, version, filename string) string {
+	return "maven|" + ns + "|" + repo + "|" + version + "|" + filename
+}
+
+func packageRef(repo string) string {
+	parts := strings.Split(strings.Trim(repo, "/"), "/")
+	if len(parts) < 2 {
+		return repo
+	}
+	artifact := parts[len(parts)-1]
+	groupID := strings.Join(parts[:len(parts)-1], ".")
+	return groupID + ":" + artifact
+}
+
+func filterKind(f filter.Filter) string {
+	if f == nil {
+		return ""
+	}
+	if k, ok := f.(filter.Kinded); ok {
+		return k.Kind()
+	}
+	return fmt.Sprintf("%T", f)
+}

--- a/pkg/handler/maven/proxy_test.go
+++ b/pkg/handler/maven/proxy_test.go
@@ -69,6 +69,21 @@ func (f *fakeProxyFetcher) FetchFile(_ context.Context, repoPath, version, filen
 	return nil, fmt.Errorf("fake: no file for %q: %w", key, proxy.ErrNotFound)
 }
 
+func (f *fakeProxyFetcher) FetchPath(_ context.Context, repoPath, filename string) (*proxymaven.FileResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.fetchFileCalls++
+	key := repoPath + "/" + filename
+	if err, ok := f.fileErr[key]; ok {
+		return nil, err
+	}
+	if r, ok := f.files[key]; ok {
+		cp := *r
+		return &cp, nil
+	}
+	return nil, fmt.Errorf("fake: no file for %q: %w", key, proxy.ErrNotFound)
+}
+
 func (f *fakeProxyFetcher) calls() (metadata, files int) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -219,6 +234,59 @@ func TestProxy_MetadataPassthrough(t *testing.T) {
 	}
 }
 
+func TestProxy_MetadataChecksumSidecarFetchesAndCaches(t *testing.T) {
+	t.Parallel()
+
+	fetcher := newFakeProxyFetcher()
+	const checksum = "0123456789abcdef"
+	fetcher.files["com/example/demo/maven-metadata.xml.sha1"] = &proxymaven.FileResponse{
+		Body:          io.NopCloser(strings.NewReader(checksum)),
+		ContentType:   "text/plain",
+		ContentLength: int64(len(checksum)),
+	}
+	h, _, _ := newProxyTestHandler(t, fetcher, namespace.Spec{})
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodGet, nsPath("/com/example/demo/maven-metadata.xml.sha1"), nil)
+		rec := httptest.NewRecorder()
+		h.Mux().ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("request %d: status=%d, want 200 (body=%s)", i+1, rec.Code, rec.Body.String())
+		}
+		if got := rec.Body.String(); got != checksum {
+			t.Errorf("request %d: body=%q, want %q", i+1, got, checksum)
+		}
+	}
+
+	_, gotFileCalls := fetcher.calls()
+	if gotFileCalls != 1 {
+		t.Errorf("FetchPath calls=%d, want 1 cache fill", gotFileCalls)
+	}
+}
+
+func TestProxy_SnapshotMetadataChecksumSidecarFetchesFromSnapshotPath(t *testing.T) {
+	t.Parallel()
+
+	fetcher := newFakeProxyFetcher()
+	const checksum = "fedcba9876543210"
+	fetcher.files["com/example/demo/1.0-SNAPSHOT/maven-metadata.xml.sha1"] = &proxymaven.FileResponse{
+		Body:          io.NopCloser(strings.NewReader(checksum)),
+		ContentType:   "text/plain",
+		ContentLength: int64(len(checksum)),
+	}
+	h, _, _ := newProxyTestHandler(t, fetcher, namespace.Spec{})
+
+	req := httptest.NewRequest(http.MethodGet, nsPath("/com/example/demo/1.0-SNAPSHOT/maven-metadata.xml.sha1"), nil)
+	rec := httptest.NewRecorder()
+	h.Mux().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != checksum {
+		t.Errorf("body=%q, want %q", got, checksum)
+	}
+}
+
 func TestProxy_UploadsReturn405(t *testing.T) {
 	t.Parallel()
 
@@ -262,6 +330,51 @@ func TestProxy_FilterDenySkipsUpstream(t *testing.T) {
 	}
 	if gotMetadata, gotFiles := fetcher.calls(); gotMetadata != 0 || gotFiles != 0 {
 		t.Errorf("upstream calls metadata=%d files=%d, want 0/0", gotMetadata, gotFiles)
+	}
+}
+
+func TestProxy_DelayFilterFailsClosedWithoutLastUpdated(t *testing.T) {
+	t.Parallel()
+
+	fetcher := newFakeProxyFetcher()
+	fetcher.metadata["com/example/demo"] = &proxymaven.MetadataResponse{Versions: []string{"1.2.0"}}
+	fetcher.files["com/example/demo/1.2.0/demo-1.2.0.jar"] = &proxymaven.FileResponse{
+		Body:          io.NopCloser(strings.NewReader("jar")),
+		ContentType:   "application/java-archive",
+		ContentLength: 3,
+	}
+	h, _, _ := newProxyTestHandler(t, fetcher, namespace.Spec{Proxy: namespace.Proxy{
+		Filters: filter.Filters{&filter.Delay{MinAge: time.Hour}},
+	}})
+
+	req := httptest.NewRequest(http.MethodGet, nsPath("/com/example/demo/1.2.0/demo-1.2.0.jar"), nil)
+	rec := httptest.NewRecorder()
+	h.Mux().ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d, want 404 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if gotMetadata, gotFiles := fetcher.calls(); gotMetadata != 1 || gotFiles != 0 {
+		t.Errorf("upstream calls metadata=%d files=%d, want 1/0", gotMetadata, gotFiles)
+	}
+}
+
+func TestProxy_FileExceedingSizeCapIsRejectedBeforeFetchBody(t *testing.T) {
+	t.Parallel()
+
+	fetcher := newFakeProxyFetcher()
+	fetcher.metadata["com/example/demo"] = &proxymaven.MetadataResponse{Versions: []string{"1.2.0"}}
+	fetcher.files["com/example/demo/1.2.0/demo-1.2.0.jar"] = &proxymaven.FileResponse{
+		Body:          io.NopCloser(strings.NewReader("too-large")),
+		ContentType:   "application/java-archive",
+		ContentLength: 9,
+	}
+	h, _, _ := newProxyTestHandler(t, fetcher, namespace.Spec{}, WithMaxUploadBytes(8))
+
+	req := httptest.NewRequest(http.MethodGet, nsPath("/com/example/demo/1.2.0/demo-1.2.0.jar"), nil)
+	rec := httptest.NewRecorder()
+	h.Mux().ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status=%d, want 502 (body=%s)", rec.Code, rec.Body.String())
 	}
 }
 

--- a/pkg/handler/maven/proxy_test.go
+++ b/pkg/handler/maven/proxy_test.go
@@ -1,0 +1,321 @@
+package maven
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/yolocs/ocifactory/pkg/auth"
+	"github.com/yolocs/ocifactory/pkg/namespace"
+	"github.com/yolocs/ocifactory/pkg/oci"
+	"github.com/yolocs/ocifactory/pkg/proxy"
+	"github.com/yolocs/ocifactory/pkg/proxy/filter"
+	proxymaven "github.com/yolocs/ocifactory/pkg/proxy/maven"
+)
+
+type fakeProxyFetcher struct {
+	mu sync.Mutex
+
+	metadata    map[string]*proxymaven.MetadataResponse
+	metadataErr map[string]error
+	files       map[string]*proxymaven.FileResponse
+	fileErr     map[string]error
+
+	getMetadataCalls int
+	fetchFileCalls   int
+}
+
+func newFakeProxyFetcher() *fakeProxyFetcher {
+	return &fakeProxyFetcher{
+		metadata:    map[string]*proxymaven.MetadataResponse{},
+		metadataErr: map[string]error{},
+		files:       map[string]*proxymaven.FileResponse{},
+		fileErr:     map[string]error{},
+	}
+}
+
+func (f *fakeProxyFetcher) GetMetadata(_ context.Context, repoPath string) (*proxymaven.MetadataResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.getMetadataCalls++
+	if err, ok := f.metadataErr[repoPath]; ok {
+		return nil, err
+	}
+	if r, ok := f.metadata[repoPath]; ok {
+		return r, nil
+	}
+	return nil, fmt.Errorf("fake: no metadata for %q: %w", repoPath, proxy.ErrNotFound)
+}
+
+func (f *fakeProxyFetcher) FetchFile(_ context.Context, repoPath, version, filename string) (*proxymaven.FileResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.fetchFileCalls++
+	key := repoPath + "/" + version + "/" + filename
+	if err, ok := f.fileErr[key]; ok {
+		return nil, err
+	}
+	if r, ok := f.files[key]; ok {
+		cp := *r
+		return &cp, nil
+	}
+	return nil, fmt.Errorf("fake: no file for %q: %w", key, proxy.ErrNotFound)
+}
+
+func (f *fakeProxyFetcher) calls() (metadata, files int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.getMetadataCalls, f.fetchFileCalls
+}
+
+func newProxyTestHandler(t *testing.T, fetcher ProxyFetcher, spec namespace.Spec, opts ...Option) (*Handler, *namespace.Store, *oci.FakeRegistry) {
+	t.Helper()
+	fake := oci.NewFakeRegistry()
+	store := namespace.NewStore(fake)
+	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+
+	if spec.Mode == "" {
+		spec.Mode = namespace.ModeProxy
+	}
+	if spec.Proxy.Upstream == "" {
+		spec.Proxy.Upstream = "https://repo.maven.apache.org/maven2"
+	}
+	if spec.Policy.Readers == nil && spec.Policy.Writers == nil {
+		spec.Policy = allowAllPolicy()
+	}
+	if err := store.Put(t.Context(), &namespace.Namespace{Name: testNS, Spec: spec}); err != nil {
+		t.Fatalf("Put namespace: %v", err)
+	}
+
+	authMW := auth.Middleware(auth.AlwaysAnonymous)
+	allOpts := []Option{
+		WithAuthMiddleware(authMW),
+		WithFetcherFactory(func(*url.URL) (ProxyFetcher, error) { return fetcher, nil }),
+	}
+	allOpts = append(allOpts, opts...)
+	h, err := NewHandler(reg, allOpts...)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	return h, store, fake
+}
+
+func TestProxy_FileMissFetchesAndCaches(t *testing.T) {
+	t.Parallel()
+
+	fetcher := newFakeProxyFetcher()
+	body := "jar-bytes"
+	fetcher.metadata["com/example/demo"] = &proxymaven.MetadataResponse{
+		Body:        []byte(`<metadata><versioning><versions><version>1.2.0</version></versions><lastUpdated>20260516040506</lastUpdated></versioning></metadata>`),
+		ContentType: "text/xml",
+		Versions:    []string{"1.2.0"},
+		LastUpdated: time.Date(2026, 5, 16, 4, 5, 6, 0, time.UTC),
+	}
+	fetcher.files["com/example/demo/1.2.0/demo-1.2.0.jar"] = &proxymaven.FileResponse{
+		Body:          io.NopCloser(strings.NewReader(body)),
+		ContentType:   "application/java-archive",
+		ContentLength: int64(len(body)),
+	}
+	h, _, _ := newProxyTestHandler(t, fetcher, namespace.Spec{})
+
+	req := httptest.NewRequest(http.MethodGet, nsPath("/com/example/demo/1.2.0/demo-1.2.0.jar"), nil)
+	rec := httptest.NewRecorder()
+	h.Mux().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != body {
+		t.Errorf("body=%q, want %q", got, body)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, nsPath("/com/example/demo/1.2.0/demo-1.2.0.jar"), nil)
+	rec = httptest.NewRecorder()
+	h.Mux().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("cached status=%d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != body {
+		t.Errorf("cached body=%q, want %q", got, body)
+	}
+	_, gotFileCalls := fetcher.calls()
+	if gotFileCalls != 1 {
+		t.Errorf("FetchFile calls=%d, want 1 cache fill", gotFileCalls)
+	}
+}
+
+func TestProxy_FileCacheHitSkipsUpstream(t *testing.T) {
+	t.Parallel()
+
+	fetcher := newFakeProxyFetcher()
+	h, _, backing := newProxyTestHandler(t, fetcher, namespace.Spec{})
+	if _, err := backing.AddFile(t.Context(), &oci.RepoFile{
+		OwningRepo: testNS + "/com/example/demo",
+		OwningTag:  "1.2.0",
+		Name:       "demo-1.2.0.jar",
+		MediaType:  "application/java-archive",
+	}, strings.NewReader("cached-jar")); err != nil {
+		t.Fatalf("seed AddFile: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, nsPath("/com/example/demo/1.2.0/demo-1.2.0.jar"), nil)
+	rec := httptest.NewRecorder()
+	h.Mux().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != "cached-jar" {
+		t.Errorf("body=%q, want cached-jar", got)
+	}
+	if gotMetadata, gotFiles := fetcher.calls(); gotMetadata != 0 || gotFiles != 0 {
+		t.Errorf("upstream calls metadata=%d files=%d, want 0/0", gotMetadata, gotFiles)
+	}
+}
+
+func TestProxy_MetadataPassthrough(t *testing.T) {
+	t.Parallel()
+
+	fetcher := newFakeProxyFetcher()
+	const releaseMeta = `<metadata><groupId>com.example</groupId><artifactId>demo</artifactId></metadata>`
+	const snapshotMeta = `<metadata><version>1.0-SNAPSHOT</version><versioning><snapshotVersions></snapshotVersions></versioning></metadata>`
+	fetcher.metadata["com/example/demo"] = &proxymaven.MetadataResponse{
+		Body:        []byte(releaseMeta),
+		ContentType: "text/xml",
+	}
+	fetcher.metadata["com/example/demo/1.0-SNAPSHOT"] = &proxymaven.MetadataResponse{
+		Body:        []byte(snapshotMeta),
+		ContentType: "text/xml",
+	}
+	h, _, _ := newProxyTestHandler(t, fetcher, namespace.Spec{})
+
+	tests := []struct {
+		name     string
+		path     string
+		wantBody string
+	}{
+		{name: "release metadata", path: nsPath("/com/example/demo/maven-metadata.xml"), wantBody: releaseMeta},
+		{name: "snapshot metadata", path: nsPath("/com/example/demo/1.0-SNAPSHOT/maven-metadata.xml"), wantBody: snapshotMeta},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			rec := httptest.NewRecorder()
+			h.Mux().ServeHTTP(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status=%d, want 200 (body=%s)", rec.Code, rec.Body.String())
+			}
+			if got := rec.Body.String(); got != tc.wantBody {
+				t.Errorf("body=%q, want %q", got, tc.wantBody)
+			}
+		})
+	}
+}
+
+func TestProxy_UploadsReturn405(t *testing.T) {
+	t.Parallel()
+
+	h, _, _ := newProxyTestHandler(t, newFakeProxyFetcher(), namespace.Spec{})
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{name: "artifact put", method: http.MethodPut, path: nsPath("/com/example/demo/1.2.0/demo-1.2.0.jar")},
+		{name: "metadata post", method: http.MethodPost, path: nsPath("/com/example/demo/maven-metadata.xml")},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(tc.method, tc.path, strings.NewReader("body"))
+			rec := httptest.NewRecorder()
+			h.Mux().ServeHTTP(rec, req)
+			if rec.Code != http.StatusMethodNotAllowed {
+				t.Errorf("status=%d, want 405 (body=%s)", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestProxy_FilterDenySkipsUpstream(t *testing.T) {
+	t.Parallel()
+
+	fetcher := newFakeProxyFetcher()
+	h, _, _ := newProxyTestHandler(t, fetcher, namespace.Spec{Proxy: namespace.Proxy{
+		Filters: filter.Filters{&filter.Denylist{Patterns: []string{"com.example:demo"}}},
+	}})
+
+	req := httptest.NewRequest(http.MethodGet, nsPath("/com/example/demo/1.2.0/demo-1.2.0.jar"), nil)
+	rec := httptest.NewRecorder()
+	h.Mux().ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d, want 404 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if gotMetadata, gotFiles := fetcher.calls(); gotMetadata != 0 || gotFiles != 0 {
+		t.Errorf("upstream calls metadata=%d files=%d, want 0/0", gotMetadata, gotFiles)
+	}
+}
+
+func TestProxy_UpstreamErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		setup      func(*fakeProxyFetcher)
+		path       string
+		wantStatus int
+	}{
+		{
+			name: "file not found",
+			setup: func(f *fakeProxyFetcher) {
+				f.metadata["com/example/demo"] = &proxymaven.MetadataResponse{Versions: []string{"1.2.0"}}
+				f.fileErr["com/example/demo/1.2.0/demo-1.2.0.jar"] = fmt.Errorf("missing: %w", proxy.ErrNotFound)
+			},
+			path:       nsPath("/com/example/demo/1.2.0/demo-1.2.0.jar"),
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name: "file upstream unavailable",
+			setup: func(f *fakeProxyFetcher) {
+				f.metadata["com/example/demo"] = &proxymaven.MetadataResponse{Versions: []string{"1.2.0"}}
+				f.fileErr["com/example/demo/1.2.0/demo-1.2.0.jar"] = fmt.Errorf("down: %w", proxy.ErrUpstreamUnavailable)
+			},
+			path:       nsPath("/com/example/demo/1.2.0/demo-1.2.0.jar"),
+			wantStatus: http.StatusBadGateway,
+		},
+		{
+			name: "metadata upstream unavailable",
+			setup: func(f *fakeProxyFetcher) {
+				f.metadataErr["com/example/demo"] = fmt.Errorf("down: %w", proxy.ErrUpstreamUnavailable)
+			},
+			path:       nsPath("/com/example/demo/maven-metadata.xml"),
+			wantStatus: http.StatusServiceUnavailable,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fetcher := newFakeProxyFetcher()
+			tc.setup(fetcher)
+			h, _, _ := newProxyTestHandler(t, fetcher, namespace.Spec{})
+
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			rec := httptest.NewRecorder()
+			h.Mux().ServeHTTP(rec, req)
+			if rec.Code != tc.wantStatus {
+				t.Errorf("status=%d, want %d (body=%s)", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+		})
+	}
+}

--- a/pkg/handler/python/pypi_upstream_integration_test.go
+++ b/pkg/handler/python/pypi_upstream_integration_test.go
@@ -4,8 +4,8 @@
 // behind a separate `pypiupstream` build tag (NOT `integration`)
 // because the test is intentionally non-hermetic: it talks to
 // https://pypi.org over the public internet. PyPI outages, rate
-// limits, or response-shape changes will turn this test red. Run it
-// on a schedule (nightly), not on every PR.
+// limits, or response-shape changes will turn this test red. CI runs
+// it on every PR in the separate live-upstream workflow.
 //
 // Invoke via `go test -tags=pypiupstream ./pkg/handler/python/...`.
 

--- a/pkg/proxy/maven/maven.go
+++ b/pkg/proxy/maven/maven.go
@@ -1,0 +1,240 @@
+// Package maven is the per-format proxy fetcher for Maven 2 layout
+// repositories such as Maven Central. It fetches maven-metadata.xml
+// and streams artifact files from group/artifact/version paths.
+package maven
+
+import (
+	"context"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/yolocs/ocifactory/pkg/proxy"
+	"github.com/yolocs/ocifactory/pkg/proxy/httpclient"
+)
+
+const (
+	userAgent        = "ocifactory-maven-proxy"
+	maxMetadataBytes = 2 << 20
+)
+
+// MetadataResponse is the result of a successful maven-metadata.xml
+// fetch. Body is the raw upstream XML; Versions and LastUpdated are
+// parsed best-effort from <versioning> for the handler's proxy path.
+type MetadataResponse struct {
+	Body        []byte
+	ContentType string
+	Versions    []string
+	LastUpdated time.Time
+}
+
+// FileResponse is the result of a successful [Fetcher.FetchFile] call.
+// Body is the upstream stream the caller must close.
+type FileResponse struct {
+	Body          io.ReadCloser
+	ContentType   string
+	ContentLength int64
+}
+
+// Fetcher is a Maven-2-layout upstream client. A Fetcher is safe for
+// concurrent use.
+type Fetcher struct {
+	upstream *url.URL
+	client   *httpclient.Client
+}
+
+// Option configures a [Fetcher].
+type Option func(*config)
+
+type config struct {
+	client *httpclient.Client
+}
+
+// WithClient overrides the shared HTTP client. Defaults to a fresh
+// [httpclient.New] with package defaults.
+func WithClient(c *httpclient.Client) Option {
+	return func(o *config) { o.client = c }
+}
+
+// New constructs a Fetcher that talks to upstream. upstream must be an
+// absolute http or https URL, typically https://repo.maven.apache.org/maven2.
+func New(upstream *url.URL, opts ...Option) (*Fetcher, error) {
+	if upstream == nil {
+		return nil, errors.New("maven proxy: upstream URL is required")
+	}
+	if !upstream.IsAbs() || upstream.Host == "" {
+		return nil, fmt.Errorf("maven proxy: upstream %q must be absolute", upstream)
+	}
+	if upstream.Scheme != "http" && upstream.Scheme != "https" {
+		return nil, fmt.Errorf("maven proxy: upstream %q scheme must be http or https", upstream)
+	}
+
+	cfg := config{}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	if cfg.client == nil {
+		cfg.client = httpclient.New(httpclient.Options{UserAgent: userAgent})
+	}
+	u := *upstream
+	u.Path = strings.TrimRight(u.Path, "/")
+	return &Fetcher{upstream: &u, client: cfg.client}, nil
+}
+
+// Upstream returns the canonical upstream URL the fetcher talks to.
+func (f *Fetcher) Upstream() *url.URL { return f.upstream }
+
+// GetMetadata fetches <repoPath>/maven-metadata.xml from upstream.
+// repoPath is the Maven path form "group/path/artifact" or, for
+// snapshot metadata, "group/path/artifact/version-SNAPSHOT".
+func (f *Fetcher) GetMetadata(ctx context.Context, repoPath string) (*MetadataResponse, error) {
+	if repoPath == "" {
+		return nil, fmt.Errorf("maven proxy: GetMetadata: repo path is required")
+	}
+	u, err := f.mavenURL(repoPath, "maven-metadata.xml")
+	if err != nil {
+		return nil, err
+	}
+	resp, err := f.client.Get(ctx, u, httpclient.GetOptions{
+		Header: http.Header{"Accept": []string{"application/xml, text/xml, */*;q=0.1"}},
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("maven proxy: metadata %s: %w", repoPath, proxy.ErrNotFound)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("maven proxy: metadata %s: status %d: %w",
+			repoPath, resp.StatusCode, proxy.ErrUpstreamUnavailable)
+	}
+	body, err := readLimited(resp.Body, maxMetadataBytes)
+	if err != nil {
+		if errors.Is(err, errBodyTooLarge) {
+			return nil, fmt.Errorf("maven proxy: metadata %s exceeds %d bytes: %w", repoPath, maxMetadataBytes, proxy.ErrUpstreamMalformed)
+		}
+		return nil, fmt.Errorf("maven proxy: read metadata %s: %w", repoPath, proxy.ErrUpstreamUnavailable)
+	}
+	versions, lastUpdated, err := parseMetadata(body)
+	if err != nil {
+		return nil, err
+	}
+	ct := resp.Header.Get("Content-Type")
+	if ct == "" {
+		ct = "text/xml"
+	}
+	return &MetadataResponse{
+		Body:        body,
+		ContentType: ct,
+		Versions:    versions,
+		LastUpdated: lastUpdated,
+	}, nil
+}
+
+// FetchFile opens a streaming GET for
+// <repoPath>/<version>/<filename>. The returned Body must be closed.
+func (f *Fetcher) FetchFile(ctx context.Context, repoPath, version, filename string) (*FileResponse, error) {
+	if repoPath == "" || version == "" || filename == "" {
+		return nil, fmt.Errorf("maven proxy: FetchFile: repo path, version, and filename are required")
+	}
+	u, err := f.mavenURL(repoPath, version, filename)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := f.client.Get(ctx, u, httpclient.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		resp.Body.Close()
+		return nil, fmt.Errorf("maven proxy: file %s/%s/%s: %w", repoPath, version, filename, proxy.ErrNotFound)
+	}
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		return nil, fmt.Errorf("maven proxy: file %s/%s/%s: status %d: %w",
+			repoPath, version, filename, resp.StatusCode, proxy.ErrUpstreamUnavailable)
+	}
+	ct := resp.Header.Get("Content-Type")
+	if ct == "" {
+		ct = "application/octet-stream"
+	}
+	var size int64 = -1
+	if s := resp.Header.Get("Content-Length"); s != "" {
+		if n, err := strconv.ParseInt(s, 10, 64); err == nil && n >= 0 {
+			size = n
+		}
+	}
+	return &FileResponse{Body: resp.Body, ContentType: ct, ContentLength: size}, nil
+}
+
+func (f *Fetcher) mavenURL(parts ...string) (string, error) {
+	segments := make([]string, 0, len(parts)*2)
+	for _, part := range parts {
+		if part == "" {
+			return "", errors.New("maven proxy: empty path segment")
+		}
+		for _, s := range strings.Split(part, "/") {
+			if s == "" || s == "." || s == ".." {
+				return "", fmt.Errorf("maven proxy: invalid path segment %q", s)
+			}
+			segments = append(segments, s)
+		}
+	}
+	return f.upstream.JoinPath(segments...).String(), nil
+}
+
+type metadataXML struct {
+	Versioning struct {
+		Versions struct {
+			Version []string `xml:"version"`
+		} `xml:"versions"`
+		LastUpdated string `xml:"lastUpdated"`
+	} `xml:"versioning"`
+}
+
+func parseMetadata(body []byte) ([]string, time.Time, error) {
+	var doc metadataXML
+	if err := xml.Unmarshal(body, &doc); err != nil {
+		return nil, time.Time{}, fmt.Errorf("maven proxy: decode metadata: %v: %w", err, proxy.ErrUpstreamMalformed)
+	}
+	versions := append([]string(nil), doc.Versioning.Versions.Version...)
+	lastUpdated, err := parseMavenTime(doc.Versioning.LastUpdated)
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("maven proxy: decode metadata lastUpdated %q: %v: %w",
+			doc.Versioning.LastUpdated, err, proxy.ErrUpstreamMalformed)
+	}
+	return versions, lastUpdated, nil
+}
+
+func parseMavenTime(s string) (time.Time, error) {
+	if s == "" {
+		return time.Time{}, nil
+	}
+	layouts := []string{"20060102150405", "200601021504", "20060102"}
+	for _, layout := range layouts {
+		if t, err := time.ParseInLocation(layout, s, time.UTC); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, errors.New("unsupported timestamp format")
+}
+
+var errBodyTooLarge = errors.New("body too large")
+
+func readLimited(r io.Reader, limit int64) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > limit {
+		return nil, errBodyTooLarge
+	}
+	return body, nil
+}

--- a/pkg/proxy/maven/maven.go
+++ b/pkg/proxy/maven/maven.go
@@ -144,22 +144,37 @@ func (f *Fetcher) FetchFile(ctx context.Context, repoPath, version, filename str
 	if repoPath == "" || version == "" || filename == "" {
 		return nil, fmt.Errorf("maven proxy: FetchFile: repo path, version, and filename are required")
 	}
-	u, err := f.mavenURL(repoPath, version, filename)
+	return f.fetchPath(ctx, repoPath, version, filename)
+}
+
+// FetchPath opens a streaming GET for <repoPath>/<filename>. It is
+// used for Maven metadata checksum sidecars, which live next to
+// maven-metadata.xml rather than under a version directory.
+func (f *Fetcher) FetchPath(ctx context.Context, repoPath, filename string) (*FileResponse, error) {
+	if repoPath == "" || filename == "" {
+		return nil, fmt.Errorf("maven proxy: FetchPath: repo path and filename are required")
+	}
+	return f.fetchPath(ctx, repoPath, filename)
+}
+
+func (f *Fetcher) fetchPath(ctx context.Context, parts ...string) (*FileResponse, error) {
+	u, err := f.mavenURL(parts...)
 	if err != nil {
 		return nil, err
 	}
+	path := strings.Join(parts, "/")
 	resp, err := f.client.Get(ctx, u, httpclient.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
 	if resp.StatusCode == http.StatusNotFound {
 		resp.Body.Close()
-		return nil, fmt.Errorf("maven proxy: file %s/%s/%s: %w", repoPath, version, filename, proxy.ErrNotFound)
+		return nil, fmt.Errorf("maven proxy: file %s: %w", path, proxy.ErrNotFound)
 	}
 	if resp.StatusCode != http.StatusOK {
 		resp.Body.Close()
-		return nil, fmt.Errorf("maven proxy: file %s/%s/%s: status %d: %w",
-			repoPath, version, filename, resp.StatusCode, proxy.ErrUpstreamUnavailable)
+		return nil, fmt.Errorf("maven proxy: file %s: status %d: %w",
+			path, resp.StatusCode, proxy.ErrUpstreamUnavailable)
 	}
 	ct := resp.Header.Get("Content-Type")
 	if ct == "" {

--- a/pkg/proxy/maven/maven_test.go
+++ b/pkg/proxy/maven/maven_test.go
@@ -1,0 +1,163 @@
+package maven
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/yolocs/ocifactory/pkg/proxy"
+)
+
+func TestFetcherGetMetadata(t *testing.T) {
+	t.Parallel()
+
+	const metadataBody = `<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>com.example</groupId>
+  <artifactId>demo</artifactId>
+  <versioning>
+    <latest>1.2.0</latest>
+    <release>1.2.0</release>
+    <versions>
+      <version>1.0.0</version>
+      <version>1.2.0</version>
+    </versions>
+    <lastUpdated>20260516040506</lastUpdated>
+  </versioning>
+</metadata>`
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/com/example/demo/maven-metadata.xml"; got != want {
+			t.Errorf("path = %q, want %q", got, want)
+		}
+		w.Header().Set("Content-Type", "text/xml")
+		_, _ = w.Write([]byte(metadataBody))
+	}))
+	defer upstream.Close()
+
+	base, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("Parse upstream URL: %v", err)
+	}
+	f, err := New(base)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	got, err := f.GetMetadata(t.Context(), "com/example/demo")
+	if err != nil {
+		t.Fatalf("GetMetadata: %v", err)
+	}
+
+	wantUpdated := time.Date(2026, 5, 16, 4, 5, 6, 0, time.UTC)
+	want := &MetadataResponse{
+		Body:        []byte(metadataBody),
+		ContentType: "text/xml",
+		Versions:    []string{"1.0.0", "1.2.0"},
+		LastUpdated: wantUpdated,
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("GetMetadata mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestFetcherFetchFile(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/com/example/demo/1.2.0/demo-1.2.0.jar"; got != want {
+			t.Errorf("path = %q, want %q", got, want)
+		}
+		w.Header().Set("Content-Type", "application/java-archive")
+		w.Header().Set("Content-Length", "7")
+		_, _ = w.Write([]byte("jarbody"))
+	}))
+	defer upstream.Close()
+
+	base, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("Parse upstream URL: %v", err)
+	}
+	f, err := New(base)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	resp, err := f.FetchFile(t.Context(), "com/example/demo", "1.2.0", "demo-1.2.0.jar")
+	if err != nil {
+		t.Fatalf("FetchFile: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+
+	want := &FileResponse{
+		Body:          resp.Body,
+		ContentType:   "application/java-archive",
+		ContentLength: 7,
+	}
+	if diff := cmp.Diff(want, resp, cmpopts.IgnoreFields(FileResponse{}, "Body")); diff != "" {
+		t.Errorf("FetchFile response mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff([]byte("jarbody"), body); diff != "" {
+		t.Errorf("FetchFile body mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestFetcherMapsUpstreamStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		wantErr    error
+	}{
+		{
+			name:       "not found",
+			statusCode: http.StatusNotFound,
+			wantErr:    proxy.ErrNotFound,
+		},
+		{
+			name:       "unavailable",
+			statusCode: http.StatusBadGateway,
+			wantErr:    proxy.ErrUpstreamUnavailable,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.statusCode)
+			}))
+			defer upstream.Close()
+
+			base, err := url.Parse(upstream.URL)
+			if err != nil {
+				t.Fatalf("Parse upstream URL: %v", err)
+			}
+			f, err := New(base)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+
+			_, err = f.GetMetadata(t.Context(), "com/example/demo")
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("GetMetadata error = %v, want errors.Is(_, %v)", err, tc.wantErr)
+			}
+
+			_, err = f.FetchFile(t.Context(), "com/example/demo", "1.2.0", "demo-1.2.0.jar")
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("FetchFile error = %v, want errors.Is(_, %v)", err, tc.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

Closes #115.

Adds Maven pull-through proxy support so `mode: proxy` namespaces can mirror Maven Central-style Maven 2 repositories while preserving ocifactory's OCI-only storage model.

## Summary

- Adds `pkg/proxy/maven` with a concrete Maven 2 upstream fetcher for `maven-metadata.xml` and artifact file streams.
- Integrates Maven proxy dispatch into `pkg/handler/maven`: cache hit first, filter chain, live upstream metadata, file fetch, tee into OCI via read-authorized cache fill, and `405` for proxy writes.
- Wires production `serve --repo-type=maven` with Maven proxy negative caching.
- Adds `mavenupstream` live integration coverage against Maven Central and includes it in the live-upstream CI workflow.
- Documents Maven proxy mode and updates project status/roadmap notes.

## Validation

- `go test -race -shuffle=on ./pkg/handler/maven/... ./pkg/proxy/maven/...`
- `go test -tags=mavenupstream ./pkg/handler/maven/...` (compiles locally; skips here because `mvn`/Docker are unavailable)
- `go vet ./...`
- `go test -race -short ./...`
- `git diff --check`

## Manual smoke

The real Maven Central smoke is now automated in CI via the `mavenupstream` live-upstream test. It was not executed locally because this environment does not have `mvn` or `docker`.