### PR TITLE
Fix Python proxy cache auth

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -115,6 +115,9 @@ Names must satisfy:
   file downloads (allow / deny / publish-time delay). Index requests
   bypass the chain. See [`docs/proxy/filter-policy.md`](proxy/filter-policy.md)
   for the policy semantics and config shapes.
+- Shared pull-through proxy design notes, including why cold misses
+  are streamed through ocifactory instead of redirected to upstream,
+  live in [`docs/proxy/README.md`](proxy/README.md).
 - `format` is reserved for future format-specific knobs; ocifactory
   preserves it across roundtrips so a newer ocifactory's keys aren't
   silently dropped by an older one.

--- a/docs/proxy/README.md
+++ b/docs/proxy/README.md
@@ -1,0 +1,36 @@
+# Pull-through proxy design
+
+Proxy namespaces are read-through caches. On a file miss, ocifactory
+checks policy, fetches the upstream artifact itself, streams the bytes
+to the client, and writes the same bytes into OCI. It intentionally
+does **not** redirect cold-miss clients to the upstream artifact URL
+and warm the OCI cache asynchronously.
+
+The primary reason is network topology. In many deployments,
+ocifactory is the only artifact endpoint allowlisted from build
+workers, CI runners, or developer networks. The public upstream
+(`pypi.org`, `registry.npmjs.org`, Maven Central, or an internal
+upstream in another network zone) may be blocked by firewall, egress
+policy, proxy configuration, or audit controls. A redirect makes the
+client open the upstream URL directly, so installs would fail exactly
+in the environments where a proxy is most useful.
+
+Keeping cold-miss bytes on the ocifactory data path also preserves the
+proxy contract:
+
+- Clients only need network access to ocifactory.
+- Namespace readers can populate the cache without being granted
+  publish rights.
+- Filters, size caps, and audit logs stay at the same boundary as the
+  artifact bytes.
+- A successful cold miss has a deterministic cache-fill attempt tied
+  to the request, rather than a best-effort background job that may be
+  lost if the serving instance stops.
+- Concurrent first misses can collapse to one upstream fetch per
+  process; followers serve from OCI after the leader fills the cache.
+
+This is distinct from **backend blob redirect** on cache hits. When an
+artifact already exists in OCI, ocifactory may return a `307` to an
+operator-controlled backend presigned URL, depending on backend support
+and the `--disable-blob-redirect` flag. That redirect targets the OCI
+storage backend, not the package upstream.

--- a/pkg/handler/maven/maven_upstream_integration_test.go
+++ b/pkg/handler/maven/maven_upstream_integration_test.go
@@ -13,6 +13,7 @@ package maven_test
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
@@ -25,6 +26,7 @@ import (
 	mavenhandler "github.com/yolocs/ocifactory/pkg/handler/maven"
 	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
+	"oras.land/oras-go/v2/errdef"
 )
 
 // TestMavenIntegration_LiveCentralProxy proves Maven proxy mode works
@@ -173,7 +175,22 @@ func assertMavenArtifactCached(t *testing.T, zotURL *url.URL, backendRepo, names
 	}
 	desc, rc, err := inner.ReadFile(t.Context(), f)
 	if err != nil {
-		t.Fatalf("read cached artifact from OCI: %v", err)
+		// The proxy fill returns after AddCachedFile completes, but
+		// this assertion uses a separate OCI client against live zot.
+		// Give zot's referrer lookup a short window to observe the
+		// freshly pushed file manifest before declaring the cache
+		// fill broken.
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) && errors.Is(err, errdef.ErrNotFound) {
+			time.Sleep(100 * time.Millisecond)
+			desc, rc, err = inner.ReadFile(t.Context(), f)
+			if err == nil {
+				break
+			}
+		}
+		if err != nil {
+			t.Fatalf("read cached artifact from OCI: %v", err)
+		}
 	}
 	defer rc.Close()
 	if desc.File.Size == 0 {

--- a/pkg/handler/maven/proxy_test.go
+++ b/pkg/handler/maven/proxy_test.go
@@ -138,7 +138,7 @@ func TestProxy_FileMissFetchesAndCaches(t *testing.T) {
 		ContentType:   "application/java-archive",
 		ContentLength: int64(len(body)),
 	}
-	h, _, _ := newProxyTestHandler(t, fetcher, namespace.Spec{})
+	h, _, backing := newProxyTestHandler(t, fetcher, namespace.Spec{})
 
 	req := httptest.NewRequest(http.MethodGet, nsPath("/com/example/demo/1.2.0/demo-1.2.0.jar"), nil)
 	rec := httptest.NewRecorder()
@@ -148,6 +148,16 @@ func TestProxy_FileMissFetchesAndCaches(t *testing.T) {
 	}
 	if got := rec.Body.String(); got != body {
 		t.Errorf("body=%q, want %q", got, body)
+	}
+	files, err := backing.ListFiles(t.Context(), testNS+"/com/example/demo")
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("cached files = %d, want 1", len(files))
+	}
+	if got, want := files[0].Name, "demo-1.2.0.jar"; got != want {
+		t.Errorf("cached file name = %q, want %q", got, want)
 	}
 
 	req = httptest.NewRequest(http.MethodGet, nsPath("/com/example/demo/1.2.0/demo-1.2.0.jar"), nil)

--- a/pkg/handler/python/proxy.go
+++ b/pkg/handler/python/proxy.go
@@ -204,8 +204,8 @@ func (h *Handler) dispatchProxy(w http.ResponseWriter, req *http.Request, scoped
 //     status.
 //  4. metadata-dependent filters (publish-time delay). Deny → 404.
 //  5. upstream file fetch.
-//  6. tee through AddFile while streaming to client. AddFile error
-//     mid-stream → 502; next request retries.
+//  6. tee through AddCachedFile while streaming to client. Cache-fill
+//     error mid-stream → 502; next request retries.
 //
 // Concurrent first-misses for the same (ns, pkg, version, filename)
 // collapse onto one upstream fetch via the file-singleflight group.
@@ -370,13 +370,13 @@ func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, s
 			body = io.TeeReader(body, teeRef)
 		}
 
-		// AddFile writes blob + file manifest + version anchor;
-		// authorizes for write on the bound namespace policy. An
+		// AddCachedFile writes blob + file manifest + version anchor;
+		// authorizes for read on the bound namespace policy. An
 		// already-exists error means a concurrent cold-miss raced us
 		// before singleflight could; probeExistingFile reports it
 		// before reading the body, so no client bytes were written and
 		// the follower path can serve from the cache the peer wrote.
-		if _, addErr := scoped.AddFile(ctx, populated, body); addErr != nil {
+		if _, addErr := scoped.AddCachedFile(ctx, populated, body); addErr != nil {
 			if errors.Is(addErr, oci.ErrAlreadyExists) {
 				return fileFlightResult{cached: true}, nil
 			}

--- a/pkg/handler/python/proxy_test.go
+++ b/pkg/handler/python/proxy_test.go
@@ -329,6 +329,51 @@ func TestProxy_FileMissFetchAndCache(t *testing.T) {
 	}
 }
 
+func TestProxy_FileMissCacheFillRequiresOnlyReadPolicy(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeFetcher()
+	const fileURL = "https://files.pythonhosted.org/packages/abc/requests-2.31.0-py3-none-any.whl"
+	fake.versionMeta["requests@2.31.0"] = &pypython.VersionMetadata{
+		Package: "requests",
+		Version: "2.31.0",
+		Files: []pypython.FileMetadata{{
+			Filename:   "requests-2.31.0-py3-none-any.whl",
+			URL:        fileURL,
+			Size:       11,
+			UploadTime: time.Date(2023, 5, 22, 15, 12, 42, 0, time.UTC),
+		}},
+		UploadTime: time.Date(2023, 5, 22, 15, 12, 42, 0, time.UTC),
+	}
+	fake.files[fileURL] = []byte("wheel-bytes")
+
+	spec := namespace.Spec{
+		Policy: namespace.Policy{
+			Readers: []namespace.SubjectMatcher{{Issuer: "anonymous"}},
+			Writers: []namespace.SubjectMatcher{{Issuer: "https://accounts.google.com"}},
+		},
+	}
+	h, _, backing := newProxyTestHandler(t, fake, spec)
+
+	path := "/" + testNS + "/packages/requests/2.31.0/requests-2.31.0-py3-none-any.whl"
+	w := httptest.NewRecorder()
+	h.Mux().ServeHTTP(w, httptest.NewRequest(http.MethodGet, path, nil))
+	if got, want := w.Code, http.StatusOK; got != want {
+		t.Fatalf("status = %d, want %d (body=%s)", got, want, w.Body.String())
+	}
+	if body := w.Body.String(); body != "wheel-bytes" {
+		t.Errorf("body = %q, want %q", body, "wheel-bytes")
+	}
+
+	files, err := backing.ListFiles(t.Context(), testNS+"/packages/requests")
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	if len(files) != 1 {
+		t.Errorf("backing has %d files, want 1", len(files))
+	}
+}
+
 // TestProxy_FileMetadataSidecar exercises the PEP 658 path: when pip
 // asks for `<wheel>.metadata` (because the upstream simple index
 // advertised `data-core-metadata`), the proxy synthesizes the upstream


### PR DESCRIPTION
## Motivation

Python proxy cold misses were using `ScopedRegistry.AddFile`, which authorizes with `OpWrite`. That made Python inconsistent with npm and Maven proxy cache fills: a namespace reader could install from proxy indexes but could not populate the OCI cache unless they were also granted writer privileges.

## Summary

- Switch Python proxy file cache fills from `AddFile` to `AddCachedFile`, so read-through cache population requires `OpRead` rather than `OpWrite`.
- Add a regression test for a reader-only proxy namespace cold miss.
- Add shared proxy design docs explaining why cold misses stream through ocifactory instead of redirecting clients directly to upstream artifact URLs, with the network allowlist case called out as the primary reason.
- Link the shared proxy design note from the admin namespace docs.

## Validation

- `go test ./pkg/handler/python -count=1`

No GitHub issue is linked; this came from design review follow-up.