### PR TITLE
Add artifact storage API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ HTTP request ──►     │  cmd/ocifactory  (CLI entrypoint)         │
                      └───────────────┬──────────────────────────┘
                                      │ handler.Registry interface
                      ┌───────────────▼──────────────────────────┐
-                     │  pkg/artifact.ScopedNamespace             │
+                     │  pkg/artifact.NamespaceView               │
                      │  • authorizes (read/write) against the    │
                      │    namespace's compiled Policy            │
                      │  • prefixes OwningRepo with <namespace>/  │
@@ -108,13 +108,13 @@ Read that doc before touching the `pkg/oci` write paths.
 ### Key types
 
 - `oci.RepoFile{OwningRepo, OwningTag, RefTag, Name, MediaType, Digest, Size, AllowOverwrite}` — addresses one file inside the OCI-backed virtual store.
-  - `OwningRepo` is the OCI repository name **relative to the namespace** at the handler boundary. Package storage must use the format's `storage.go` codec and live under `packages/<format-specific encoding>` (e.g. `packages/requests`, `packages/com/foo/bar`). Sibling/internal repos such as `archetype`, `ocifactory-packages`, `python-packages`, `npm-packages`, and `_proxy_cache`/`ocifactory-proxy-cache` stay outside `packages/`. The `artifact.ScopedNamespace` wrapper prefixes with `<namespace>/`, and `pkg/oci` may add `--repo-prefix` before that, so the real backend repo can be `<repo-prefix>/<namespace>/packages/requests`.
+  - `OwningRepo` is the OCI repository name **relative to the namespace** at the handler boundary. Package storage must use the format's `storage.go` codec and live under `packages/<format-specific encoding>` (e.g. `packages/requests`, `packages/com/foo/bar`). Sibling/internal repos such as `archetype`, `ocifactory-packages`, `python-packages`, `npm-packages`, and `_proxy_cache`/`ocifactory-proxy-cache` stay outside `packages/`. The `artifact.NamespaceView` wrapper prefixes with `<namespace>/`, and `pkg/oci` may add `--repo-prefix` before that, so the real backend repo can be `<repo-prefix>/<namespace>/packages/requests`.
   - `OwningTag` is the canonical version tag (e.g. `2.31.0`). It identifies the **version manifest** — a constant-size anchor in the [OCI 1.1 referrers layout](docs/architecture/storage-model.md). Files for that version are *not* layers on this manifest; each file is its own **file manifest** with `subject = versionDesc`, addressed via the referrers API and tagged with a deterministic `_f_<sha256>` tag so reads resolve in one round-trip.
   - `RefTag` is an alias tag like `latest`. It identifies an **alias manifest** with `subject = versionDesc` and the canonical version recorded in the `ocifactory.alias.target` annotation.
   - `AllowOverwrite` is a per-file flag handlers set when the file is intentionally mutable (Maven snapshot artifacts, snapshot `maven-metadata.xml`). It overrides the registry-level `--allow-overwrite` default for that one call.
   - The three manifest kinds are distinguished by `artifactType` suffix — `.version`, `.file`, `.alias` — appended to the operator-configured base type (e.g. `application/vnd.ocifactory.python.version`).
-- `handler.Registry` — the interface every per-format handler depends on. Keep it minimal; do not push format-specific concepts into it. Implementations are `*oci.Registry` (raw) and `*artifact.ScopedNamespace` (namespaced + authorized, used in production).
-- `artifact.Store` / `artifact.ScopedNamespace` — the data-plane artifact wrapper. `Store.For(ns)` returns a cheap per-request `ScopedNamespace` that handlers use as their `handler.Registry`. Authorizer instances are cached per namespace (`DefaultPolicyCacheTTL = 60s`) and invalidated automatically when admin-side `namespace.Store.Put` / `namespace.Store.Delete` fires the mutation hook.
+- `handler.Registry` — the interface every per-format handler depends on. Keep it minimal; do not push format-specific concepts into it. Implementations are `*oci.Registry` (raw) and `*artifact.NamespaceView` (namespaced + authorized, used in production).
+- `artifact.Store` / `artifact.NamespaceView` — the data-plane artifact wrapper. `Store.View(ns)` returns a cheap per-request `NamespaceView` that handlers use as their `handler.Registry`. Authorizer instances are cached per namespace (`DefaultPolicyCacheTTL = 60s`) and invalidated automatically when admin-side `namespace.Store.Put` / `namespace.Store.Delete` fires the mutation hook.
 - `namespace.Policy` — the JSON-serialised authz block on a namespace `Spec`. Empty Policy is deny-all. `Readers` and `Writers` are independent `SubjectMatcher` lists; matchers ANDed across fields (`issuer`, `sub_match` regex, `email`, `claims_match`, `kind`).
 - `auth.AuthContext{Issuer, ID, Email, Claims}` — the verified caller identity the OIDC authenticator installs into the request context. The `namespace.PolicyAuthorizer` consumes it; out-of-tree authorizers (OPA / Cedar / Casbin) plug in via `artifact.WithAuthzFactory`.
 - `auth.Authorizer` / `auth.Op` (`OpRead`, `OpWrite`) — the coarse pluggable authz surface every namespace policy compiles to.
@@ -125,10 +125,10 @@ Each `pkg/handler/<format>` package owns:
 - `RepoType` constant (`"npm"`, `"python"`, …) — used by `serve` to dispatch.
 - `ArtifactType` constant — the OCI manifest `artifactType` base (e.g. `application/vnd.ocifactory.npm`). `pkg/oci` appends `.version` / `.file` / `.alias` to it so the three manifest kinds are distinguishable in the OCI backend.
 - `NewHandler(*artifact.Store, opts ...Option) (*Handler, error)` — takes the artifact data-plane wrapper, not a raw `*oci.Registry`, so every request goes through the authorizer.
-- `Mux() http.Handler` — gorilla/mux router for that format's URL scheme. Mount every route on a `router.PathPrefix("/{namespace}").Subrouter()` (or `"/{namespace}/<format-prefix>"`) so the handler can read the namespace from `mux.Vars(req)` and call `r.For(ns)` to get a per-request `*artifact.ScopedNamespace`.
-- Translation logic mapping client protocol calls ↔ `RepoFile` operations through the scoped artifact.
+- `Mux() http.Handler` — gorilla/mux router for that format's URL scheme. Mount every route on a `router.PathPrefix("/{namespace}").Subrouter()` (or `"/{namespace}/<format-prefix>"`) so the handler can read the namespace from `mux.Vars(req)` and call `r.View(ns)` to get a per-request `*artifact.NamespaceView`.
+- Translation logic mapping client protocol calls ↔ `RepoFile` operations through the namespace view.
 
-When adding a new format, copy the structure from `pkg/handler/python` (it's the most complete reference, including the embedded simple index template, the per-package simple-index cache, and the `storage.go` codec + `ScopedNamespace.Index` pattern for fast "list packages").
+When adding a new format, copy the structure from `pkg/handler/python` (it's the most complete reference, including the embedded simple index template, the per-package simple-index cache, and the `storage.go` codec + `NamespaceView.Index` pattern for fast "list packages").
 
 ### Namespace URL layout
 
@@ -143,15 +143,15 @@ single hostname serves multiple formats per namespace:
 | npm    | `/{namespace}/<pkg>`, `/{namespace}/{@scope/name}`, `/{namespace}/-/package/<pkg>/dist-tags/<tag>`, `/{namespace}/-/ping` |
 
 Namespaces have to be created via the [admin API](docs/admin.md) before any
-request can land on them — there is no auto-vivification. `ScopedNamespace`
+request can land on them — there is no auto-vivification. `NamespaceView`
 returns `namespace.ErrNotFound` (mapped to 404 by `handler.WriteNamespaceError`)
 when the namespace's metadata document is missing.
 
 ### Index repos pattern
 
-For formats where you need "list all packages I have" (PyPI simple index, npm registry root, etc.), use `(*artifact.ScopedNamespace).Index("<format>-packages")`. The namespace index primitive owns tag encoding/decoding and stores one sentinel tag per package in a sibling repo outside `packages/`; do not write literal `OwningRepo: "index"` entries from handlers.
+For formats where you need "list all packages I have" (PyPI simple index, npm registry root, etc.), use `(*artifact.NamespaceView).Index("<format>-packages")`. The namespace index primitive owns tag encoding/decoding and stores one sentinel tag per package in a sibling repo outside `packages/`; do not write literal `OwningRepo: "index"` entries from handlers.
 
-Separately, `artifact.Store` itself maintains a per-namespace **package index repo** at `<namespace>/ocifactory-packages` (configurable via `WithPackageIndexSuffix`). It's an in-process LRU-deduped record of every owning-repo the wrapper has written to, used by `admin serve`'s soft-delete to refuse deleting a non-empty namespace. Format handlers don't write to it directly — every `ScopedNamespace.AddFile` call updates it best-effort.
+Separately, `artifact.Store` itself maintains a per-namespace **package index repo** at `<namespace>/ocifactory-packages` (configurable via `WithPackageIndexSuffix`). It's an in-process LRU-deduped record of every owning-repo the wrapper has written to, used by `admin serve`'s soft-delete to refuse deleting a non-empty namespace. Format handlers don't write to it directly — every `NamespaceView.AddFile` call updates it best-effort.
 
 ## Build, run, test
 
@@ -241,10 +241,10 @@ These are non-negotiable. Apply them to every test in the repo:
 1. Create `pkg/handler/<format>/` with `handler.go`, the `Mux()`, and translation logic.
 2. Define `RepoType` and `ArtifactType` constants.
 3. Define a `storage.go` codec module that owns the `packages/<encoding>` mapping. Handlers must call the codec, not construct `OwningRepo` strings inline.
-4. If the format needs package enumeration, use `(*ScopedNamespace).Index("<format>-packages")`; do not write to a literal `OwningRepo: "index"`. If user data must become an OCI tag, use `oci.EncodeTag` / `oci.DecodeTag`.
-5. **Mount every route under a `/{namespace}` sub-router** so the handler can read the namespace from `mux.Vars(req)` and call `registry.For(ns)` to get a per-request `*artifact.ScopedNamespace`. Optionally prefix routes with a per-format segment (`/{namespace}/maven2/...`, `/{namespace}/simple/...`) when the URL would otherwise be ambiguous against another format on the same hostname.
+4. If the format needs package enumeration, use `(*NamespaceView).Index("<format>-packages")`; do not write to a literal `OwningRepo: "index"`. If user data must become an OCI tag, use `oci.EncodeTag` / `oci.DecodeTag`.
+5. **Mount every route under a `/{namespace}` sub-router** so the handler can read the namespace from `mux.Vars(req)` and call `registry.View(ns)` to get a per-request `*artifact.NamespaceView`. Optionally prefix routes with a per-format segment (`/{namespace}/maven2/...`, `/{namespace}/simple/...`) when the URL would otherwise be ambiguous against another format on the same hostname.
 6. **Accept `WithAuthMiddleware(func(http.Handler) http.Handler)` as an Option** and chain the middleware on whichever routes need authentication. The convention today (python, maven, npm) is `router.Use(mux.MiddlewareFunc(h.authMW))` on the root router (python, maven) or on the `/{namespace}` sub-router (npm) so every route is gated. Public-by-default formats (Go module proxy listings, future read-without-token endpoints) would chain on a sub-router and leave reads ungated; outlier endpoints with their own auth contract sit on a sub-router that doesn't chain it at all. **Do not add an open default**: in `pkg/commands/serve.go`, always pass `WithAuthMiddleware(authMW)` when constructing the handler. The handler-side option is permissive (omitting it leaves routes ungated, which is what tests want), so the gate against silent-no-auth lives in serve.go — verify it's wired before merging.
-7. **Take a `*artifact.Store` in `NewHandler`**, not a `*oci.Registry`. Every backend op flows through the scoped view so the namespace's compiled `Policy` runs on every read and write. Map `namespace.ErrNotFound`, `namespace.ErrInvalidName`, `namespace.ErrInvalidOwningRepo`, and `auth.ErrUnauthorized` to HTTP via `handler.WriteNamespaceError` — there's a shared helper because every format needs the same translation.
+7. **Take a `*artifact.Store` in `NewHandler`**, not a `*oci.Registry`. Every backend op flows through the namespace view so the namespace's compiled `Policy` runs on every read and write. Map `namespace.ErrNotFound`, `namespace.ErrInvalidName`, `namespace.ErrInvalidOwningRepo`, and `auth.ErrUnauthorized` to HTTP via `handler.WriteNamespaceError` — there's a shared helper because every format needs the same translation.
 8. Plumb it into `pkg/commands/serve.go`'s `supportedRepoTypes` and the `switch` in `Run`. Build a `namespace.Store` for control-plane metadata and an `artifact.Store` for data-plane access next to the format-specific `*oci.Registry`, then pass the artifact store to the handler constructor along with `WithAuthMiddleware(authMW)`.
 9. Add handler tests using the `oci.fake` backend (cover happy path + 404 + auth errors at minimum). Add a `pkg/handler/<format>/auth_test.go` that mirrors `pkg/handler/python/auth_test.go`: a deny-all middleware reaches every route, omitting the option leaves routes ungated, and the middleware chains before the route handler runs. Add a `pkg/handler/<format>/namespace_test.go` mirroring `pkg/handler/python/namespace_test.go`: unknown namespace → 404, deny-all policy → 403, cross-namespace request can't reach another namespace's data.
 10. Add an integration test or a documented manual test against a real client (`pip`, `mvn`, `npm install`, `go mod download`, `apt-get`). The harness in `pkg/handler/integrationtest/` seeds a `default` namespace via `Store.Put` before the subprocess starts; copy that pattern.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ HTTP request ──►     │  cmd/ocifactory  (CLI entrypoint)         │
                      └───────────────┬──────────────────────────┘
                                      │ handler.Registry interface
                      ┌───────────────▼──────────────────────────┐
-                     │  pkg/namespace.ScopedRegistry             │
+                     │  pkg/artifact.ScopedNamespace             │
                      │  • authorizes (read/write) against the    │
                      │    namespace's compiled Policy            │
                      │  • prefixes OwningRepo with <namespace>/  │
@@ -108,15 +108,15 @@ Read that doc before touching the `pkg/oci` write paths.
 ### Key types
 
 - `oci.RepoFile{OwningRepo, OwningTag, RefTag, Name, MediaType, Digest, Size, AllowOverwrite}` — addresses one file inside the OCI-backed virtual store.
-  - `OwningRepo` is the OCI repository name **relative to the namespace** at the handler boundary. Package storage must use the format's `storage.go` codec and live under `packages/<format-specific encoding>` (e.g. `packages/requests`, `packages/com/foo/bar`). Sibling/internal repos such as `archetype`, `ocifactory-packages`, `python-packages`, `npm-packages`, and `_proxy_cache`/`ocifactory-proxy-cache` stay outside `packages/`. The `namespace.ScopedRegistry` wrapper prefixes with `<namespace>/`, and `pkg/oci` may add `--repo-prefix` before that, so the real backend repo can be `<repo-prefix>/<namespace>/packages/requests`.
+  - `OwningRepo` is the OCI repository name **relative to the namespace** at the handler boundary. Package storage must use the format's `storage.go` codec and live under `packages/<format-specific encoding>` (e.g. `packages/requests`, `packages/com/foo/bar`). Sibling/internal repos such as `archetype`, `ocifactory-packages`, `python-packages`, `npm-packages`, and `_proxy_cache`/`ocifactory-proxy-cache` stay outside `packages/`. The `artifact.ScopedNamespace` wrapper prefixes with `<namespace>/`, and `pkg/oci` may add `--repo-prefix` before that, so the real backend repo can be `<repo-prefix>/<namespace>/packages/requests`.
   - `OwningTag` is the canonical version tag (e.g. `2.31.0`). It identifies the **version manifest** — a constant-size anchor in the [OCI 1.1 referrers layout](docs/architecture/storage-model.md). Files for that version are *not* layers on this manifest; each file is its own **file manifest** with `subject = versionDesc`, addressed via the referrers API and tagged with a deterministic `_f_<sha256>` tag so reads resolve in one round-trip.
   - `RefTag` is an alias tag like `latest`. It identifies an **alias manifest** with `subject = versionDesc` and the canonical version recorded in the `ocifactory.alias.target` annotation.
   - `AllowOverwrite` is a per-file flag handlers set when the file is intentionally mutable (Maven snapshot artifacts, snapshot `maven-metadata.xml`). It overrides the registry-level `--allow-overwrite` default for that one call.
   - The three manifest kinds are distinguished by `artifactType` suffix — `.version`, `.file`, `.alias` — appended to the operator-configured base type (e.g. `application/vnd.ocifactory.python.version`).
-- `handler.Registry` — the interface every per-format handler depends on. Keep it minimal; do not push format-specific concepts into it. Implementations are `*oci.Registry` (raw) and `*namespace.ScopedRegistry` (namespaced + authorized, used in production).
-- `namespace.Registry` / `namespace.ScopedRegistry` — the data-plane namespace wrapper. `Registry.For(ns)` returns a cheap per-request `ScopedRegistry` that handlers use as their `handler.Registry`. Authorizer instances are cached per namespace (`DefaultPolicyCacheTTL = 60s`) and invalidated automatically when admin-side `Store.Put` / `Store.Delete` fires the mutation hook.
+- `handler.Registry` — the interface every per-format handler depends on. Keep it minimal; do not push format-specific concepts into it. Implementations are `*oci.Registry` (raw) and `*artifact.ScopedNamespace` (namespaced + authorized, used in production).
+- `artifact.Store` / `artifact.ScopedNamespace` — the data-plane artifact wrapper. `Store.For(ns)` returns a cheap per-request `ScopedNamespace` that handlers use as their `handler.Registry`. Authorizer instances are cached per namespace (`DefaultPolicyCacheTTL = 60s`) and invalidated automatically when admin-side `namespace.Store.Put` / `namespace.Store.Delete` fires the mutation hook.
 - `namespace.Policy` — the JSON-serialised authz block on a namespace `Spec`. Empty Policy is deny-all. `Readers` and `Writers` are independent `SubjectMatcher` lists; matchers ANDed across fields (`issuer`, `sub_match` regex, `email`, `claims_match`, `kind`).
-- `auth.AuthContext{Issuer, ID, Email, Claims}` — the verified caller identity the OIDC authenticator installs into the request context. The `namespace.PolicyAuthorizer` consumes it; out-of-tree authorizers (OPA / Cedar / Casbin) plug in via `namespace.WithAuthzFactory`.
+- `auth.AuthContext{Issuer, ID, Email, Claims}` — the verified caller identity the OIDC authenticator installs into the request context. The `namespace.PolicyAuthorizer` consumes it; out-of-tree authorizers (OPA / Cedar / Casbin) plug in via `artifact.WithAuthzFactory`.
 - `auth.Authorizer` / `auth.Op` (`OpRead`, `OpWrite`) — the coarse pluggable authz surface every namespace policy compiles to.
 
 ### How a per-format handler is structured
@@ -124,11 +124,11 @@ Read that doc before touching the `pkg/oci` write paths.
 Each `pkg/handler/<format>` package owns:
 - `RepoType` constant (`"npm"`, `"python"`, …) — used by `serve` to dispatch.
 - `ArtifactType` constant — the OCI manifest `artifactType` base (e.g. `application/vnd.ocifactory.npm`). `pkg/oci` appends `.version` / `.file` / `.alias` to it so the three manifest kinds are distinguishable in the OCI backend.
-- `NewHandler(*namespace.Registry, opts ...Option) (*Handler, error)` — takes the namespace wrapper, not a raw `*oci.Registry`, so every request goes through the authorizer.
-- `Mux() http.Handler` — gorilla/mux router for that format's URL scheme. Mount every route on a `router.PathPrefix("/{namespace}").Subrouter()` (or `"/{namespace}/<format-prefix>"`) so the handler can read the namespace from `mux.Vars(req)` and call `r.For(ns)` to get a per-request `*namespace.ScopedRegistry`.
-- Translation logic mapping client protocol calls ↔ `RepoFile` operations through the scoped registry.
+- `NewHandler(*artifact.Store, opts ...Option) (*Handler, error)` — takes the artifact data-plane wrapper, not a raw `*oci.Registry`, so every request goes through the authorizer.
+- `Mux() http.Handler` — gorilla/mux router for that format's URL scheme. Mount every route on a `router.PathPrefix("/{namespace}").Subrouter()` (or `"/{namespace}/<format-prefix>"`) so the handler can read the namespace from `mux.Vars(req)` and call `r.For(ns)` to get a per-request `*artifact.ScopedNamespace`.
+- Translation logic mapping client protocol calls ↔ `RepoFile` operations through the scoped artifact.
 
-When adding a new format, copy the structure from `pkg/handler/python` (it's the most complete reference, including the embedded simple index template, the per-package simple-index cache, and the `storage.go` codec + `ScopedRegistry.Index` pattern for fast "list packages").
+When adding a new format, copy the structure from `pkg/handler/python` (it's the most complete reference, including the embedded simple index template, the per-package simple-index cache, and the `storage.go` codec + `ScopedNamespace.Index` pattern for fast "list packages").
 
 ### Namespace URL layout
 
@@ -143,15 +143,15 @@ single hostname serves multiple formats per namespace:
 | npm    | `/{namespace}/<pkg>`, `/{namespace}/{@scope/name}`, `/{namespace}/-/package/<pkg>/dist-tags/<tag>`, `/{namespace}/-/ping` |
 
 Namespaces have to be created via the [admin API](docs/admin.md) before any
-request can land on them — there is no auto-vivification. `ScopedRegistry`
+request can land on them — there is no auto-vivification. `ScopedNamespace`
 returns `namespace.ErrNotFound` (mapped to 404 by `handler.WriteNamespaceError`)
 when the namespace's metadata document is missing.
 
 ### Index repos pattern
 
-For formats where you need "list all packages I have" (PyPI simple index, npm registry root, etc.), use `(*namespace.ScopedRegistry).Index("<format>-packages")`. The namespace index primitive owns tag encoding/decoding and stores one sentinel tag per package in a sibling repo outside `packages/`; do not write literal `OwningRepo: "index"` entries from handlers.
+For formats where you need "list all packages I have" (PyPI simple index, npm registry root, etc.), use `(*artifact.ScopedNamespace).Index("<format>-packages")`. The namespace index primitive owns tag encoding/decoding and stores one sentinel tag per package in a sibling repo outside `packages/`; do not write literal `OwningRepo: "index"` entries from handlers.
 
-Separately, `namespace.Registry` itself maintains a per-namespace **package index repo** at `<namespace>/ocifactory-packages` (configurable via `WithPackageIndexSuffix`). It's an in-process LRU-deduped record of every owning-repo the wrapper has written to, used by `admin serve`'s soft-delete to refuse deleting a non-empty namespace. Format handlers don't write to it directly — every `ScopedRegistry.AddFile` call updates it best-effort.
+Separately, `artifact.Store` itself maintains a per-namespace **package index repo** at `<namespace>/ocifactory-packages` (configurable via `WithPackageIndexSuffix`). It's an in-process LRU-deduped record of every owning-repo the wrapper has written to, used by `admin serve`'s soft-delete to refuse deleting a non-empty namespace. Format handlers don't write to it directly — every `ScopedNamespace.AddFile` call updates it best-effort.
 
 ## Build, run, test
 
@@ -241,11 +241,11 @@ These are non-negotiable. Apply them to every test in the repo:
 1. Create `pkg/handler/<format>/` with `handler.go`, the `Mux()`, and translation logic.
 2. Define `RepoType` and `ArtifactType` constants.
 3. Define a `storage.go` codec module that owns the `packages/<encoding>` mapping. Handlers must call the codec, not construct `OwningRepo` strings inline.
-4. If the format needs package enumeration, use `(*ScopedRegistry).Index("<format>-packages")`; do not write to a literal `OwningRepo: "index"`. If user data must become an OCI tag, use `oci.EncodeTag` / `oci.DecodeTag`.
-5. **Mount every route under a `/{namespace}` sub-router** so the handler can read the namespace from `mux.Vars(req)` and call `registry.For(ns)` to get a per-request `*namespace.ScopedRegistry`. Optionally prefix routes with a per-format segment (`/{namespace}/maven2/...`, `/{namespace}/simple/...`) when the URL would otherwise be ambiguous against another format on the same hostname.
+4. If the format needs package enumeration, use `(*ScopedNamespace).Index("<format>-packages")`; do not write to a literal `OwningRepo: "index"`. If user data must become an OCI tag, use `oci.EncodeTag` / `oci.DecodeTag`.
+5. **Mount every route under a `/{namespace}` sub-router** so the handler can read the namespace from `mux.Vars(req)` and call `registry.For(ns)` to get a per-request `*artifact.ScopedNamespace`. Optionally prefix routes with a per-format segment (`/{namespace}/maven2/...`, `/{namespace}/simple/...`) when the URL would otherwise be ambiguous against another format on the same hostname.
 6. **Accept `WithAuthMiddleware(func(http.Handler) http.Handler)` as an Option** and chain the middleware on whichever routes need authentication. The convention today (python, maven, npm) is `router.Use(mux.MiddlewareFunc(h.authMW))` on the root router (python, maven) or on the `/{namespace}` sub-router (npm) so every route is gated. Public-by-default formats (Go module proxy listings, future read-without-token endpoints) would chain on a sub-router and leave reads ungated; outlier endpoints with their own auth contract sit on a sub-router that doesn't chain it at all. **Do not add an open default**: in `pkg/commands/serve.go`, always pass `WithAuthMiddleware(authMW)` when constructing the handler. The handler-side option is permissive (omitting it leaves routes ungated, which is what tests want), so the gate against silent-no-auth lives in serve.go — verify it's wired before merging.
-7. **Take a `*namespace.Registry` in `NewHandler`**, not a `*oci.Registry`. Every backend op flows through the scoped view so the namespace's compiled `Policy` runs on every read and write. Map `namespace.ErrNotFound`, `namespace.ErrInvalidName`, `namespace.ErrInvalidOwningRepo`, and `auth.ErrUnauthorized` to HTTP via `handler.WriteNamespaceError` — there's a shared helper because every format needs the same translation.
-8. Plumb it into `pkg/commands/serve.go`'s `supportedRepoTypes` and the `switch` in `Run`. Build the `*namespace.Registry` next to the format-specific `*oci.Registry`, pass it to the handler constructor along with `WithAuthMiddleware(authMW)`.
+7. **Take a `*artifact.Store` in `NewHandler`**, not a `*oci.Registry`. Every backend op flows through the scoped view so the namespace's compiled `Policy` runs on every read and write. Map `namespace.ErrNotFound`, `namespace.ErrInvalidName`, `namespace.ErrInvalidOwningRepo`, and `auth.ErrUnauthorized` to HTTP via `handler.WriteNamespaceError` — there's a shared helper because every format needs the same translation.
+8. Plumb it into `pkg/commands/serve.go`'s `supportedRepoTypes` and the `switch` in `Run`. Build a `namespace.Store` for control-plane metadata and an `artifact.Store` for data-plane access next to the format-specific `*oci.Registry`, then pass the artifact store to the handler constructor along with `WithAuthMiddleware(authMW)`.
 9. Add handler tests using the `oci.fake` backend (cover happy path + 404 + auth errors at minimum). Add a `pkg/handler/<format>/auth_test.go` that mirrors `pkg/handler/python/auth_test.go`: a deny-all middleware reaches every route, omitting the option leaves routes ungated, and the middleware chains before the route handler runs. Add a `pkg/handler/<format>/namespace_test.go` mirroring `pkg/handler/python/namespace_test.go`: unknown namespace → 404, deny-all policy → 403, cross-namespace request can't reach another namespace's data.
 10. Add an integration test or a documented manual test against a real client (`pip`, `mvn`, `npm install`, `go mod download`, `apt-get`). The harness in `pkg/handler/integrationtest/` seeds a `default` namespace via `Store.Put` before the subprocess starts; copy that pattern.
 11. Document the format under `docs/repos/<format>.md`: URL layout (including the `/{namespace}/` prefix), supported client commands, known limitations. Copy [`docs/repos/_template.md`](docs/repos/_template.md) — it has the headings and depth `python.md` / `maven.md` / `npm.md` use, plus inline notes on what to call out front-and-center (e.g. operator footguns that break the second invocation of the most common client command).

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ client ──► handler/<format> ──► artifact.Store ──► pkg/oci.Reg
 One Go binary. One process. Storage offloaded entirely to your OCI registry.
 Each artifact format gets its own `pkg/handler/<format>` package implementing
 the relevant protocol; every request resolves its `{namespace}` URL segment
-into a per-namespace `ScopedNamespace` view that authorizes the operation
+into a per-namespace `NamespaceView` that authorizes the operation
 against the namespace's policy and prefixes OCI repos with the namespace.
 
 For the on-OCI shape — version anchors, file manifests, alias manifests, and

--- a/README.md
+++ b/README.md
@@ -96,13 +96,13 @@ options and [`docs/repos/`](docs/repos/) for per-format guides.
 ## Architecture
 
 ```
-client ──► handler/<format> ──► namespace.Registry ──► pkg/oci.Registry ──► OCI registry (ORAS)
+client ──► handler/<format> ──► artifact.Store ──► pkg/oci.Registry ──► OCI registry (ORAS)
 ```
 
 One Go binary. One process. Storage offloaded entirely to your OCI registry.
 Each artifact format gets its own `pkg/handler/<format>` package implementing
 the relevant protocol; every request resolves its `{namespace}` URL segment
-into a per-namespace `ScopedRegistry` view that authorizes the operation
+into a per-namespace `ScopedNamespace` view that authorizes the operation
 against the namespace's policy and prefixes OCI repos with the namespace.
 
 For the on-OCI shape — version anchors, file manifests, alias manifests, and

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -69,7 +69,7 @@ scoped-token issuance.
   — a matcher-based authorizer compiled from each namespace's `Policy`
   block (`readers` / `writers` `SubjectMatcher` lists). Out-of-tree
   authorizers (OPA / Cedar / Casbin) plug in via
-  `namespace.WithAuthzFactory`.
+  `artifact.WithAuthzFactory`.
 - [x] **Pluggable backend credential `Provider`.** In-tree adapters:
   `anonymous`, `gcpadc` (ADC), `staticenv` (env vars, re-read every
   call), `dockerconfig` (honours credential helpers). See
@@ -93,7 +93,7 @@ scoped-token issuance.
   the interface.
 - [ ] **Documented "how to plug in your own authorizer" recipe.**
   Today it's "implement `auth.Authorizer`, pass it via
-  `namespace.WithAuthzFactory`"; the surface is small enough that a
+  `artifact.WithAuthzFactory`"; the surface is small enough that a
   recipe in [`auth.md`](auth.md) is sufficient.
 
 ## Phase 4 — Pull-through proxy / cache

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -167,7 +167,7 @@ a hosted namespace.
 
 Policy changes via this API take effect on the very next data-plane
 request. The admin `Store` fires a mutation hook on `Put` / `Delete`
-that the data plane's `namespace.Registry` consumes to invalidate its
+that the data plane's `artifact.Store` consumes to invalidate its
 cached authorizer for the affected namespace. Without that hook,
 changes would only land after the cache TTL (`DefaultPolicyCacheTTL = 60s`)
 expired.

--- a/docs/architecture/storage-model.md
+++ b/docs/architecture/storage-model.md
@@ -8,7 +8,7 @@ link here from their "How it's stored" sections.
 The implementation lives in [`pkg/oci/registry.go`](../../pkg/oci/registry.go);
 the deterministic file-tag helper lives in
 [`pkg/oci/filetag.go`](../../pkg/oci/filetag.go). The data-plane
-namespace wrapper that prefixes every backend repo with `<namespace>/`
+artifact data-plane wrapper that prefixes every backend repo with `<namespace>/`
 before reaching `pkg/oci` lives in
 [`pkg/namespace/registry.go`](../../pkg/namespace/registry.go); this
 doc shows the shape `pkg/oci` ends up writing, so every repo path
@@ -128,7 +128,7 @@ requests-2.31.0-cp311-cp311-manylinux_2_17_x86_64.whl
 `twine` issues **three independent POSTs** to ocifactory's
 `/{namespace}/` endpoint — one per file. They may arrive in any order
 and may overlap if `twine` is parallelised across CI workers. The
-namespace wrapper resolves each request to the `myteam` namespace's
+artifact data-plane wrapper resolves each request to the `myteam` namespace's
 authorizer, prefixes the python handler's `packages/requests`
 owning-repo with the namespace segment, and forwards to `pkg/oci`.
 
@@ -197,7 +197,7 @@ PUT /com/example/foo/maven-metadata.xml.sha1
 
 Each PUT lands as one `AddFile` call against the
 `<namespace>/com/example/foo` OCI repo (the maven handler addresses
-the repo as `com/example/foo`; the namespace wrapper prefixes it
+the repo as `com/example/foo`; the artifact data-plane wrapper prefixes it
 before forwarding). The first one (jar, say) walks the same five
 steps as the python sdist above: probe, push blob, ensure `1.0.0`
 version manifest, push file manifest with `subject = versionDesc`,

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -41,7 +41,7 @@ router, so:
   sub-router that doesn't `Use(authMW)`.
 
 Authorization runs one layer deeper, inside the
-`namespace.ScopedRegistry` wrapper: every `AddFile` / `ReadFile` /
+`artifact.ScopedNamespace` wrapper: every `AddFile` / `ReadFile` /
 `ListTags` / `ListFiles` call routes through the namespace's
 compiled `Policy` before reaching the OCI backend, so even a
 handler bug that skipped its own pre-check would not let a request
@@ -107,7 +107,7 @@ Granularity is per-namespace, not per-package. A caller matched by
 any reader matcher can read every package in the namespace; a caller
 matched by any writer matcher can write to any. Per-coordinate
 granularity is intentionally deferred — operators who need it plug
-in their own `Authorizer` via `namespace.WithAuthzFactory` (OPA,
+in their own `Authorizer` via `artifact.WithAuthzFactory` (OPA,
 Cedar, Casbin) and consume the same `AuthContext`.
 
 ### Policy shape
@@ -184,17 +184,18 @@ match on environment, ref, or workflow file precisely.
 
 ### Plugging in an alternative authorizer
 
-`namespace.AuthzFactory` is `func(Policy) (auth.Authorizer, error)`.
+`artifact.AuthzFactory` is `func(namespace.Policy) (auth.Authorizer, error)`.
 A custom main can replace the built-in factory:
 
 ```go
 import (
+    "github.com/yolocs/ocifactory/pkg/artifact"
     "github.com/yolocs/ocifactory/pkg/auth"
     "github.com/yolocs/ocifactory/pkg/namespace"
 )
 
-reg := namespace.NewRegistry(ociReg, store,
-    namespace.WithAuthzFactory(func(p namespace.Policy) (auth.Authorizer, error) {
+reg := artifact.NewStore(ociReg, store,
+    artifact.WithAuthzFactory(func(p namespace.Policy) (auth.Authorizer, error) {
         // compile p (or fetch a richer policy keyed by namespace name) into
         // an authorizer that consumes auth.AuthContext.
         return myOPAAuthorizer(p)
@@ -449,7 +450,7 @@ OCI backend, no real artifacts. See `pkg/handler/echo`.
 - **Per-coordinate authorization** — every reader in a namespace
   can read every package in it, every writer can write to any.
   Operators who need finer control plug in their own `Authorizer`
-  via `namespace.WithAuthzFactory` (OPA, Cedar, Casbin).
+  via `artifact.WithAuthzFactory` (OPA, Cedar, Casbin).
 - **Scoped-token issuance.** A planned `POST /admin/v1/tokens`
   endpoint would take a verified OIDC token and mint a shorter-lived
   ocifactory-audience token bound to a namespace and op; the wire

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -41,7 +41,7 @@ router, so:
   sub-router that doesn't `Use(authMW)`.
 
 Authorization runs one layer deeper, inside the
-`artifact.ScopedNamespace` wrapper: every `AddFile` / `ReadFile` /
+`artifact.NamespaceView` wrapper: every `AddFile` / `ReadFile` /
 `ListTags` / `ListFiles` call routes through the namespace's
 compiled `Policy` before reaching the OCI backend, so even a
 handler bug that skipped its own pre-check would not let a request

--- a/docs/repos/_template.md
+++ b/docs/repos/_template.md
@@ -136,7 +136,7 @@ versus `OpWrite`). The namespace's `Policy` (readers / writers
 [`docs/auth.md#namespace-authorization`](../auth.md#namespace-authorization).
 Note any granularity beyond per-namespace (almost certainly: none
 in v1; per-package authz is operator-pluggable via
-`namespace.WithAuthzFactory`).
+`artifact.WithAuthzFactory`).
 
 ## Operator knobs
 

--- a/docs/repos/maven.md
+++ b/docs/repos/maven.md
@@ -331,7 +331,7 @@ segment):
 | `/{ns}/maven2/archetype-catalog.xml` | `<ns>/archetype` | `latest` | `archetype-catalog.xml` |
 
 `{groupId}` keeps its slash form (`com/example/foo`), matching the URL.
-The namespace wrapper adds the `<ns>/` prefix transparently; the maven
+The artifact data-plane wrapper adds the `<ns>/` prefix transparently; the maven
 handler's storage codec addresses package repos as
 `packages/{groupId}/{artifactId}` and the wrapper turns them into
 `<ns>/packages/{groupId}/{artifactId}` before they hit the OCI backend.
@@ -339,7 +339,7 @@ If `--repo-prefix` is configured, that prefix sits before `<ns>` in the
 backend repository path.
 
 A fourth per-namespace repo, `<ns>/ocifactory-packages`, is maintained
-by the namespace wrapper itself — its tags enumerate every owning-repo
+by the artifact data-plane wrapper itself — its tags enumerate every owning-repo
 the wrapper has written to. It backs the admin service's "namespace is
 empty" check on soft delete; operators don't write to it directly.
 
@@ -404,7 +404,7 @@ covers blob fetches and metadata reads, `OpWrite` covers every PUT/POST.
 There is no per-coordinate granularity today: every reader in a
 namespace can read every coordinate in it, every writer can write to
 any. Out-of-tree authorizers (OPA / Cedar / Casbin) plug in via
-`namespace.WithAuthzFactory` if you need finer control.
+`artifact.WithAuthzFactory` if you need finer control.
 
 See [`docs/auth.md`](../auth.md#namespace-authorization) for the
 policy model and matcher reference.

--- a/docs/repos/npm.md
+++ b/docs/repos/npm.md
@@ -183,7 +183,7 @@ Package storage and the npm package-list index live per namespace under
 | `<namespace>/npm-packages` | `<encoded-name>` per package | A single sentinel layer (`name=present`, body=`"present\n"`). The namespace index primitive decodes tags before returning package names. |
 
 A fourth per-namespace repo, `<namespace>/ocifactory-packages`, is
-maintained by the namespace wrapper itself — its tags enumerate every
+maintained by the artifact data-plane wrapper itself — its tags enumerate every
 owning-repo the wrapper has recorded a write for. It backs the admin
 service's "namespace is empty" check on soft delete; operators don't
 write to it directly.
@@ -265,7 +265,7 @@ covers packument GETs, tarball downloads, and dist-tag listings;
 granularity today: every reader in a namespace can read every package
 in it, every writer can publish any package in it. Out-of-tree
 authorizers (OPA / Cedar / Casbin) plug in via
-`namespace.WithAuthzFactory` if you need finer control.
+`artifact.WithAuthzFactory` if you need finer control.
 
 See [`docs/auth.md`](../auth.md#namespace-authorization) for the
 policy model and matcher reference.

--- a/docs/repos/python.md
+++ b/docs/repos/python.md
@@ -144,7 +144,7 @@ under `--backend-registry` plus any configured `--repo-prefix`:
 | `<namespace>/python-packages` | `<pkg>` per package | A single sentinel layer (`name=present`, body=`"present\n"`). The body is unused; this is the package list for this namespace. |
 
 A third per-namespace repo, `<namespace>/ocifactory-packages`, is
-maintained by the data-plane namespace wrapper itself — its tags
+maintained by the artifact data-plane wrapper itself — its tags
 enumerate every OwningRepo the wrapper has recorded a write for, and
 it backs the admin service's "namespace is empty" check on soft
 delete. Operators don't write to it directly.
@@ -205,7 +205,7 @@ covers `/simple/...` listings and `/packages/.../<file>` blob fetches;
 granularity today: every reader in a namespace can read every package
 in it, every writer can write to any package in it. Out-of-tree
 authorizers (OPA / Cedar / Casbin) plug in via
-`namespace.WithAuthzFactory` if you need finer control.
+`artifact.WithAuthzFactory` if you need finer control.
 
 See [`docs/auth.md`](../auth.md#namespace-authorization) for the
 policy model and matcher reference.

--- a/docs/superpowers/plans/2026-05-19-artifact-store-api.md
+++ b/docs/superpowers/plans/2026-05-19-artifact-store-api.md
@@ -101,7 +101,9 @@ Add test coverage that `pkg.Tag(ctx, "latest", "1.0.0")` and `pkg.ListTags(ctx)`
 
 Replace hosted-path direct calls to `ListFiles`, `ListTags`, `AppendRefs`, and `ReadFile` with `artifact.Package` methods.
 
-- [ ] **Step 3: Run npm tests**
+Progress: npm publish file writes and dist-tag writes now use `artifact.Package`. Packument and dist-tag read paths still use the old scoped registry pending typed tag-target resolution.
+
+- [x] **Step 3: Run npm tests**
 
 Run: `go test ./pkg/handler/npm`
 

--- a/docs/superpowers/plans/2026-05-19-artifact-store-api.md
+++ b/docs/superpowers/plans/2026-05-19-artifact-store-api.md
@@ -101,7 +101,7 @@ Add test coverage that `pkg.Tag(ctx, "latest", "1.0.0")` and `pkg.ListTags(ctx)`
 
 Replace hosted-path direct calls to `ListFiles`, `ListTags`, `AppendRefs`, and `ReadFile` with `artifact.Package` methods.
 
-Progress: npm publish file writes and dist-tag writes now use `artifact.Package`. Packument and dist-tag read paths still use the old scoped registry pending typed tag-target resolution.
+Progress: npm publish file writes, dist-tag writes, packument dist-tag resolution, and dist-tag read paths now use `artifact.Package`. `Package.ResolveTag` returns an `artifact.Version` so npm no longer infers tag targets by reading `package.json` through aliases and matching blob digests.
 
 - [x] **Step 3: Run npm tests**
 

--- a/docs/superpowers/plans/2026-05-19-artifact-store-api.md
+++ b/docs/superpowers/plans/2026-05-19-artifact-store-api.md
@@ -1,0 +1,170 @@
+# Artifact Store API Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor handler-facing OCI access behind a namespace-scoped artifact API centered on package, version, tag, and file nouns.
+
+**Architecture:** Keep `pkg/oci` as the low-level OCI storage codec and add a higher-level data-plane API in `pkg/artifact`. The implementation wraps the existing `namespace.ScopedRegistry` behavior first, then handlers migrate from raw `oci.RepoFile` and repo strings to `artifact.Namespace`, `artifact.Package`, and `artifact.FileHandle` without changing the on-OCI layout.
+
+**Tech Stack:** Go, gorilla/mux handlers, existing `pkg/oci` registry, existing `pkg/namespace` authz and policy cache, `go-cmp` for tests.
+
+---
+
+### Task 1: Add Artifact API Types
+
+**Files:**
+- Create: `pkg/artifact/artifact.go`
+- Create: `pkg/artifact/artifact_test.go`
+
+- [x] **Step 1: Write failing package/version/tag/file behavior tests**
+
+`pkg/artifact/artifact_test.go` covers namespace resolution, package file put/get/list, alias tagging, invalid package paths, and backend download URL fallback.
+
+- [x] **Step 2: Run test to verify it fails**
+
+Run: `go test ./pkg/artifact`
+
+Expected: FAIL because `pkg/artifact` production code does not exist yet.
+
+- [x] **Step 3: Implement API and namespace-registry adapter**
+
+Create `pkg/artifact/artifact.go` and `pkg/artifact/namespace.go`. The adapter should:
+- expose `NewStore(registry *namespace.Registry) *Store`;
+- validate namespace existence with `Spec(ctx)` before returning a scoped namespace;
+- expose `Namespace.Package(name)` as a cheap value object;
+- construct `oci.RepoFile` only inside `pkg/artifact`;
+- keep package names namespace-relative and pass them to `namespace.ScopedRegistry`;
+- implement `FileHandle.DownloadURL` through `BlobRedirectURL`;
+- implement `FileHandle.Open` through `ReadFile`.
+
+- [x] **Step 4: Run test to verify it passes**
+
+Run: `go test ./pkg/artifact`
+
+Expected: PASS.
+
+### Task 2: Migrate Shared Handler File Serving
+
+**Files:**
+- Modify: `pkg/handler/common.go`
+- Create: `pkg/handler/storage.go`
+
+- [ ] **Step 1: Write failing helper tests**
+
+Add tests for redirect-or-stream serving through `artifact.FileHandle`.
+
+- [ ] **Step 2: Implement helper**
+
+Create a shared helper that contains the redirect/read/error mapping currently duplicated across Python, Maven, and npm.
+
+- [ ] **Step 3: Run focused tests**
+
+Run: `go test ./pkg/handler ./pkg/artifact`
+
+Expected: PASS.
+
+### Task 3: Migrate Python Hosted Path
+
+**Files:**
+- Modify: `pkg/handler/python/handler.go`
+- Modify tests in `pkg/handler/python/*_test.go`
+
+- [ ] **Step 1: Write failing Python tests for abstraction usage**
+
+Add or adjust tests so Python hosted upload/read/index behavior does not depend on handler code calling raw `ListTags`, `ListFiles`, and `oci.RepoFile`. Tests may still inspect fake OCI backend state to prove storage compatibility.
+
+- [x] **Step 2: Migrate code**
+
+Change hosted path to:
+- get `artifact.Namespace` from the request namespace;
+- use `ns.Package(packageOwningRepo(pkg))`;
+- use `pkg.PutFile`, `pkg.GetFile`, and `pkg.ListFiles`;
+- keep `scoped.Index(packageIndexName)` as the transitional index path until index/cache files are moved fully behind package/version/file storage.
+
+- [x] **Step 3: Run Python tests**
+
+Run: `go test ./pkg/handler/python`
+
+Expected: PASS.
+
+### Task 4: Migrate npm Hosted Path
+
+**Files:**
+- Modify: `pkg/handler/npm/handler.go`
+- Modify tests in `pkg/handler/npm/*_test.go`
+
+- [ ] **Step 1: Write failing npm tests for tags**
+
+Add test coverage that `pkg.Tag(ctx, "latest", "1.0.0")` and `pkg.ListTags(ctx)` provide the data needed for `dist-tags` and packument generation.
+
+- [ ] **Step 2: Migrate code**
+
+Replace hosted-path direct calls to `ListFiles`, `ListTags`, `AppendRefs`, and `ReadFile` with `artifact.Package` methods.
+
+- [ ] **Step 3: Run npm tests**
+
+Run: `go test ./pkg/handler/npm`
+
+Expected: PASS.
+
+### Task 5: Migrate Maven Hosted Path
+
+**Files:**
+- Modify: `pkg/handler/maven/handler.go`
+- Modify: `pkg/handler/maven/checksum.go`
+- Modify tests in `pkg/handler/maven/*_test.go`
+
+- [ ] **Step 1: Write failing Maven checksum test against package/file API**
+
+Add a checksum verification test that uses the new package file API and proves snapshot overwrite behavior still sets `AllowOverwrite`.
+
+- [ ] **Step 2: Migrate code**
+
+Replace direct `oci.RepoFile` construction in request handlers with package/file construction inside shared helpers.
+
+- [ ] **Step 3: Run Maven tests**
+
+Run: `go test ./pkg/handler/maven`
+
+Expected: PASS.
+
+### Task 6: Final Cleanup and Compatibility
+
+**Files:**
+- Modify: `pkg/handler/common.go`
+- Modify: `pkg/namespace/registry.go` comments as needed
+- Modify: `docs/architecture/storage-model.md`
+
+- [ ] **Step 1: Remove obsolete handler registry dependency where possible**
+
+Keep low-level `namespace.ScopedRegistry` methods until all proxy/fetcher paths are migrated. Do not delete `oci.RepoFile`; it remains the low-level storage representation.
+
+- [ ] **Step 2: Run full short verification**
+
+Run:
+
+```bash
+gofmt -w pkg/artifact pkg/handler pkg/namespace
+go test -race -short ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git add .
+git commit -m "Add artifact storage API"
+```
+
+Expected: commit created on `artifact-store-api`.
+
+---
+
+## Self-Review
+
+- Spec coverage: The plan introduces a namespace-scoped data-plane API, keeps namespace metadata separate, keeps OCI as the backing implementation, and migrates handlers incrementally.
+- Scope check: The full migration spans all handlers and proxies. The first PR can stop after the core abstraction and one handler migration if review size grows too large.
+- Risk: Existing OCI layout and handler behavior must remain compatible; `pkg/oci` remains the low-level storage representation.

--- a/docs/superpowers/plans/2026-05-19-artifact-store-api.md
+++ b/docs/superpowers/plans/2026-05-19-artifact-store-api.md
@@ -4,7 +4,7 @@
 
 **Goal:** Refactor handler-facing OCI access behind a namespace-scoped artifact API centered on package, version, tag, and file nouns.
 
-**Architecture:** Keep `pkg/oci` as the low-level OCI storage codec and add a higher-level data-plane API in `pkg/artifact`. The implementation wraps the existing `namespace.ScopedRegistry` behavior first, then handlers migrate from raw `oci.RepoFile` and repo strings to `artifact.Namespace`, `artifact.Package`, and `artifact.FileHandle` without changing the on-OCI layout.
+**Architecture:** Keep `pkg/oci` as the low-level OCI storage codec and add a higher-level data-plane API in `pkg/artifact`. The implementation wraps the existing `artifact.ScopedNamespace` behavior first, then handlers migrate from raw `oci.RepoFile` and repo strings to `artifact.Namespace`, `artifact.Package`, and `artifact.FileHandle` without changing the on-OCI layout.
 
 **Tech Stack:** Go, gorilla/mux handlers, existing `pkg/oci` registry, existing `pkg/namespace` authz and policy cache, `go-cmp` for tests.
 
@@ -29,11 +29,11 @@ Expected: FAIL because `pkg/artifact` production code does not exist yet.
 - [x] **Step 3: Implement API and namespace-registry adapter**
 
 Create `pkg/artifact/artifact.go` and `pkg/artifact/namespace.go`. The adapter should:
-- expose `NewStore(registry *namespace.Registry) *Store`;
+- expose `NewStore(inner artifact.Backend, namespaces artifact.NamespaceStore) *Store`;
 - validate namespace existence with `Spec(ctx)` before returning a scoped namespace;
 - expose `Namespace.Package(name)` as a cheap value object;
 - construct `oci.RepoFile` only inside `pkg/artifact`;
-- keep package names namespace-relative and pass them to `namespace.ScopedRegistry`;
+- keep package names namespace-relative and pass them to `artifact.ScopedNamespace`;
 - implement `FileHandle.DownloadURL` through `BlobRedirectURL`;
 - implement `FileHandle.Open` through `ReadFile`.
 
@@ -139,7 +139,7 @@ Expected: PASS.
 
 - [ ] **Step 1: Remove obsolete handler registry dependency where possible**
 
-Keep low-level `namespace.ScopedRegistry` methods until all proxy/fetcher paths are migrated. Do not delete `oci.RepoFile`; it remains the low-level storage representation.
+Keep low-level `artifact.ScopedNamespace` methods until all proxy/fetcher paths are migrated. Do not delete `oci.RepoFile`; it remains the low-level storage representation.
 
 - [ ] **Step 2: Run full short verification**
 

--- a/docs/superpowers/plans/2026-05-19-artifact-store-api.md
+++ b/docs/superpowers/plans/2026-05-19-artifact-store-api.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Refactor handler-facing OCI access behind a namespace-scoped artifact API centered on package, version, tag, and file nouns.
+**Goal:** Refactor handler-facing OCI access behind a namespaced artifact API centered on package, version, tag, and file nouns.
 
-**Architecture:** Keep `pkg/oci` as the low-level OCI storage codec and add a higher-level data-plane API in `pkg/artifact`. The implementation wraps the existing `artifact.ScopedNamespace` behavior first, then handlers migrate from raw `oci.RepoFile` and repo strings to `artifact.Namespace`, `artifact.Package`, and `artifact.FileHandle` without changing the on-OCI layout.
+**Architecture:** Keep `pkg/oci` as the low-level OCI storage codec and add a higher-level data-plane API in `pkg/artifact`. The implementation wraps the existing `artifact.NamespaceView` behavior first, then handlers migrate from raw `oci.RepoFile` and repo strings to `artifact.Namespace`, `artifact.Package`, and `artifact.FileHandle` without changing the on-OCI layout.
 
 **Tech Stack:** Go, gorilla/mux handlers, existing `pkg/oci` registry, existing `pkg/namespace` authz and policy cache, `go-cmp` for tests.
 
@@ -30,10 +30,10 @@ Expected: FAIL because `pkg/artifact` production code does not exist yet.
 
 Create `pkg/artifact/artifact.go` and `pkg/artifact/namespace.go`. The adapter should:
 - expose `NewStore(inner artifact.Backend, namespaces artifact.NamespaceStore) *Store`;
-- validate namespace existence with `Spec(ctx)` before returning a scoped namespace;
+- validate namespace existence with `Spec(ctx)` before returning a namespaced view;
 - expose `Namespace.Package(name)` as a cheap value object;
 - construct `oci.RepoFile` only inside `pkg/artifact`;
-- keep package names namespace-relative and pass them to `artifact.ScopedNamespace`;
+- keep package names namespace-relative and pass them to `artifact.NamespaceView`;
 - implement `FileHandle.DownloadURL` through `BlobRedirectURL`;
 - implement `FileHandle.Open` through `ReadFile`.
 
@@ -79,7 +79,7 @@ Change hosted path to:
 - get `artifact.Namespace` from the request namespace;
 - use `ns.Package(packageOwningRepo(pkg))`;
 - use `pkg.PutFile`, `pkg.GetFile`, and `pkg.ListFiles`;
-- keep `scoped.Index(packageIndexName)` as the transitional index path until index/cache files are moved fully behind package/version/file storage.
+- keep `view.Index(packageIndexName)` as the transitional index path until index/cache files are moved fully behind package/version/file storage.
 
 - [x] **Step 3: Run Python tests**
 
@@ -139,7 +139,7 @@ Expected: PASS.
 
 - [ ] **Step 1: Remove obsolete handler registry dependency where possible**
 
-Keep low-level `artifact.ScopedNamespace` methods until all proxy/fetcher paths are migrated. Do not delete `oci.RepoFile`; it remains the low-level storage representation.
+Keep low-level `artifact.NamespaceView` methods until all proxy/fetcher paths are migrated. Do not delete `oci.RepoFile`; it remains the low-level storage representation.
 
 - [ ] **Step 2: Run full short verification**
 
@@ -167,6 +167,6 @@ Expected: commit created on `artifact-store-api`.
 
 ## Self-Review
 
-- Spec coverage: The plan introduces a namespace-scoped data-plane API, keeps namespace metadata separate, keeps OCI as the backing implementation, and migrates handlers incrementally.
+- Spec coverage: The plan introduces a namespaced data-plane API, keeps namespace metadata separate, keeps OCI as the backing implementation, and migrates handlers incrementally.
 - Scope check: The full migration spans all handlers and proxies. The first PR can stop after the core abstraction and one handler migration if review size grows too large.
 - Risk: Existing OCI layout and handler behavior must remain compatible; `pkg/oci` remains the low-level storage representation.

--- a/pkg/artifact/artifact.go
+++ b/pkg/artifact/artifact.go
@@ -27,6 +27,7 @@ type Package interface {
 	GetFileByTag(ctx context.Context, tag, name string) (FileHandle, error)
 	ListVersions(ctx context.Context) ([]string, error)
 	ListTags(ctx context.Context) ([]Tag, error)
+	ResolveTag(ctx context.Context, tag string) (Version, error)
 	ListFiles(ctx context.Context, opts ListFilesOptions) ([]FileInfo, error)
 	Tag(ctx context.Context, tag, version string) error
 }
@@ -60,6 +61,11 @@ type FileInfo struct {
 type Tag struct {
 	Name    string
 	Version string
+}
+
+// Version is a canonical package version.
+type Version struct {
+	Name string
 }
 
 // ListFilesOptions filters package file listings.

--- a/pkg/artifact/artifact.go
+++ b/pkg/artifact/artifact.go
@@ -1,0 +1,75 @@
+// Package artifact exposes the handler-facing storage nouns used by
+// ocifactory: package, version, tag, and file.
+package artifact
+
+import (
+	"context"
+	"io"
+
+	"github.com/yolocs/ocifactory/pkg/namespace"
+	"github.com/yolocs/ocifactory/pkg/oci"
+)
+
+// Namespace is a namespace-scoped view of artifact storage.
+type Namespace interface {
+	Name() string
+	Spec(ctx context.Context) (*namespace.Spec, error)
+	Package(name string) Package
+	ListPackages(ctx context.Context) ([]string, error)
+}
+
+// Package is a namespace-local package/repository.
+type Package interface {
+	Name() string
+	PutFile(ctx context.Context, version string, file FilePut, body io.Reader) (*FileDescriptor, error)
+	PutCachedFile(ctx context.Context, version string, file FilePut, body io.Reader) (*FileDescriptor, error)
+	GetFile(ctx context.Context, version, name string) (FileHandle, error)
+	GetFileByTag(ctx context.Context, tag, name string) (FileHandle, error)
+	ListVersions(ctx context.Context) ([]string, error)
+	ListTags(ctx context.Context) ([]Tag, error)
+	ListFiles(ctx context.Context, opts ListFilesOptions) ([]FileInfo, error)
+	Tag(ctx context.Context, tag, version string) error
+}
+
+// FilePut describes a file write under a package version.
+type FilePut struct {
+	Name           string
+	MediaType      string
+	Digest         string
+	Size           int64
+	AllowOverwrite bool
+}
+
+// FileDescriptor identifies a stored file. It aliases the low-level
+// descriptor until handlers no longer need OCI descriptor details.
+type FileDescriptor = oci.FileDescriptor
+
+// FileInfo is the handler-facing description of a file.
+type FileInfo struct {
+	Package   string
+	Version   string
+	Name      string
+	MediaType string
+	Digest    string
+	Size      int64
+}
+
+// Tag is a package tag or alias. Version is optional for now because
+// the current low-level registry exposes aliases separately from their
+// target version unless a caller resolves a known file through the tag.
+type Tag struct {
+	Name    string
+	Version string
+}
+
+// ListFilesOptions filters package file listings.
+type ListFilesOptions struct {
+	Version string
+}
+
+// FileHandle is a read-capable handle for one package file.
+type FileHandle interface {
+	Info() FileInfo
+	DownloadURL(ctx context.Context) (string, error)
+	Open(ctx context.Context) (io.ReadCloser, error)
+}

--- a/pkg/artifact/artifact.go
+++ b/pkg/artifact/artifact.go
@@ -10,7 +10,7 @@ import (
 	"github.com/yolocs/ocifactory/pkg/oci"
 )
 
-// Namespace is a namespace-scoped view of artifact storage.
+// Namespace is the handler-facing view of artifact storage inside one namespace.
 type Namespace interface {
 	Name() string
 	Spec(ctx context.Context) (*namespace.Spec, error)

--- a/pkg/artifact/artifact_test.go
+++ b/pkg/artifact/artifact_test.go
@@ -165,7 +165,7 @@ func setupStore(t *testing.T) (*oci.FakeRegistry, *Store) {
 
 	fake := oci.NewFakeRegistry()
 	nsStore := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, nsStore, namespace.WithPolicyCacheTTL(0))
+	store := NewStore(fake, nsStore, WithPolicyCacheTTL(0))
 	if err := nsStore.Put(t.Context(), &namespace.Namespace{
 		Name: testNS,
 		Spec: namespace.Spec{
@@ -177,7 +177,7 @@ func setupStore(t *testing.T) (*oci.FakeRegistry, *Store) {
 	}); err != nil {
 		t.Fatalf("Put namespace: %v", err)
 	}
-	return fake, NewStore(reg)
+	return fake, store
 }
 
 func authedContext(t *testing.T) context.Context {

--- a/pkg/artifact/artifact_test.go
+++ b/pkg/artifact/artifact_test.go
@@ -1,0 +1,177 @@
+package artifact
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/yolocs/ocifactory/pkg/auth"
+	"github.com/yolocs/ocifactory/pkg/namespace"
+	"github.com/yolocs/ocifactory/pkg/oci"
+)
+
+const (
+	testIssuer = "https://accounts.google.com"
+	testNS     = "default"
+)
+
+func TestNamespacePackagePutGetListAndTag(t *testing.T) {
+	t.Parallel()
+
+	_, store := setupStore(t)
+	ctx := authedContext(t)
+
+	ns, err := store.Namespace(ctx, testNS)
+	if err != nil {
+		t.Fatalf("Namespace: %v", err)
+	}
+	pkg := ns.Package("packages/requests")
+
+	desc, err := pkg.PutFile(ctx, "1.0.0", FilePut{
+		Name:      "requests.whl",
+		MediaType: "application/octet-stream",
+		Size:      int64(len("wheel")),
+	}, strings.NewReader("wheel"))
+	if err != nil {
+		t.Fatalf("PutFile: %v", err)
+	}
+	if desc.File.Size != int64(len("wheel")) {
+		t.Fatalf("PutFile size = %d, want %d", desc.File.Size, len("wheel"))
+	}
+
+	versions, err := pkg.ListVersions(ctx)
+	if err != nil {
+		t.Fatalf("ListVersions: %v", err)
+	}
+	if diff := cmp.Diff([]string{"1.0.0"}, versions); diff != "" {
+		t.Errorf("ListVersions mismatch (-want +got):\n%s", diff)
+	}
+
+	files, err := pkg.ListFiles(ctx, ListFilesOptions{})
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	wantFiles := []FileInfo{{
+		Package: "packages/requests",
+		Version: "1.0.0",
+		Name:    "requests.whl",
+		Digest:  desc.File.Digest.String(),
+	}}
+	if diff := cmp.Diff(wantFiles, files); diff != "" {
+		t.Errorf("ListFiles mismatch (-want +got):\n%s", diff)
+	}
+
+	if err := pkg.Tag(ctx, "latest", "1.0.0"); err != nil {
+		t.Fatalf("Tag: %v", err)
+	}
+
+	tags, err := pkg.ListTags(ctx)
+	if err != nil {
+		t.Fatalf("ListTags: %v", err)
+	}
+	if diff := cmp.Diff([]Tag{{Name: "latest"}}, tags); diff != "" {
+		t.Errorf("ListTags mismatch (-want +got):\n%s", diff)
+	}
+
+	handle, err := pkg.GetFileByTag(ctx, "latest", "requests.whl")
+	if err != nil {
+		t.Fatalf("GetFileByTag: %v", err)
+	}
+	rc, err := handle.Open(ctx)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer rc.Close()
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(got) != "wheel" {
+		t.Errorf("Open body = %q, want %q", got, "wheel")
+	}
+}
+
+func TestNamespaceValidatesExistence(t *testing.T) {
+	t.Parallel()
+
+	_, store := setupStore(t)
+
+	if _, err := store.Namespace(authedContext(t), "missing"); err == nil {
+		t.Fatal("Namespace(missing) = nil, want error")
+	}
+}
+
+func TestPackageRejectsInvalidName(t *testing.T) {
+	t.Parallel()
+
+	_, store := setupStore(t)
+	ns, err := store.Namespace(authedContext(t), testNS)
+	if err != nil {
+		t.Fatalf("Namespace: %v", err)
+	}
+
+	_, err = ns.Package("../escape").PutFile(authedContext(t), "1.0.0", FilePut{Name: "x"}, strings.NewReader("x"))
+	if err == nil {
+		t.Fatal("PutFile with escaping package = nil, want error")
+	}
+}
+
+func TestFileHandleDownloadURLFallsBackToEmptyURL(t *testing.T) {
+	t.Parallel()
+
+	_, store := setupStore(t)
+	ctx := authedContext(t)
+	ns, err := store.Namespace(ctx, testNS)
+	if err != nil {
+		t.Fatalf("Namespace: %v", err)
+	}
+	pkg := ns.Package("packages/requests")
+	if _, err := pkg.PutFile(ctx, "1.0.0", FilePut{Name: "requests.whl"}, strings.NewReader("wheel")); err != nil {
+		t.Fatalf("PutFile: %v", err)
+	}
+
+	handle, err := pkg.GetFile(ctx, "1.0.0", "requests.whl")
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+	u, err := handle.DownloadURL(ctx)
+	if err != nil {
+		t.Fatalf("DownloadURL: %v", err)
+	}
+	if u != "" {
+		t.Errorf("DownloadURL = %q, want empty fake-registry fallback", u)
+	}
+}
+
+func setupStore(t *testing.T) (*oci.FakeRegistry, *Store) {
+	t.Helper()
+
+	fake := oci.NewFakeRegistry()
+	nsStore := namespace.NewStore(fake)
+	reg := namespace.NewRegistry(fake, nsStore, namespace.WithPolicyCacheTTL(0))
+	if err := nsStore.Put(t.Context(), &namespace.Namespace{
+		Name: testNS,
+		Spec: namespace.Spec{
+			Policy: namespace.Policy{
+				Readers: []namespace.SubjectMatcher{{Issuer: testIssuer}},
+				Writers: []namespace.SubjectMatcher{{Issuer: testIssuer}},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Put namespace: %v", err)
+	}
+	return fake, NewStore(reg)
+}
+
+func authedContext(t *testing.T) context.Context {
+	t.Helper()
+
+	return auth.WithAuthContext(t.Context(), &auth.AuthContext{
+		Issuer: testIssuer,
+		ID:     "alice",
+		Email:  "alice@example.com",
+	})
+}

--- a/pkg/artifact/artifact_test.go
+++ b/pkg/artifact/artifact_test.go
@@ -49,6 +49,13 @@ func TestNamespacePackagePutGetListAndTag(t *testing.T) {
 	if diff := cmp.Diff([]string{"1.0.0"}, versions); diff != "" {
 		t.Errorf("ListVersions mismatch (-want +got):\n%s", diff)
 	}
+	resolvedVersion, err := pkg.ResolveTag(ctx, "1.0.0")
+	if err != nil {
+		t.Fatalf("ResolveTag canonical version: %v", err)
+	}
+	if diff := cmp.Diff(Version{Name: "1.0.0"}, resolvedVersion); diff != "" {
+		t.Errorf("ResolveTag canonical version mismatch (-want +got):\n%s", diff)
+	}
 
 	files, err := pkg.ListFiles(ctx, ListFilesOptions{})
 	if err != nil {
@@ -74,6 +81,13 @@ func TestNamespacePackagePutGetListAndTag(t *testing.T) {
 	}
 	if diff := cmp.Diff([]Tag{{Name: "latest"}}, tags); diff != "" {
 		t.Errorf("ListTags mismatch (-want +got):\n%s", diff)
+	}
+	resolvedAlias, err := pkg.ResolveTag(ctx, "latest")
+	if err != nil {
+		t.Fatalf("ResolveTag alias: %v", err)
+	}
+	if diff := cmp.Diff(Version{Name: "1.0.0"}, resolvedAlias); diff != "" {
+		t.Errorf("ResolveTag alias mismatch (-want +got):\n%s", diff)
 	}
 
 	handle, err := pkg.GetFileByTag(ctx, "latest", "requests.whl")

--- a/pkg/artifact/cache.go
+++ b/pkg/artifact/cache.go
@@ -1,4 +1,4 @@
-package namespace
+package artifact
 
 import (
 	"time"
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/golang-lru/v2/expirable"
 
 	"github.com/yolocs/ocifactory/pkg/auth"
+	nsmeta "github.com/yolocs/ocifactory/pkg/namespace"
 )
 
 // cachedPolicy is the value stored per namespace name in the policy
@@ -13,7 +14,7 @@ import (
 // burst of requests against a missing namespace doesn't repeatedly
 // hit the metadata backend.
 //
-// spec is the raw [Spec] body the authorizer was compiled from. It is
+// spec is the raw [namespace.Spec] body the authorizer was compiled from. It is
 // held alongside the authorizer so format handlers can dispatch on
 // [Spec.Mode] / read [Spec.Proxy] without paying a second
 // [Store.Get]; spec and authorizer always reflect the same point-in-time
@@ -21,7 +22,7 @@ import (
 // the pointer for free read access and must not mutate it.
 type cachedPolicy struct {
 	authorizer auth.Authorizer
-	spec       *Spec
+	spec       *nsmeta.Spec
 	notFound   bool
 }
 

--- a/pkg/artifact/cache_test.go
+++ b/pkg/artifact/cache_test.go
@@ -1,4 +1,4 @@
-package namespace
+package artifact
 
 import (
 	"testing"

--- a/pkg/artifact/registry.go
+++ b/pkg/artifact/registry.go
@@ -1,4 +1,4 @@
-package namespace
+package artifact
 
 import (
 	"bytes"
@@ -17,6 +17,7 @@ import (
 
 	"github.com/yolocs/ocifactory/pkg/auth"
 	"github.com/yolocs/ocifactory/pkg/logging"
+	nsmeta "github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
 )
 
@@ -67,10 +68,10 @@ var packageIndexSentinelBody = []byte("present\n")
 // AuthzFactory builds an [auth.Authorizer] from a namespace [Policy].
 // Operators wire in alternative implementations (OPA, Casbin, Cedar,
 // ...) by passing one to [WithAuthzFactory]; the default is
-// [NewPolicyAuthorizer].
-type AuthzFactory func(Policy) (auth.Authorizer, error)
+// [namespace.NewPolicyAuthorizer].
+type AuthzFactory func(nsmeta.Policy) (auth.Authorizer, error)
 
-// RegistryBackend is the subset of *pkg/oci.Registry the wrapper
+// Backend is the subset of *pkg/oci.Registry the wrapper
 // needs. Pinned as an interface so tests can substitute the in-memory
 // [oci.FakeRegistry]; production passes *oci.Registry directly.
 //
@@ -79,7 +80,7 @@ type AuthzFactory func(Policy) (auth.Authorizer, error)
 // metadata-store [Backend] avoids two parallel interfaces and lets
 // future yank semantics (single-version delete) plug in without
 // reshaping the surface.
-type RegistryBackend interface {
+type Backend interface {
 	AddFile(ctx context.Context, f *oci.RepoFile, ro io.Reader) (*oci.FileDescriptor, error)
 	ReadFile(ctx context.Context, f *oci.RepoFile) (*oci.FileDescriptor, io.ReadCloser, error)
 	BlobRedirectURL(ctx context.Context, f *oci.RepoFile) (string, error)
@@ -91,25 +92,34 @@ type RegistryBackend interface {
 	DeleteTagFiles(ctx context.Context, repo string, tag string) error
 }
 
-// Registry is the data-plane wrapper that holds the cross-namespace
+// NamespaceStore is the control-plane namespace metadata surface the
+// artifact data-plane needs for existence checks, policy compilation, and
+// cache invalidation. The concrete OCI implementation is
+// [namespace.Store], but artifact storage depends only on this interface.
+type NamespaceStore interface {
+	Get(ctx context.Context, name string) (*nsmeta.Namespace, error)
+	SetMutationHook(func(name string))
+}
+
+// Store is the data-plane wrapper that holds the cross-namespace
 // state — the authorizer cache, the package-index dedupe set, the
 // pluggable authz factory — and hands out per-namespace
-// [ScopedRegistry] views via [Registry.For].
+// [ScopedNamespace] views via [Store.For].
 //
-// Handlers don't use *Registry directly; they hold a
-// *ScopedRegistry obtained per request:
+// Handlers don't use *Store directly; they hold a
+// *ScopedNamespace obtained per request:
 //
 //	ns := mux.Vars(req)["namespace"]
 //	scoped := r.For(ns)
 //	desc, err := scoped.AddFile(ctx, f, body)
 //
-// *ScopedRegistry implements the existing [pkg/handler.Registry]
+// *ScopedNamespace implements the existing [pkg/handler.Registry]
 // interface, so handlers can swap a *pkg/oci.Registry for a
-// *ScopedRegistry without changing any call site — namespace-aware
+// *ScopedNamespace without changing any call site — namespace-aware
 // authz and OwningRepo prefixing happen transparently.
-type Registry struct {
-	inner       RegistryBackend
-	store       *Store
+type Store struct {
+	inner       Backend
+	namespaces  NamespaceStore
 	cache       *policyCache
 	indexed     *expirable.LRU[string, struct{}]
 	indexSuffix string
@@ -132,43 +142,43 @@ type Registry struct {
 	indexLocks sync.Map
 }
 
-// RegistryOption customises a [Registry].
-type RegistryOption func(*Registry)
+// StoreOption customises a [Store].
+type StoreOption func(*Store)
 
 // WithPackageIndexSuffix overrides the default
 // ("ocifactory-packages"). Operators set this when their backend
 // already has a per-namespace "ocifactory-packages" repo they want to
 // keep — extremely unlikely, but cheap to make configurable.
-func WithPackageIndexSuffix(s string) RegistryOption {
-	return func(r *Registry) { r.indexSuffix = s }
+func WithPackageIndexSuffix(s string) StoreOption {
+	return func(r *Store) { r.indexSuffix = s }
 }
 
 // WithAuthzFactory overrides the authorizer constructor.
-// Defaults to [NewPolicyAuthorizer].
-func WithAuthzFactory(f AuthzFactory) RegistryOption {
-	return func(r *Registry) { r.factory = f }
+// Defaults to [namespace.NewPolicyAuthorizer].
+func WithAuthzFactory(f AuthzFactory) StoreOption {
+	return func(r *Store) { r.factory = f }
 }
 
 // WithPolicyCacheTTL overrides [DefaultPolicyCacheTTL]. A value of
 // zero or negative disables caching — every request pays for a
 // Store.Get + authorizer compile. Operators set ttl=0 in tests that
 // want every Put to take effect immediately without sleeping.
-func WithPolicyCacheTTL(ttl time.Duration) RegistryOption {
-	return func(r *Registry) { r.cacheTTL = ttl }
+func WithPolicyCacheTTL(ttl time.Duration) StoreOption {
+	return func(r *Store) { r.cacheTTL = ttl }
 }
 
-// NewRegistry wraps inner in a namespace [Registry] backed by store
+// NewStore wraps inner in a namespace [Store] backed by store
 // for namespace metadata. The wrapper installs a mutation hook on
 // store so admin-side Put / Delete calls invalidate the cached
-// authorizer — failing to use NewRegistry (e.g. constructing the
+// authorizer — failing to use NewStore (e.g. constructing the
 // fields by hand in a test) means admin mutations only take effect
 // after the cache TTL expires.
-func NewRegistry(inner RegistryBackend, store *Store, opts ...RegistryOption) *Registry {
-	r := &Registry{
+func NewStore(inner Backend, namespaces NamespaceStore, opts ...StoreOption) *Store {
+	r := &Store{
 		inner:       inner,
-		store:       store,
+		namespaces:  namespaces,
 		indexSuffix: defaultPackageIndexSuffix,
-		factory:     NewPolicyAuthorizer,
+		factory:     nsmeta.NewPolicyAuthorizer,
 		cacheTTL:    DefaultPolicyCacheTTL,
 	}
 	for _, o := range opts {
@@ -182,18 +192,28 @@ func NewRegistry(inner RegistryBackend, store *Store, opts ...RegistryOption) *R
 	// expirable.NewLRU means "10-year TTL" (effectively no expiry),
 	// which is what we want; bounded size is the only ceiling.
 	r.indexed = expirable.NewLRU[string, struct{}](packageIndexedReposCacheSize, nil, 0)
-	store.SetMutationHook(r.InvalidatePolicy)
+	namespaces.SetMutationHook(r.InvalidatePolicy)
 	return r
 }
 
-// For returns a [ScopedRegistry] bound to namespace. The returned
+// Namespace returns a handler-facing namespace after validating that the
+// namespace metadata exists.
+func (r *Store) Namespace(ctx context.Context, name string) (Namespace, error) {
+	scoped := r.For(name)
+	if _, err := scoped.Spec(ctx); err != nil {
+		return nil, err
+	}
+	return artifactNamespace{scoped: scoped}, nil
+}
+
+// For returns a [ScopedNamespace] bound to namespace. The returned
 // view is cheap to construct (a small struct, no I/O) so handlers
 // should call it per request rather than caching it. The bound
 // namespace is enforced on every method invocation — there is no
 // way to issue a cross-namespace operation through a single
-// ScopedRegistry.
-func (r *Registry) For(namespace string) *ScopedRegistry {
-	return &ScopedRegistry{parent: r, namespace: namespace}
+// ScopedNamespace.
+func (r *Store) For(namespace string) *ScopedNamespace {
+	return &ScopedNamespace{parent: r, namespace: namespace}
 }
 
 // InvalidatePolicy drops the cached authorizer for name so the next
@@ -201,14 +221,14 @@ func (r *Registry) For(namespace string) *ScopedRegistry {
 // automatically after a successful Put or Delete; admin-side code
 // that bypasses the Store can call it directly. A name that wasn't
 // cached is a no-op.
-func (r *Registry) InvalidatePolicy(name string) { r.cache.invalidate(name) }
+func (r *Store) InvalidatePolicy(name string) { r.cache.invalidate(name) }
 
 // authorize loads (cached or freshly compiled) the namespace's
 // authorizer and runs op against the [auth.AuthContext] in ctx.
 // Returns:
 //
 //   - nil on allow.
-//   - an error wrapping [ErrNotFound] when the namespace is unknown
+//   - an error wrapping [namespace.ErrNotFound] when the namespace is unknown
 //     (and caches the negative result).
 //   - an error wrapping [auth.ErrUnauthorized] on policy deny or on
 //     a missing AuthContext.
@@ -218,7 +238,7 @@ func (r *Registry) InvalidatePolicy(name string) { r.cache.invalidate(name) }
 // authorizer, because the wrapper is the trust boundary: a
 // third-party [AuthzFactory] that forgets to deny nil would
 // otherwise turn into an auth bypass.
-func (r *Registry) authorize(ctx context.Context, namespace string, op auth.Op) error {
+func (r *Store) authorize(ctx context.Context, namespace string, op auth.Op) error {
 	az, err := r.authorizerFor(ctx, namespace)
 	if err != nil {
 		return err
@@ -231,20 +251,20 @@ func (r *Registry) authorize(ctx context.Context, namespace string, op auth.Op) 
 }
 
 // specFor is the cache-aware single-namespace lookup that
-// [Registry.authorizerFor] and [ScopedRegistry.Spec] funnel through.
+// [Store.authorizerFor] and [ScopedNamespace.Spec] funnel through.
 // On a hit it returns the cached entry without any I/O; on a miss it
 // resolves through the shared singleflight so concurrent callers
 // observe one [Store.Get] + authorizer compile.
 //
 // A namespace that doesn't exist returns an error wrapping
-// [ErrNotFound] with notFound=true on the cached entry — callers that
+// [namespace.ErrNotFound] with notFound=true on the cached entry — callers that
 // only need the spec must inspect the notFound flag rather than the
 // returned error so they can produce the expected 404 mapping without
 // re-running the load.
-func (r *Registry) specFor(ctx context.Context, namespace string) (cachedPolicy, error) {
+func (r *Store) specFor(ctx context.Context, namespace string) (cachedPolicy, error) {
 	if v, ok := r.cache.get(namespace); ok {
 		if v.notFound {
-			return v, fmt.Errorf("%w: %s", ErrNotFound, namespace)
+			return v, fmt.Errorf("%w: %s", nsmeta.ErrNotFound, namespace)
 		}
 		return v, nil
 	}
@@ -252,9 +272,9 @@ func (r *Registry) specFor(ctx context.Context, namespace string) (cachedPolicy,
 		if v, ok := r.cache.get(namespace); ok {
 			return v, nil
 		}
-		ns, err := r.store.Get(ctx, namespace)
+		ns, err := r.namespaces.Get(ctx, namespace)
 		if err != nil {
-			if errors.Is(err, ErrNotFound) {
+			if errors.Is(err, nsmeta.ErrNotFound) {
 				neg := cachedPolicy{notFound: true}
 				r.cache.put(namespace, neg)
 				return neg, err
@@ -275,12 +295,12 @@ func (r *Registry) specFor(ctx context.Context, namespace string) (cachedPolicy,
 	}
 	cp := v.(cachedPolicy)
 	if cp.notFound {
-		return cp, fmt.Errorf("%w: %s", ErrNotFound, namespace)
+		return cp, fmt.Errorf("%w: %s", nsmeta.ErrNotFound, namespace)
 	}
 	return cp, nil
 }
 
-func (r *Registry) authorizerFor(ctx context.Context, namespace string) (auth.Authorizer, error) {
+func (r *Store) authorizerFor(ctx context.Context, namespace string) (auth.Authorizer, error) {
 	cp, err := r.specFor(ctx, namespace)
 	if err != nil {
 		return nil, err
@@ -294,7 +314,7 @@ func (r *Registry) authorizerFor(ctx context.Context, namespace string) (auth.Au
 // or is absolute is rejected as malformed — without this check
 // path.Join("alpha", "../beta/foo") collapses to "beta/foo" and
 // silently lands traffic in another namespace.
-func (r *Registry) resolveRepo(namespace, owningRepo string) (string, error) {
+func (r *Store) resolveRepo(namespace, owningRepo string) (string, error) {
 	if owningRepo == "" {
 		// An empty owning repo is a meaningful root for some
 		// operations (e.g. an admin "list everything in this
@@ -303,14 +323,14 @@ func (r *Registry) resolveRepo(namespace, owningRepo string) (string, error) {
 		return namespace, nil
 	}
 	if path.IsAbs(owningRepo) {
-		return "", fmt.Errorf("%w: owning repo %q is absolute", ErrInvalidOwningRepo, owningRepo)
+		return "", fmt.Errorf("%w: owning repo %q is absolute", nsmeta.ErrInvalidOwningRepo, owningRepo)
 	}
 	cleaned := path.Clean(owningRepo)
 	if cleaned != owningRepo {
-		return "", fmt.Errorf("%w: owning repo %q is not in canonical form (clean: %q)", ErrInvalidOwningRepo, owningRepo, cleaned)
+		return "", fmt.Errorf("%w: owning repo %q is not in canonical form (clean: %q)", nsmeta.ErrInvalidOwningRepo, owningRepo, cleaned)
 	}
 	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") || strings.Contains(cleaned, "/../") || strings.HasSuffix(cleaned, "/..") {
-		return "", fmt.Errorf("%w: owning repo %q escapes namespace", ErrInvalidOwningRepo, owningRepo)
+		return "", fmt.Errorf("%w: owning repo %q escapes namespace", nsmeta.ErrInvalidOwningRepo, owningRepo)
 	}
 	// The first path segment of the namespace package index repo is
 	// reserved: a write that landed there would mix user artifacts in
@@ -318,52 +338,47 @@ func (r *Registry) resolveRepo(namespace, owningRepo string) (string, error) {
 	// can otherwise reach it, so the check lives at the resolver — the
 	// chokepoint every per-format handler funnels through.
 	if cleaned == r.indexSuffix || strings.HasPrefix(cleaned, r.indexSuffix+"/") {
-		return "", fmt.Errorf("%w: owning repo %q uses reserved prefix %q", ErrInvalidOwningRepo, owningRepo, r.indexSuffix)
+		return "", fmt.Errorf("%w: owning repo %q uses reserved prefix %q", nsmeta.ErrInvalidOwningRepo, owningRepo, r.indexSuffix)
 	}
 	return path.Join(namespace, cleaned), nil
 }
 
-// ErrInvalidOwningRepo is returned when an owning-repo string is
-// malformed or attempts to escape the namespace it was scoped to.
-// Handlers should map this to 400.
-var ErrInvalidOwningRepo = errors.New("invalid owning repo")
-
-func (r *Registry) packageIndexRepo(namespace string) string {
+func (r *Store) packageIndexRepo(namespace string) string {
 	return path.Join(namespace, r.indexSuffix)
 }
 
 // NamespaceIndex is a tag-backed sibling repository inside one
 // namespace. Tags are encoded keys; callers see only decoded keys.
 type NamespaceIndex struct {
-	scoped *ScopedRegistry
+	scoped *ScopedNamespace
 	name   string
 }
 
-// ScopedRegistry is a per-namespace view of a [Registry]. Every
+// ScopedNamespace is a per-namespace view of a [Store]. Every
 // method authorizes the bound namespace, prefixes OwningRepo (or the
 // raw repo string for ListTags/ListFiles/etc.) with it, and forwards
 // to the underlying OCI backend.
 //
 // The struct is intentionally cheap to construct — it carries a
 // pointer to the parent and a string. Handlers obtain one per
-// request via [Registry.For] and discard it when the request
+// request via [Store.For] and discard it when the request
 // finishes.
 //
-// *ScopedRegistry implements the existing [pkg/handler.Registry]
+// *ScopedNamespace implements the existing [pkg/handler.Registry]
 // interface so handler code that previously held a *pkg/oci.Registry
-// can swap to a *ScopedRegistry with no signature changes.
-type ScopedRegistry struct {
-	parent    *Registry
+// can swap to a *ScopedNamespace with no signature changes.
+type ScopedNamespace struct {
+	parent    *Store
 	namespace string
 }
 
 // Namespace returns the bound namespace name.
-func (s *ScopedRegistry) Namespace() string { return s.namespace }
+func (s *ScopedNamespace) Namespace() string { return s.namespace }
 
 // Index returns a handle to a named namespace-local sentinel index.
 // The index name is a single repo segment such as "python-packages";
 // the backing repo lives beside package repos at "<namespace>/<name>".
-func (s *ScopedRegistry) Index(name string) *NamespaceIndex {
+func (s *ScopedNamespace) Index(name string) *NamespaceIndex {
 	return &NamespaceIndex{scoped: s, name: name}
 }
 
@@ -371,22 +386,22 @@ func (s *ScopedRegistry) Index(name string) *NamespaceIndex {
 // subject may perform op in the bound namespace. Format handlers use
 // this for protocol paths that don't naturally map to a concrete OCI
 // read/write operation before returning data.
-func (s *ScopedRegistry) Authorize(ctx context.Context, op auth.Op) error {
+func (s *ScopedNamespace) Authorize(ctx context.Context, op auth.Op) error {
 	return s.parent.authorize(ctx, s.namespace, op)
 }
 
-// Spec returns the namespace's current [Spec], used by per-format
+// Spec returns the namespace's current [namespace.Spec], used by per-format
 // handlers to dispatch on [Spec.Mode] / read [Spec.Proxy] before
 // committing to a code path.
 //
 // The returned pointer references the cached entry; callers must not
 // mutate the value. An unknown namespace returns an error wrapping
-// [ErrNotFound] so [handler.WriteNamespaceError] maps it to 404.
+// [namespace.ErrNotFound] so [handler.WriteNamespaceError] maps it to 404.
 //
 // Spec does not authorize: the namespace's compiled authorizer still
 // runs on downstream [AddFile] / [ReadFile] / [ListFiles] / etc., so
 // the dispatch primitive does not become an auth bypass.
-func (s *ScopedRegistry) Spec(ctx context.Context) (*Spec, error) {
+func (s *ScopedNamespace) Spec(ctx context.Context) (*nsmeta.Spec, error) {
 	cp, err := s.parent.specFor(ctx, s.namespace)
 	if err != nil {
 		return nil, err
@@ -398,7 +413,7 @@ func (s *ScopedRegistry) Spec(ctx context.Context) (*Spec, error) {
 // f.OwningRepo with the namespace, forwards to the inner registry,
 // and (best-effort) records the owning-repo in the namespace's
 // package index.
-func (s *ScopedRegistry) AddFile(ctx context.Context, f *oci.RepoFile, body io.Reader) (*oci.FileDescriptor, error) {
+func (s *ScopedNamespace) AddFile(ctx context.Context, f *oci.RepoFile, body io.Reader) (*oci.FileDescriptor, error) {
 	if f == nil {
 		return nil, errors.New("RepoFile must not be nil")
 	}
@@ -422,7 +437,7 @@ func (s *ScopedRegistry) AddFile(ctx context.Context, f *oci.RepoFile, body io.R
 // publish APIs must continue to call AddFile so namespace write policy
 // gates real artifact writes, while pull-through proxy cache misses can
 // populate OCI storage for readers without granting them publish rights.
-func (s *ScopedRegistry) AddCachedFile(ctx context.Context, f *oci.RepoFile, body io.Reader) (*oci.FileDescriptor, error) {
+func (s *ScopedNamespace) AddCachedFile(ctx context.Context, f *oci.RepoFile, body io.Reader) (*oci.FileDescriptor, error) {
 	if f == nil {
 		return nil, errors.New("RepoFile must not be nil")
 	}
@@ -443,7 +458,7 @@ func (s *ScopedRegistry) AddCachedFile(ctx context.Context, f *oci.RepoFile, bod
 
 // ReadFile authorizes the bound namespace for read and forwards to
 // the inner registry with OwningRepo prefixed.
-func (s *ScopedRegistry) ReadFile(ctx context.Context, f *oci.RepoFile) (*oci.FileDescriptor, io.ReadCloser, error) {
+func (s *ScopedNamespace) ReadFile(ctx context.Context, f *oci.RepoFile) (*oci.FileDescriptor, io.ReadCloser, error) {
 	if f == nil {
 		return nil, nil, errors.New("RepoFile must not be nil")
 	}
@@ -460,8 +475,8 @@ func (s *ScopedRegistry) ReadFile(ctx context.Context, f *oci.RepoFile) (*oci.Fi
 // BlobRedirectURL authorizes the bound namespace for read and
 // forwards to the inner registry with OwningRepo prefixed. Returns
 // ("", nil) when the backend serves blobs inline, mirroring
-// [oci.Registry].
-func (s *ScopedRegistry) BlobRedirectURL(ctx context.Context, f *oci.RepoFile) (string, error) {
+// [oci.Store].
+func (s *ScopedNamespace) BlobRedirectURL(ctx context.Context, f *oci.RepoFile) (string, error) {
 	if f == nil {
 		return "", errors.New("RepoFile must not be nil")
 	}
@@ -477,7 +492,7 @@ func (s *ScopedRegistry) BlobRedirectURL(ctx context.Context, f *oci.RepoFile) (
 
 // ListTags authorizes the bound namespace for read and returns the
 // canonical tags for repo within the namespace.
-func (s *ScopedRegistry) ListTags(ctx context.Context, repo string) ([]string, error) {
+func (s *ScopedNamespace) ListTags(ctx context.Context, repo string) ([]string, error) {
 	if err := s.parent.authorize(ctx, s.namespace, auth.OpRead); err != nil {
 		return nil, err
 	}
@@ -490,7 +505,7 @@ func (s *ScopedRegistry) ListTags(ctx context.Context, repo string) ([]string, e
 
 // ResolveTag authorizes the bound namespace for read and returns the
 // canonical version tag identified by tag within repo.
-func (s *ScopedRegistry) ResolveTag(ctx context.Context, repo, tag string) (string, error) {
+func (s *ScopedNamespace) ResolveTag(ctx context.Context, repo, tag string) (string, error) {
 	if err := s.parent.authorize(ctx, s.namespace, auth.OpRead); err != nil {
 		return "", err
 	}
@@ -508,7 +523,7 @@ func (s *ScopedRegistry) ResolveTag(ctx context.Context, repo, tag string) (stri
 // the raw backend prefix leak through. Each returned *RepoFile is
 // freshly allocated by the wrapper so a future inner-side cache of
 // descriptors stays safe.
-func (s *ScopedRegistry) ListFiles(ctx context.Context, repo string) ([]*oci.RepoFile, error) {
+func (s *ScopedNamespace) ListFiles(ctx context.Context, repo string) ([]*oci.RepoFile, error) {
 	if err := s.parent.authorize(ctx, s.namespace, auth.OpRead); err != nil {
 		return nil, err
 	}
@@ -538,8 +553,8 @@ func (s *ScopedRegistry) ListFiles(ctx context.Context, repo string) ([]*oci.Rep
 //
 // An absent index repo is reported as an empty list — a namespace
 // that has never been written to legitimately has no packages.
-func (r *Registry) ListPackages(ctx context.Context, namespace string) ([]string, error) {
-	if err := ValidateName(namespace); err != nil {
+func (r *Store) ListPackages(ctx context.Context, namespace string) ([]string, error) {
+	if err := nsmeta.ValidateName(namespace); err != nil {
 		return nil, err
 	}
 	return r.listPackages(ctx, namespace)
@@ -547,20 +562,20 @@ func (r *Registry) ListPackages(ctx context.Context, namespace string) ([]string
 
 // ListPackages authorizes the bound namespace for read and returns
 // package-index entries for that namespace.
-func (s *ScopedRegistry) ListPackages(ctx context.Context) ([]string, error) {
+func (s *ScopedNamespace) ListPackages(ctx context.Context) ([]string, error) {
 	if err := s.parent.authorize(ctx, s.namespace, auth.OpRead); err != nil {
 		return nil, err
 	}
 	return s.parent.listPackages(ctx, s.namespace)
 }
 
-func (r *Registry) listPackages(ctx context.Context, namespace string) ([]string, error) {
+func (r *Store) listPackages(ctx context.Context, namespace string) ([]string, error) {
 	return r.listIndex(ctx, namespace, r.indexSuffix)
 }
 
 // AppendRefs authorizes the bound namespace for write and forwards
 // to the inner registry with repo prefixed.
-func (s *ScopedRegistry) AppendRefs(ctx context.Context, repo string, canonicalTag string, refs ...string) error {
+func (s *ScopedNamespace) AppendRefs(ctx context.Context, repo string, canonicalTag string, refs ...string) error {
 	if err := s.parent.authorize(ctx, s.namespace, auth.OpWrite); err != nil {
 		return err
 	}
@@ -580,7 +595,7 @@ func (s *ScopedRegistry) AppendRefs(ctx context.Context, repo string, canonicalT
 // both the in-process indexed marker AND the backend index tag — so
 // [ListPackages] no longer reports the now-empty repo. Index cleanup
 // failures are logged at WARN and do not fail the call.
-func (s *ScopedRegistry) DeleteRepoFiles(ctx context.Context, repo string) error {
+func (s *ScopedNamespace) DeleteRepoFiles(ctx context.Context, repo string) error {
 	if err := s.parent.authorize(ctx, s.namespace, auth.OpWrite); err != nil {
 		return err
 	}
@@ -610,9 +625,9 @@ func (s *ScopedRegistry) DeleteRepoFiles(ctx context.Context, repo string) error
 }
 
 // scopedFile returns a copy of f with OwningRepo rewritten to the
-// namespace-prefixed backend form. Returns [ErrInvalidOwningRepo]
+// namespace-prefixed backend form. Returns [namespace.ErrInvalidOwningRepo]
 // when the input would escape the namespace.
-func (r *Registry) scopedFile(namespace string, f *oci.RepoFile) (*oci.RepoFile, error) {
+func (r *Store) scopedFile(namespace string, f *oci.RepoFile) (*oci.RepoFile, error) {
 	scoped := *f
 	resolved, err := r.resolveRepo(namespace, f.OwningRepo)
 	if err != nil {
@@ -635,7 +650,7 @@ func (r *Registry) scopedFile(namespace string, f *oci.RepoFile) (*oci.RepoFile,
 // *sync.Mutex would let an arriving third goroutine LoadOrStore a
 // fresh mutex for the same key, "guarding" with two unrelated
 // mutexes. The map is bounded by the indexed-LRU's eviction.
-func (r *Registry) recordPackage(ctx context.Context, namespace, owningRepo string) {
+func (r *Store) recordPackage(ctx context.Context, namespace, owningRepo string) {
 	if owningRepo == "" {
 		return
 	}
@@ -733,7 +748,7 @@ func (i *NamespaceIndex) List(ctx context.Context) ([]string, error) {
 	return i.scoped.parent.listIndex(ctx, i.scoped.namespace, i.name)
 }
 
-func (r *Registry) markIndex(ctx context.Context, namespace, indexName, key string) error {
+func (r *Store) markIndex(ctx context.Context, namespace, indexName, key string) error {
 	encoded, err := oci.EncodeTag(key)
 	if err != nil {
 		return err
@@ -751,7 +766,7 @@ func (r *Registry) markIndex(ctx context.Context, namespace, indexName, key stri
 	return nil
 }
 
-func (r *Registry) listIndex(ctx context.Context, namespace, indexName string) ([]string, error) {
+func (r *Store) listIndex(ctx context.Context, namespace, indexName string) ([]string, error) {
 	tags, err := r.inner.ListTags(ctx, path.Join(namespace, indexName))
 	if err != nil {
 		if errors.Is(err, errdef.ErrNotFound) {
@@ -773,18 +788,18 @@ func (r *Registry) listIndex(ctx context.Context, namespace, indexName string) (
 	return out, nil
 }
 
-func (r *Registry) validatePublicIndexName(name string) error {
+func (r *Store) validatePublicIndexName(name string) error {
 	if name == "" {
-		return fmt.Errorf("%w: index name must not be empty", ErrInvalidOwningRepo)
+		return fmt.Errorf("%w: index name must not be empty", nsmeta.ErrInvalidOwningRepo)
 	}
 	if name == r.indexSuffix {
-		return fmt.Errorf("%w: index name %q is reserved", ErrInvalidOwningRepo, name)
+		return fmt.Errorf("%w: index name %q is reserved", nsmeta.ErrInvalidOwningRepo, name)
 	}
 	if path.Clean(name) != name || strings.ContainsRune(name, '/') || name == "." || name == ".." {
-		return fmt.Errorf("%w: index name %q is not a single canonical segment", ErrInvalidOwningRepo, name)
+		return fmt.Errorf("%w: index name %q is not a single canonical segment", nsmeta.ErrInvalidOwningRepo, name)
 	}
 	if err := oci.ValidateRepoPrefix(name); err != nil {
-		return fmt.Errorf("%w: index name %q is invalid: %v", ErrInvalidOwningRepo, name, err)
+		return fmt.Errorf("%w: index name %q is invalid: %v", nsmeta.ErrInvalidOwningRepo, name, err)
 	}
 	return nil
 }

--- a/pkg/artifact/registry.go
+++ b/pkg/artifact/registry.go
@@ -104,18 +104,18 @@ type NamespaceStore interface {
 // Store is the data-plane wrapper that holds the cross-namespace
 // state — the authorizer cache, the package-index dedupe set, the
 // pluggable authz factory — and hands out per-namespace
-// [ScopedNamespace] views via [Store.For].
+// [NamespaceView] views via [Store.View].
 //
 // Handlers don't use *Store directly; they hold a
-// *ScopedNamespace obtained per request:
+// *NamespaceView obtained per request:
 //
 //	ns := mux.Vars(req)["namespace"]
-//	scoped := r.For(ns)
-//	desc, err := scoped.AddFile(ctx, f, body)
+//	view := r.View(ns)
+//	desc, err := view.AddFile(ctx, f, body)
 //
-// *ScopedNamespace implements the existing [pkg/handler.Registry]
+// *NamespaceView implements the existing [pkg/handler.Registry]
 // interface, so handlers can swap a *pkg/oci.Registry for a
-// *ScopedNamespace without changing any call site — namespace-aware
+// *NamespaceView without changing any call site — namespace-aware
 // authz and OwningRepo prefixing happen transparently.
 type Store struct {
 	inner       Backend
@@ -199,21 +199,21 @@ func NewStore(inner Backend, namespaces NamespaceStore, opts ...StoreOption) *St
 // Namespace returns a handler-facing namespace after validating that the
 // namespace metadata exists.
 func (r *Store) Namespace(ctx context.Context, name string) (Namespace, error) {
-	scoped := r.For(name)
-	if _, err := scoped.Spec(ctx); err != nil {
+	view := r.View(name)
+	if _, err := view.Spec(ctx); err != nil {
 		return nil, err
 	}
-	return artifactNamespace{scoped: scoped}, nil
+	return artifactNamespace{view: view}, nil
 }
 
-// For returns a [ScopedNamespace] bound to namespace. The returned
+// View returns a [NamespaceView] bound to namespace. The returned
 // view is cheap to construct (a small struct, no I/O) so handlers
 // should call it per request rather than caching it. The bound
 // namespace is enforced on every method invocation — there is no
 // way to issue a cross-namespace operation through a single
-// ScopedNamespace.
-func (r *Store) For(namespace string) *ScopedNamespace {
-	return &ScopedNamespace{parent: r, namespace: namespace}
+// NamespaceView.
+func (r *Store) View(namespace string) *NamespaceView {
+	return &NamespaceView{parent: r, namespace: namespace}
 }
 
 // InvalidatePolicy drops the cached authorizer for name so the next
@@ -251,7 +251,7 @@ func (r *Store) authorize(ctx context.Context, namespace string, op auth.Op) err
 }
 
 // specFor is the cache-aware single-namespace lookup that
-// [Store.authorizerFor] and [ScopedNamespace.Spec] funnel through.
+// [Store.authorizerFor] and [NamespaceView.Spec] funnel through.
 // On a hit it returns the cached entry without any I/O; on a miss it
 // resolves through the shared singleflight so concurrent callers
 // observe one [Store.Get] + authorizer compile.
@@ -350,43 +350,43 @@ func (r *Store) packageIndexRepo(namespace string) string {
 // NamespaceIndex is a tag-backed sibling repository inside one
 // namespace. Tags are encoded keys; callers see only decoded keys.
 type NamespaceIndex struct {
-	scoped *ScopedNamespace
-	name   string
+	view *NamespaceView
+	name string
 }
 
-// ScopedNamespace is a per-namespace view of a [Store]. Every
+// NamespaceView is a per-namespace view of a [Store]. Every
 // method authorizes the bound namespace, prefixes OwningRepo (or the
 // raw repo string for ListTags/ListFiles/etc.) with it, and forwards
 // to the underlying OCI backend.
 //
 // The struct is intentionally cheap to construct — it carries a
 // pointer to the parent and a string. Handlers obtain one per
-// request via [Store.For] and discard it when the request
+// request via [Store.View] and discard it when the request
 // finishes.
 //
-// *ScopedNamespace implements the existing [pkg/handler.Registry]
+// *NamespaceView implements the existing [pkg/handler.Registry]
 // interface so handler code that previously held a *pkg/oci.Registry
-// can swap to a *ScopedNamespace with no signature changes.
-type ScopedNamespace struct {
+// can swap to a *NamespaceView with no signature changes.
+type NamespaceView struct {
 	parent    *Store
 	namespace string
 }
 
 // Namespace returns the bound namespace name.
-func (s *ScopedNamespace) Namespace() string { return s.namespace }
+func (s *NamespaceView) Namespace() string { return s.namespace }
 
 // Index returns a handle to a named namespace-local sentinel index.
 // The index name is a single repo segment such as "python-packages";
 // the backing repo lives beside package repos at "<namespace>/<name>".
-func (s *ScopedNamespace) Index(name string) *NamespaceIndex {
-	return &NamespaceIndex{scoped: s, name: name}
+func (s *NamespaceView) Index(name string) *NamespaceIndex {
+	return &NamespaceIndex{view: s, name: name}
 }
 
 // Authorize checks whether the request context's authenticated
 // subject may perform op in the bound namespace. Format handlers use
 // this for protocol paths that don't naturally map to a concrete OCI
 // read/write operation before returning data.
-func (s *ScopedNamespace) Authorize(ctx context.Context, op auth.Op) error {
+func (s *NamespaceView) Authorize(ctx context.Context, op auth.Op) error {
 	return s.parent.authorize(ctx, s.namespace, op)
 }
 
@@ -401,7 +401,7 @@ func (s *ScopedNamespace) Authorize(ctx context.Context, op auth.Op) error {
 // Spec does not authorize: the namespace's compiled authorizer still
 // runs on downstream [AddFile] / [ReadFile] / [ListFiles] / etc., so
 // the dispatch primitive does not become an auth bypass.
-func (s *ScopedNamespace) Spec(ctx context.Context) (*nsmeta.Spec, error) {
+func (s *NamespaceView) Spec(ctx context.Context) (*nsmeta.Spec, error) {
 	cp, err := s.parent.specFor(ctx, s.namespace)
 	if err != nil {
 		return nil, err
@@ -413,18 +413,18 @@ func (s *ScopedNamespace) Spec(ctx context.Context) (*nsmeta.Spec, error) {
 // f.OwningRepo with the namespace, forwards to the inner registry,
 // and (best-effort) records the owning-repo in the namespace's
 // package index.
-func (s *ScopedNamespace) AddFile(ctx context.Context, f *oci.RepoFile, body io.Reader) (*oci.FileDescriptor, error) {
+func (s *NamespaceView) AddFile(ctx context.Context, f *oci.RepoFile, body io.Reader) (*oci.FileDescriptor, error) {
 	if f == nil {
 		return nil, errors.New("RepoFile must not be nil")
 	}
 	if err := s.parent.authorize(ctx, s.namespace, auth.OpWrite); err != nil {
 		return nil, err
 	}
-	scoped, err := s.parent.scopedFile(s.namespace, f)
+	backendFile, err := s.parent.backendFile(s.namespace, f)
 	if err != nil {
 		return nil, err
 	}
-	desc, err := s.parent.inner.AddFile(ctx, scoped, body)
+	desc, err := s.parent.inner.AddFile(ctx, backendFile, body)
 	if err != nil {
 		return nil, err
 	}
@@ -437,18 +437,18 @@ func (s *ScopedNamespace) AddFile(ctx context.Context, f *oci.RepoFile, body io.
 // publish APIs must continue to call AddFile so namespace write policy
 // gates real artifact writes, while pull-through proxy cache misses can
 // populate OCI storage for readers without granting them publish rights.
-func (s *ScopedNamespace) AddCachedFile(ctx context.Context, f *oci.RepoFile, body io.Reader) (*oci.FileDescriptor, error) {
+func (s *NamespaceView) AddCachedFile(ctx context.Context, f *oci.RepoFile, body io.Reader) (*oci.FileDescriptor, error) {
 	if f == nil {
 		return nil, errors.New("RepoFile must not be nil")
 	}
 	if err := s.parent.authorize(ctx, s.namespace, auth.OpRead); err != nil {
 		return nil, err
 	}
-	scoped, err := s.parent.scopedFile(s.namespace, f)
+	backendFile, err := s.parent.backendFile(s.namespace, f)
 	if err != nil {
 		return nil, err
 	}
-	desc, err := s.parent.inner.AddFile(ctx, scoped, body)
+	desc, err := s.parent.inner.AddFile(ctx, backendFile, body)
 	if err != nil {
 		return nil, err
 	}
@@ -458,62 +458,62 @@ func (s *ScopedNamespace) AddCachedFile(ctx context.Context, f *oci.RepoFile, bo
 
 // ReadFile authorizes the bound namespace for read and forwards to
 // the inner registry with OwningRepo prefixed.
-func (s *ScopedNamespace) ReadFile(ctx context.Context, f *oci.RepoFile) (*oci.FileDescriptor, io.ReadCloser, error) {
+func (s *NamespaceView) ReadFile(ctx context.Context, f *oci.RepoFile) (*oci.FileDescriptor, io.ReadCloser, error) {
 	if f == nil {
 		return nil, nil, errors.New("RepoFile must not be nil")
 	}
 	if err := s.parent.authorize(ctx, s.namespace, auth.OpRead); err != nil {
 		return nil, nil, err
 	}
-	scoped, err := s.parent.scopedFile(s.namespace, f)
+	backendFile, err := s.parent.backendFile(s.namespace, f)
 	if err != nil {
 		return nil, nil, err
 	}
-	return s.parent.inner.ReadFile(ctx, scoped)
+	return s.parent.inner.ReadFile(ctx, backendFile)
 }
 
 // BlobRedirectURL authorizes the bound namespace for read and
 // forwards to the inner registry with OwningRepo prefixed. Returns
 // ("", nil) when the backend serves blobs inline, mirroring
-// [oci.Store].
-func (s *ScopedNamespace) BlobRedirectURL(ctx context.Context, f *oci.RepoFile) (string, error) {
+// [oci.Registry].
+func (s *NamespaceView) BlobRedirectURL(ctx context.Context, f *oci.RepoFile) (string, error) {
 	if f == nil {
 		return "", errors.New("RepoFile must not be nil")
 	}
 	if err := s.parent.authorize(ctx, s.namespace, auth.OpRead); err != nil {
 		return "", err
 	}
-	scoped, err := s.parent.scopedFile(s.namespace, f)
+	backendFile, err := s.parent.backendFile(s.namespace, f)
 	if err != nil {
 		return "", err
 	}
-	return s.parent.inner.BlobRedirectURL(ctx, scoped)
+	return s.parent.inner.BlobRedirectURL(ctx, backendFile)
 }
 
 // ListTags authorizes the bound namespace for read and returns the
 // canonical tags for repo within the namespace.
-func (s *ScopedNamespace) ListTags(ctx context.Context, repo string) ([]string, error) {
+func (s *NamespaceView) ListTags(ctx context.Context, repo string) ([]string, error) {
 	if err := s.parent.authorize(ctx, s.namespace, auth.OpRead); err != nil {
 		return nil, err
 	}
-	scoped, err := s.parent.resolveRepo(s.namespace, repo)
+	backendRepo, err := s.parent.resolveRepo(s.namespace, repo)
 	if err != nil {
 		return nil, err
 	}
-	return s.parent.inner.ListTags(ctx, scoped)
+	return s.parent.inner.ListTags(ctx, backendRepo)
 }
 
 // ResolveTag authorizes the bound namespace for read and returns the
 // canonical version tag identified by tag within repo.
-func (s *ScopedNamespace) ResolveTag(ctx context.Context, repo, tag string) (string, error) {
+func (s *NamespaceView) ResolveTag(ctx context.Context, repo, tag string) (string, error) {
 	if err := s.parent.authorize(ctx, s.namespace, auth.OpRead); err != nil {
 		return "", err
 	}
-	scoped, err := s.parent.resolveRepo(s.namespace, repo)
+	backendRepo, err := s.parent.resolveRepo(s.namespace, repo)
 	if err != nil {
 		return "", err
 	}
-	return s.parent.inner.ResolveTag(ctx, scoped, tag)
+	return s.parent.inner.ResolveTag(ctx, backendRepo, tag)
 }
 
 // ListFiles authorizes the bound namespace for read and returns
@@ -523,15 +523,15 @@ func (s *ScopedNamespace) ResolveTag(ctx context.Context, repo, tag string) (str
 // the raw backend prefix leak through. Each returned *RepoFile is
 // freshly allocated by the wrapper so a future inner-side cache of
 // descriptors stays safe.
-func (s *ScopedNamespace) ListFiles(ctx context.Context, repo string) ([]*oci.RepoFile, error) {
+func (s *NamespaceView) ListFiles(ctx context.Context, repo string) ([]*oci.RepoFile, error) {
 	if err := s.parent.authorize(ctx, s.namespace, auth.OpRead); err != nil {
 		return nil, err
 	}
-	scoped, err := s.parent.resolveRepo(s.namespace, repo)
+	backendRepo, err := s.parent.resolveRepo(s.namespace, repo)
 	if err != nil {
 		return nil, err
 	}
-	files, err := s.parent.inner.ListFiles(ctx, scoped)
+	files, err := s.parent.inner.ListFiles(ctx, backendRepo)
 	if err != nil {
 		return nil, err
 	}
@@ -562,7 +562,7 @@ func (r *Store) ListPackages(ctx context.Context, namespace string) ([]string, e
 
 // ListPackages authorizes the bound namespace for read and returns
 // package-index entries for that namespace.
-func (s *ScopedNamespace) ListPackages(ctx context.Context) ([]string, error) {
+func (s *NamespaceView) ListPackages(ctx context.Context) ([]string, error) {
 	if err := s.parent.authorize(ctx, s.namespace, auth.OpRead); err != nil {
 		return nil, err
 	}
@@ -575,18 +575,18 @@ func (r *Store) listPackages(ctx context.Context, namespace string) ([]string, e
 
 // AppendRefs authorizes the bound namespace for write and forwards
 // to the inner registry with repo prefixed.
-func (s *ScopedNamespace) AppendRefs(ctx context.Context, repo string, canonicalTag string, refs ...string) error {
+func (s *NamespaceView) AppendRefs(ctx context.Context, repo string, canonicalTag string, refs ...string) error {
 	if err := s.parent.authorize(ctx, s.namespace, auth.OpWrite); err != nil {
 		return err
 	}
 	if canonicalTag == "" {
 		return errors.New("canonicalTag must not be empty")
 	}
-	scoped, err := s.parent.resolveRepo(s.namespace, repo)
+	backendRepo, err := s.parent.resolveRepo(s.namespace, repo)
 	if err != nil {
 		return err
 	}
-	return s.parent.inner.AppendRefs(ctx, scoped, canonicalTag, refs...)
+	return s.parent.inner.AppendRefs(ctx, backendRepo, canonicalTag, refs...)
 }
 
 // DeleteRepoFiles authorizes the bound namespace for write and
@@ -595,15 +595,15 @@ func (s *ScopedNamespace) AppendRefs(ctx context.Context, repo string, canonical
 // both the in-process indexed marker AND the backend index tag — so
 // [ListPackages] no longer reports the now-empty repo. Index cleanup
 // failures are logged at WARN and do not fail the call.
-func (s *ScopedNamespace) DeleteRepoFiles(ctx context.Context, repo string) error {
+func (s *NamespaceView) DeleteRepoFiles(ctx context.Context, repo string) error {
 	if err := s.parent.authorize(ctx, s.namespace, auth.OpWrite); err != nil {
 		return err
 	}
-	scoped, err := s.parent.resolveRepo(s.namespace, repo)
+	backendRepo, err := s.parent.resolveRepo(s.namespace, repo)
 	if err != nil {
 		return err
 	}
-	if err := s.parent.inner.DeleteRepoFiles(ctx, scoped); err != nil {
+	if err := s.parent.inner.DeleteRepoFiles(ctx, backendRepo); err != nil {
 		return err
 	}
 	s.parent.indexed.Remove(indexedKey(s.namespace, repo))
@@ -624,17 +624,17 @@ func (s *ScopedNamespace) DeleteRepoFiles(ctx context.Context, repo string) erro
 	return nil
 }
 
-// scopedFile returns a copy of f with OwningRepo rewritten to the
+// backendFile returns a copy of f with OwningRepo rewritten to the
 // namespace-prefixed backend form. Returns [namespace.ErrInvalidOwningRepo]
 // when the input would escape the namespace.
-func (r *Store) scopedFile(namespace string, f *oci.RepoFile) (*oci.RepoFile, error) {
-	scoped := *f
+func (r *Store) backendFile(namespace string, f *oci.RepoFile) (*oci.RepoFile, error) {
+	copyF := *f
 	resolved, err := r.resolveRepo(namespace, f.OwningRepo)
 	if err != nil {
 		return nil, err
 	}
-	scoped.OwningRepo = resolved
-	return &scoped, nil
+	copyF.OwningRepo = resolved
+	return &copyF, nil
 }
 
 // recordPackage best-effort marks owningRepo as present in the
@@ -683,28 +683,28 @@ func (r *Store) recordPackage(ctx context.Context, namespace, owningRepo string)
 
 // Mark records key in the index.
 func (i *NamespaceIndex) Mark(ctx context.Context, key string) error {
-	if err := i.scoped.parent.authorize(ctx, i.scoped.namespace, auth.OpWrite); err != nil {
+	if err := i.view.parent.authorize(ctx, i.view.namespace, auth.OpWrite); err != nil {
 		return err
 	}
-	if err := i.scoped.parent.validatePublicIndexName(i.name); err != nil {
+	if err := i.view.parent.validatePublicIndexName(i.name); err != nil {
 		return err
 	}
-	return i.scoped.parent.markIndex(ctx, i.scoped.namespace, i.name, key)
+	return i.view.parent.markIndex(ctx, i.view.namespace, i.name, key)
 }
 
 // Unmark removes key from the index. Missing keys are a no-op.
 func (i *NamespaceIndex) Unmark(ctx context.Context, key string) error {
-	if err := i.scoped.parent.authorize(ctx, i.scoped.namespace, auth.OpWrite); err != nil {
+	if err := i.view.parent.authorize(ctx, i.view.namespace, auth.OpWrite); err != nil {
 		return err
 	}
-	if err := i.scoped.parent.validatePublicIndexName(i.name); err != nil {
+	if err := i.view.parent.validatePublicIndexName(i.name); err != nil {
 		return err
 	}
 	encoded, err := oci.EncodeTag(key)
 	if err != nil {
 		return err
 	}
-	if err := i.scoped.parent.inner.DeleteTagFiles(ctx, path.Join(i.scoped.namespace, i.name), encoded); err != nil && !errors.Is(err, errdef.ErrNotFound) {
+	if err := i.view.parent.inner.DeleteTagFiles(ctx, path.Join(i.view.namespace, i.name), encoded); err != nil && !errors.Is(err, errdef.ErrNotFound) {
 		return err
 	}
 	return nil
@@ -712,17 +712,17 @@ func (i *NamespaceIndex) Unmark(ctx context.Context, key string) error {
 
 // Has reports whether key is present in the index.
 func (i *NamespaceIndex) Has(ctx context.Context, key string) (bool, error) {
-	if err := i.scoped.parent.authorize(ctx, i.scoped.namespace, auth.OpRead); err != nil {
+	if err := i.view.parent.authorize(ctx, i.view.namespace, auth.OpRead); err != nil {
 		return false, err
 	}
-	if err := i.scoped.parent.validatePublicIndexName(i.name); err != nil {
+	if err := i.view.parent.validatePublicIndexName(i.name); err != nil {
 		return false, err
 	}
 	encoded, err := oci.EncodeTag(key)
 	if err != nil {
 		return false, err
 	}
-	tags, err := i.scoped.parent.inner.ListTags(ctx, path.Join(i.scoped.namespace, i.name))
+	tags, err := i.view.parent.inner.ListTags(ctx, path.Join(i.view.namespace, i.name))
 	if err != nil {
 		if errors.Is(err, errdef.ErrNotFound) {
 			return false, nil
@@ -739,13 +739,13 @@ func (i *NamespaceIndex) Has(ctx context.Context, key string) (bool, error) {
 
 // List returns all decoded keys in the index.
 func (i *NamespaceIndex) List(ctx context.Context) ([]string, error) {
-	if err := i.scoped.parent.authorize(ctx, i.scoped.namespace, auth.OpRead); err != nil {
+	if err := i.view.parent.authorize(ctx, i.view.namespace, auth.OpRead); err != nil {
 		return nil, err
 	}
-	if err := i.scoped.parent.validatePublicIndexName(i.name); err != nil {
+	if err := i.view.parent.validatePublicIndexName(i.name); err != nil {
 		return nil, err
 	}
-	return i.scoped.parent.listIndex(ctx, i.scoped.namespace, i.name)
+	return i.view.parent.listIndex(ctx, i.view.namespace, i.name)
 }
 
 func (r *Store) markIndex(ctx context.Context, namespace, indexName, key string) error {

--- a/pkg/artifact/registry_test.go
+++ b/pkg/artifact/registry_test.go
@@ -1,4 +1,4 @@
-package namespace_test
+package artifact_test
 
 import (
 	"context"
@@ -14,17 +14,18 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"oras.land/oras-go/v2/errdef"
 
+	"github.com/yolocs/ocifactory/pkg/artifact"
 	"github.com/yolocs/ocifactory/pkg/auth"
 	"github.com/yolocs/ocifactory/pkg/handler"
 	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
 )
 
-// Compile-time assertion: *ScopedRegistry satisfies handler.Registry
+// Compile-time assertion: *ScopedNamespace satisfies handler.Registry
 // so existing python/maven handlers can swap a *pkg/oci.Registry for
-// a *ScopedRegistry without any signature changes. Lives in the
+// a *ScopedNamespace without any signature changes. Lives in the
 // _test package to avoid pkg/namespace importing pkg/handler.
-var _ handler.Registry = (*namespace.ScopedRegistry)(nil)
+var _ handler.Registry = (*artifact.ScopedNamespace)(nil)
 
 const (
 	googleIss   = "https://accounts.google.com"
@@ -57,15 +58,15 @@ func aliceCtx(t *testing.T) context.Context {
 	})
 }
 
-func setup(t *testing.T, opts ...namespace.RegistryOption) (*oci.FakeRegistry, *namespace.Registry, *namespace.Store) {
+func setup(t *testing.T, opts ...artifact.StoreOption) (*oci.FakeRegistry, *artifact.Store, *namespace.Store) {
 	t.Helper()
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
 	// Disable the policy cache by default in tests so a Put then call
 	// in the same test sees the new spec without sleeping. The cache
 	// itself is exercised explicitly in TestRegistry_PolicyCache_*.
-	allOpts := append([]namespace.RegistryOption{namespace.WithPolicyCacheTTL(0)}, opts...)
-	reg := namespace.NewRegistry(fake, store, allOpts...)
+	allOpts := append([]artifact.StoreOption{artifact.WithPolicyCacheTTL(0)}, opts...)
+	reg := artifact.NewStore(fake, store, allOpts...)
 	return fake, reg, store
 }
 
@@ -87,7 +88,7 @@ func newRepoFile(repo, tag, name string) *oci.RepoFile {
 	}
 }
 
-func TestScopedRegistry_AddRead_HappyPath(t *testing.T) {
+func TestScopedNamespace_AddRead_HappyPath(t *testing.T) {
 	t.Parallel()
 
 	fake, reg, store := setup(t)
@@ -123,12 +124,12 @@ func TestScopedRegistry_AddRead_HappyPath(t *testing.T) {
 	}
 }
 
-// TestScopedRegistry_NamespaceIsolation pins the load-bearing
+// TestScopedNamespace_NamespaceIsolation pins the load-bearing
 // security guarantee: the beta scoped view cannot read a file
 // written through the alpha scoped view, AND alpha can still read
 // its own file (so a regression that 5xx'd on every read wouldn't
 // pass for the wrong reason).
-func TestScopedRegistry_NamespaceIsolation(t *testing.T) {
+func TestScopedNamespace_NamespaceIsolation(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
@@ -158,10 +159,10 @@ func TestScopedRegistry_NamespaceIsolation(t *testing.T) {
 	}
 }
 
-// TestScopedRegistry_NamespaceEscape is the explicit anti-vuln
+// TestScopedNamespace_NamespaceEscape is the explicit anti-vuln
 // test: the alpha scoped view cannot reach beta by passing
 // OwningRepo="../beta/foo" etc.
-func TestScopedRegistry_NamespaceEscape(t *testing.T) {
+func TestScopedNamespace_NamespaceEscape(t *testing.T) {
 	t.Parallel()
 
 	fake, reg, store := setup(t)
@@ -202,12 +203,12 @@ func TestScopedRegistry_NamespaceEscape(t *testing.T) {
 	}
 }
 
-// TestScopedRegistry_RejectsReservedIndexSuffix proves the wrapper
+// TestScopedNamespace_RejectsReservedIndexSuffix proves the wrapper
 // refuses to route a user-supplied owning-repo into the per-namespace
 // package-index repo. Without this check a maven-style handler that
 // builds OwningRepo from URL path segments could plant tags in the
 // wrapper's own sentinel repo.
-func TestScopedRegistry_RejectsReservedIndexSuffix(t *testing.T) {
+func TestScopedNamespace_RejectsReservedIndexSuffix(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
@@ -236,7 +237,7 @@ func TestScopedRegistry_RejectsReservedIndexSuffix(t *testing.T) {
 	}
 }
 
-func TestScopedRegistry_NamespaceNotFound(t *testing.T) {
+func TestScopedNamespace_NamespaceNotFound(t *testing.T) {
 	t.Parallel()
 
 	_, reg, _ := setup(t)
@@ -317,7 +318,7 @@ func TestScopedRegistry_NamespaceNotFound(t *testing.T) {
 	}
 }
 
-func TestScopedRegistry_NilFile(t *testing.T) {
+func TestScopedNamespace_NilFile(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
@@ -336,7 +337,7 @@ func TestScopedRegistry_NilFile(t *testing.T) {
 	}
 }
 
-func TestScopedRegistry_Authz(t *testing.T) {
+func TestScopedNamespace_Authz(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -457,7 +458,7 @@ func seedDirect(t *testing.T, fake *oci.FakeRegistry, ns string) {
 	}
 }
 
-func TestScopedRegistry_NoAuthContextDenied(t *testing.T) {
+func TestScopedNamespace_NoAuthContextDenied(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
@@ -472,16 +473,16 @@ func TestScopedRegistry_NoAuthContextDenied(t *testing.T) {
 	}
 }
 
-// TestScopedRegistry_NoAuthContextDeniedAtWrapper proves the wrapper
+// TestScopedNamespace_NoAuthContextDeniedAtWrapper proves the wrapper
 // itself denies nil even when the AuthzFactory would have allowed.
-func TestScopedRegistry_NoAuthContextDeniedAtWrapper(t *testing.T) {
+func TestScopedNamespace_NoAuthContextDeniedAtWrapper(t *testing.T) {
 	t.Parallel()
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store,
-		namespace.WithAuthzFactory(func(_ namespace.Policy) (auth.Authorizer, error) { return auth.AllowAll, nil }),
-		namespace.WithPolicyCacheTTL(0),
+	reg := artifact.NewStore(fake, store,
+		artifact.WithAuthzFactory(func(_ namespace.Policy) (auth.Authorizer, error) { return auth.AllowAll, nil }),
+		artifact.WithPolicyCacheTTL(0),
 	)
 	putNamespace(t, store, "alpha", allowAllSpec())
 
@@ -491,16 +492,16 @@ func TestScopedRegistry_NoAuthContextDeniedAtWrapper(t *testing.T) {
 	}
 }
 
-// TestScopedRegistry_PackageIndex_PopulatedExactlyOnce uses a
+// TestScopedNamespace_PackageIndex_PopulatedExactlyOnce uses a
 // counting backend to prove the wrapper makes exactly one
 // index-repo AddFile call across N data writes to the same
 // (ns, owning-repo).
-func TestScopedRegistry_PackageIndex_PopulatedExactlyOnce(t *testing.T) {
+func TestScopedNamespace_PackageIndex_PopulatedExactlyOnce(t *testing.T) {
 	t.Parallel()
 
 	counted := newCountingBackend()
 	store := namespace.NewStore(counted)
-	reg := namespace.NewRegistry(counted, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(counted, store, artifact.WithPolicyCacheTTL(0))
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
 	scoped := reg.For("alpha")
@@ -517,7 +518,7 @@ func TestScopedRegistry_PackageIndex_PopulatedExactlyOnce(t *testing.T) {
 	}
 }
 
-func TestScopedRegistry_PackageIndex_MultipleRepos(t *testing.T) {
+func TestScopedNamespace_PackageIndex_MultipleRepos(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
@@ -542,15 +543,15 @@ func TestScopedRegistry_PackageIndex_MultipleRepos(t *testing.T) {
 	}
 }
 
-// TestScopedRegistry_PackageIndex_ConcurrentExactlyOneAddFile is
+// TestScopedNamespace_PackageIndex_ConcurrentExactlyOneAddFile is
 // the concurrency stress: N goroutines hammering the same
 // (ns, owning-repo) must result in exactly ONE index-repo AddFile.
-func TestScopedRegistry_PackageIndex_ConcurrentExactlyOneAddFile(t *testing.T) {
+func TestScopedNamespace_PackageIndex_ConcurrentExactlyOneAddFile(t *testing.T) {
 	t.Parallel()
 
 	counted := newCountingBackend()
 	store := namespace.NewStore(counted)
-	reg := namespace.NewRegistry(counted, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(counted, store, artifact.WithPolicyCacheTTL(0))
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
 	scoped := reg.For("alpha")
@@ -586,7 +587,7 @@ func TestScopedRegistry_PackageIndex_ConcurrentExactlyOneAddFile(t *testing.T) {
 	}
 }
 
-func TestScopedRegistry_PackageIndex_Isolated(t *testing.T) {
+func TestScopedNamespace_PackageIndex_Isolated(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
@@ -607,7 +608,7 @@ func TestScopedRegistry_PackageIndex_Isolated(t *testing.T) {
 	}
 }
 
-func TestScopedRegistry_Index_RoundTrip(t *testing.T) {
+func TestScopedNamespace_Index_RoundTrip(t *testing.T) {
 	t.Parallel()
 
 	fake, reg, store := setup(t)
@@ -658,7 +659,7 @@ func TestScopedRegistry_Index_RoundTrip(t *testing.T) {
 	}
 }
 
-func TestScopedRegistry_Index_RejectsInvalidName(t *testing.T) {
+func TestScopedNamespace_Index_RejectsInvalidName(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
@@ -679,10 +680,10 @@ func TestScopedRegistry_Index_RejectsInvalidName(t *testing.T) {
 	}
 }
 
-// TestScopedRegistry_TagEncoding_RoundTrip pins the encoding
+// TestScopedNamespace_TagEncoding_RoundTrip pins the encoding
 // properties: collision-free between names that differ only in '/'
 // vs '_'.
-func TestScopedRegistry_TagEncoding_RoundTrip(t *testing.T) {
+func TestScopedNamespace_TagEncoding_RoundTrip(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
@@ -716,7 +717,7 @@ func TestScopedRegistry_TagEncoding_RoundTrip(t *testing.T) {
 	}
 }
 
-func TestScopedRegistry_ListPackages_EmptyOnUntouchedNamespace(t *testing.T) {
+func TestScopedNamespace_ListPackages_EmptyOnUntouchedNamespace(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
@@ -732,7 +733,7 @@ func TestScopedRegistry_ListPackages_EmptyOnUntouchedNamespace(t *testing.T) {
 	}
 }
 
-func TestScopedRegistry_ListTags_AndListFiles(t *testing.T) {
+func TestScopedNamespace_ListTags_AndListFiles(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
@@ -769,7 +770,7 @@ func TestScopedRegistry_ListTags_AndListFiles(t *testing.T) {
 	}
 }
 
-func TestScopedRegistry_ListFiles_MultiSegmentRepo(t *testing.T) {
+func TestScopedNamespace_ListFiles_MultiSegmentRepo(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
@@ -790,9 +791,9 @@ func TestScopedRegistry_ListFiles_MultiSegmentRepo(t *testing.T) {
 	}
 }
 
-// TestScopedRegistry_ListFiles_PrefixOfAnotherNamespace pins that
+// TestScopedNamespace_ListFiles_PrefixOfAnotherNamespace pins that
 // "alpha" doesn't accidentally strip from "alpha-foo" repos.
-func TestScopedRegistry_ListFiles_PrefixOfAnotherNamespace(t *testing.T) {
+func TestScopedNamespace_ListFiles_PrefixOfAnotherNamespace(t *testing.T) {
 	t.Parallel()
 
 	fake, reg, store := setup(t)
@@ -817,7 +818,7 @@ func TestScopedRegistry_ListFiles_PrefixOfAnotherNamespace(t *testing.T) {
 	}
 }
 
-func TestScopedRegistry_AppendRefs_Forwards(t *testing.T) {
+func TestScopedNamespace_AppendRefs_Forwards(t *testing.T) {
 	t.Parallel()
 
 	fake, reg, store := setup(t)
@@ -836,7 +837,7 @@ func TestScopedRegistry_AppendRefs_Forwards(t *testing.T) {
 	}
 }
 
-func TestScopedRegistry_ResolveTag(t *testing.T) {
+func TestScopedNamespace_ResolveTag(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
@@ -874,10 +875,10 @@ func TestScopedRegistry_ResolveTag(t *testing.T) {
 	}
 }
 
-// TestScopedRegistry_DeleteRepoFiles_SweepsBackendIndex verifies
+// TestScopedNamespace_DeleteRepoFiles_SweepsBackendIndex verifies
 // BOTH the in-process indexed marker AND the backend
 // ocifactory-packages tag are cleared.
-func TestScopedRegistry_DeleteRepoFiles_SweepsBackendIndex(t *testing.T) {
+func TestScopedNamespace_DeleteRepoFiles_SweepsBackendIndex(t *testing.T) {
 	t.Parallel()
 
 	fake, reg, store := setup(t)
@@ -933,7 +934,7 @@ func TestRegistry_PolicyCache_HotPathSkipsStore(t *testing.T) {
 
 	counted := newCountingBackend()
 	store := namespace.NewStore(counted)
-	reg := namespace.NewRegistry(counted, store, namespace.WithPolicyCacheTTL(time.Hour))
+	reg := artifact.NewStore(counted, store, artifact.WithPolicyCacheTTL(time.Hour))
 
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
@@ -965,7 +966,7 @@ func TestRegistry_PolicyCache_TTLZero_DisablesCache(t *testing.T) {
 
 	counted := newCountingBackend()
 	store := namespace.NewStore(counted)
-	reg := namespace.NewRegistry(counted, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(counted, store, artifact.WithPolicyCacheTTL(0))
 
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
@@ -995,7 +996,7 @@ func TestRegistry_PolicyCache_NegativeCaching(t *testing.T) {
 
 	counted := newCountingBackend()
 	store := namespace.NewStore(counted)
-	reg := namespace.NewRegistry(counted, store, namespace.WithPolicyCacheTTL(time.Hour))
+	reg := artifact.NewStore(counted, store, artifact.WithPolicyCacheTTL(time.Hour))
 	ctx := aliceCtx(t)
 
 	const iters = 10
@@ -1026,7 +1027,7 @@ func TestRegistry_StorePut_InvalidatesCache(t *testing.T) {
 
 	counted := newCountingBackend()
 	store := namespace.NewStore(counted)
-	reg := namespace.NewRegistry(counted, store, namespace.WithPolicyCacheTTL(time.Hour))
+	reg := artifact.NewStore(counted, store, artifact.WithPolicyCacheTTL(time.Hour))
 	ctx := aliceCtx(t)
 
 	putNamespace(t, store, "alpha", namespace.Spec{Policy: namespace.Policy{
@@ -1050,7 +1051,7 @@ func TestRegistry_PolicyCache_Singleflight(t *testing.T) {
 
 	counted := newCountingBackend()
 	store := namespace.NewStore(counted)
-	reg := namespace.NewRegistry(counted, store, namespace.WithPolicyCacheTTL(time.Hour))
+	reg := artifact.NewStore(counted, store, artifact.WithPolicyCacheTTL(time.Hour))
 	putNamespace(t, store, "alpha", allowAllSpec())
 	seedDirect(t, counted.FakeRegistry, "alpha")
 	counted.resetSpecReads("alpha")

--- a/pkg/artifact/registry_test.go
+++ b/pkg/artifact/registry_test.go
@@ -21,11 +21,11 @@ import (
 	"github.com/yolocs/ocifactory/pkg/oci"
 )
 
-// Compile-time assertion: *ScopedNamespace satisfies handler.Registry
+// Compile-time assertion: *NamespaceView satisfies handler.Registry
 // so existing python/maven handlers can swap a *pkg/oci.Registry for
-// a *ScopedNamespace without any signature changes. Lives in the
+// a *NamespaceView without any signature changes. Lives in the
 // _test package to avoid pkg/namespace importing pkg/handler.
-var _ handler.Registry = (*artifact.ScopedNamespace)(nil)
+var _ handler.Registry = (*artifact.NamespaceView)(nil)
 
 const (
 	googleIss   = "https://accounts.google.com"
@@ -88,20 +88,20 @@ func newRepoFile(repo, tag, name string) *oci.RepoFile {
 	}
 }
 
-func TestScopedNamespace_AddRead_HappyPath(t *testing.T) {
+func TestNamespaceView_AddRead_HappyPath(t *testing.T) {
 	t.Parallel()
 
 	fake, reg, store := setup(t)
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
-	scoped := reg.For("alpha")
+	view := reg.View("alpha")
 
-	if scoped.Namespace() != "alpha" {
-		t.Errorf("Namespace() = %q, want %q", scoped.Namespace(), "alpha")
+	if view.Namespace() != "alpha" {
+		t.Errorf("Namespace() = %q, want %q", view.Namespace(), "alpha")
 	}
 
 	body := strings.NewReader(defaultBody)
-	if _, err := scoped.AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"), body); err != nil {
+	if _, err := view.AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"), body); err != nil {
 		t.Fatalf("AddFile: %v", err)
 	}
 
@@ -110,7 +110,7 @@ func TestScopedNamespace_AddRead_HappyPath(t *testing.T) {
 			repoFoo, slicesSortedKeys(fake.Files))
 	}
 
-	_, rc, err := scoped.ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"))
+	_, rc, err := view.ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"))
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
 	}
@@ -124,12 +124,12 @@ func TestScopedNamespace_AddRead_HappyPath(t *testing.T) {
 	}
 }
 
-// TestScopedNamespace_NamespaceIsolation pins the load-bearing
-// security guarantee: the beta scoped view cannot read a file
-// written through the alpha scoped view, AND alpha can still read
+// TestNamespaceView_NamespaceIsolation pins the load-bearing
+// security guarantee: the beta view view cannot read a file
+// written through the alpha view view, AND alpha can still read
 // its own file (so a regression that 5xx'd on every read wouldn't
 // pass for the wrong reason).
-func TestScopedNamespace_NamespaceIsolation(t *testing.T) {
+func TestNamespaceView_NamespaceIsolation(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
@@ -137,20 +137,20 @@ func TestScopedNamespace_NamespaceIsolation(t *testing.T) {
 	putNamespace(t, store, "beta", allowAllSpec())
 	ctx := aliceCtx(t)
 
-	if _, err := reg.For("alpha").AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"), strings.NewReader(defaultBody)); err != nil {
+	if _, err := reg.View("alpha").AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"), strings.NewReader(defaultBody)); err != nil {
 		t.Fatalf("AddFile alpha: %v", err)
 	}
 
 	// Alpha must still see its own file (rules out a generic-error
 	// regression).
-	if _, rc, err := reg.For("alpha").ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt")); err != nil {
+	if _, rc, err := reg.View("alpha").ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt")); err != nil {
 		t.Errorf("ReadFile alpha (own file): %v, want success", err)
 	} else {
 		rc.Close()
 	}
 
 	// Beta must not — and the failure mode must be ErrNotFound.
-	_, _, err := reg.For("beta").ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"))
+	_, _, err := reg.View("beta").ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"))
 	if err == nil {
 		t.Fatal("ReadFile beta = nil, want not-found error (namespaces must isolate)")
 	}
@@ -159,10 +159,10 @@ func TestScopedNamespace_NamespaceIsolation(t *testing.T) {
 	}
 }
 
-// TestScopedNamespace_NamespaceEscape is the explicit anti-vuln
-// test: the alpha scoped view cannot reach beta by passing
+// TestNamespaceView_NamespaceEscape is the explicit anti-vuln
+// test: the alpha view view cannot reach beta by passing
 // OwningRepo="../beta/foo" etc.
-func TestScopedNamespace_NamespaceEscape(t *testing.T) {
+func TestNamespaceView_NamespaceEscape(t *testing.T) {
 	t.Parallel()
 
 	fake, reg, store := setup(t)
@@ -192,7 +192,7 @@ func TestScopedNamespace_NamespaceEscape(t *testing.T) {
 	for _, esc := range escapes {
 		t.Run("escape="+esc, func(t *testing.T) {
 			t.Parallel()
-			_, _, err := reg.For("alpha").ReadFile(ctx, newRepoFile(esc, "1.0.0", "secret.txt"))
+			_, _, err := reg.View("alpha").ReadFile(ctx, newRepoFile(esc, "1.0.0", "secret.txt"))
 			if err == nil {
 				t.Fatalf("ReadFile owningRepo=%q = nil, want ErrInvalidOwningRepo (namespace escape!)", esc)
 			}
@@ -203,18 +203,18 @@ func TestScopedNamespace_NamespaceEscape(t *testing.T) {
 	}
 }
 
-// TestScopedNamespace_RejectsReservedIndexSuffix proves the wrapper
+// TestNamespaceView_RejectsReservedIndexSuffix proves the wrapper
 // refuses to route a user-supplied owning-repo into the per-namespace
 // package-index repo. Without this check a maven-style handler that
 // builds OwningRepo from URL path segments could plant tags in the
 // wrapper's own sentinel repo.
-func TestScopedNamespace_RejectsReservedIndexSuffix(t *testing.T) {
+func TestNamespaceView_RejectsReservedIndexSuffix(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
-	scoped := reg.For("alpha")
+	view := reg.View("alpha")
 
 	tests := []struct {
 		name       string
@@ -226,7 +226,7 @@ func TestScopedNamespace_RejectsReservedIndexSuffix(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := scoped.AddFile(ctx, newRepoFile(tc.owningRepo, "1.0.0", "f.txt"), strings.NewReader(defaultBody))
+			_, err := view.AddFile(ctx, newRepoFile(tc.owningRepo, "1.0.0", "f.txt"), strings.NewReader(defaultBody))
 			if err == nil {
 				t.Fatalf("AddFile owningRepo=%q = nil, want ErrInvalidOwningRepo", tc.owningRepo)
 			}
@@ -237,12 +237,12 @@ func TestScopedNamespace_RejectsReservedIndexSuffix(t *testing.T) {
 	}
 }
 
-func TestScopedNamespace_NamespaceNotFound(t *testing.T) {
+func TestNamespaceView_NamespaceNotFound(t *testing.T) {
 	t.Parallel()
 
 	_, reg, _ := setup(t)
 	ctx := aliceCtx(t)
-	scoped := reg.For("ghost")
+	view := reg.View("ghost")
 
 	tests := []struct {
 		name string
@@ -251,55 +251,55 @@ func TestScopedNamespace_NamespaceNotFound(t *testing.T) {
 		{
 			name: "AddFile",
 			call: func() error {
-				_, err := scoped.AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"), strings.NewReader(defaultBody))
+				_, err := view.AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"), strings.NewReader(defaultBody))
 				return err
 			},
 		},
 		{
 			name: "ReadFile",
 			call: func() error {
-				_, _, err := scoped.ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"))
+				_, _, err := view.ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"))
 				return err
 			},
 		},
 		{
 			name: "BlobRedirectURL",
 			call: func() error {
-				_, err := scoped.BlobRedirectURL(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"))
+				_, err := view.BlobRedirectURL(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"))
 				return err
 			},
 		},
 		{
 			name: "ListTags",
 			call: func() error {
-				_, err := scoped.ListTags(ctx, repoFoo)
+				_, err := view.ListTags(ctx, repoFoo)
 				return err
 			},
 		},
 		{
 			name: "ListFiles",
 			call: func() error {
-				_, err := scoped.ListFiles(ctx, repoFoo)
+				_, err := view.ListFiles(ctx, repoFoo)
 				return err
 			},
 		},
 		{
 			name: "ListPackages",
 			call: func() error {
-				_, err := scoped.ListPackages(ctx)
+				_, err := view.ListPackages(ctx)
 				return err
 			},
 		},
 		{
 			name: "AppendRefs",
 			call: func() error {
-				return scoped.AppendRefs(ctx, repoFoo, "1.0.0", "latest")
+				return view.AppendRefs(ctx, repoFoo, "1.0.0", "latest")
 			},
 		},
 		{
 			name: "DeleteRepoFiles",
 			call: func() error {
-				return scoped.DeleteRepoFiles(ctx, repoFoo)
+				return view.DeleteRepoFiles(ctx, repoFoo)
 			},
 		},
 	}
@@ -318,26 +318,26 @@ func TestScopedNamespace_NamespaceNotFound(t *testing.T) {
 	}
 }
 
-func TestScopedNamespace_NilFile(t *testing.T) {
+func TestNamespaceView_NilFile(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
-	scoped := reg.For("alpha")
+	view := reg.View("alpha")
 
-	if _, err := scoped.AddFile(ctx, nil, strings.NewReader("")); err == nil {
+	if _, err := view.AddFile(ctx, nil, strings.NewReader("")); err == nil {
 		t.Error("AddFile(nil) = nil, want error")
 	}
-	if _, _, err := scoped.ReadFile(ctx, nil); err == nil {
+	if _, _, err := view.ReadFile(ctx, nil); err == nil {
 		t.Error("ReadFile(nil) = nil, want error")
 	}
-	if _, err := scoped.BlobRedirectURL(ctx, nil); err == nil {
+	if _, err := view.BlobRedirectURL(ctx, nil); err == nil {
 		t.Error("BlobRedirectURL(nil) = nil, want error")
 	}
 }
 
-func TestScopedNamespace_Authz(t *testing.T) {
+func TestNamespaceView_Authz(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -418,14 +418,14 @@ func TestScopedNamespace_Authz(t *testing.T) {
 			}
 
 			ctx := auth.WithAuthContext(t.Context(), tc.ac)
-			scoped := reg.For("alpha")
+			view := reg.View("alpha")
 
 			var got error
 			switch tc.op {
 			case auth.OpWrite:
-				_, got = scoped.AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"), strings.NewReader(defaultBody))
+				_, got = view.AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"), strings.NewReader(defaultBody))
 			case auth.OpRead:
-				_, _, got = scoped.ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"))
+				_, _, got = view.ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"))
 			}
 
 			if tc.wantAllow {
@@ -458,13 +458,13 @@ func seedDirect(t *testing.T, fake *oci.FakeRegistry, ns string) {
 	}
 }
 
-func TestScopedNamespace_NoAuthContextDenied(t *testing.T) {
+func TestNamespaceView_NoAuthContextDenied(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
 	putNamespace(t, store, "alpha", allowAllSpec())
 
-	_, _, err := reg.For("alpha").ReadFile(t.Context(), newRepoFile(repoFoo, "1.0.0", "foo.txt"))
+	_, _, err := reg.View("alpha").ReadFile(t.Context(), newRepoFile(repoFoo, "1.0.0", "foo.txt"))
 	if err == nil {
 		t.Fatal("ReadFile with no AuthContext = nil, want error wrapping auth.ErrUnauthorized")
 	}
@@ -473,9 +473,9 @@ func TestScopedNamespace_NoAuthContextDenied(t *testing.T) {
 	}
 }
 
-// TestScopedNamespace_NoAuthContextDeniedAtWrapper proves the wrapper
+// TestNamespaceView_NoAuthContextDeniedAtWrapper proves the wrapper
 // itself denies nil even when the AuthzFactory would have allowed.
-func TestScopedNamespace_NoAuthContextDeniedAtWrapper(t *testing.T) {
+func TestNamespaceView_NoAuthContextDeniedAtWrapper(t *testing.T) {
 	t.Parallel()
 
 	fake := oci.NewFakeRegistry()
@@ -486,17 +486,17 @@ func TestScopedNamespace_NoAuthContextDeniedAtWrapper(t *testing.T) {
 	)
 	putNamespace(t, store, "alpha", allowAllSpec())
 
-	_, _, err := reg.For("alpha").ReadFile(t.Context(), newRepoFile(repoFoo, "1.0.0", "foo.txt"))
+	_, _, err := reg.View("alpha").ReadFile(t.Context(), newRepoFile(repoFoo, "1.0.0", "foo.txt"))
 	if !errors.Is(err, auth.ErrUnauthorized) {
 		t.Errorf("ReadFile (AllowAll factory + nil ctx) err = %v, want errors.Is(auth.ErrUnauthorized)", err)
 	}
 }
 
-// TestScopedNamespace_PackageIndex_PopulatedExactlyOnce uses a
+// TestNamespaceView_PackageIndex_PopulatedExactlyOnce uses a
 // counting backend to prove the wrapper makes exactly one
 // index-repo AddFile call across N data writes to the same
 // (ns, owning-repo).
-func TestScopedNamespace_PackageIndex_PopulatedExactlyOnce(t *testing.T) {
+func TestNamespaceView_PackageIndex_PopulatedExactlyOnce(t *testing.T) {
 	t.Parallel()
 
 	counted := newCountingBackend()
@@ -504,11 +504,11 @@ func TestScopedNamespace_PackageIndex_PopulatedExactlyOnce(t *testing.T) {
 	reg := artifact.NewStore(counted, store, artifact.WithPolicyCacheTTL(0))
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
-	scoped := reg.For("alpha")
+	view := reg.View("alpha")
 
 	for i := 0; i < 5; i++ {
 		tag := fmt.Sprintf("1.0.%d", i)
-		if _, err := scoped.AddFile(ctx, newRepoFile(repoFoo, tag, "f.txt"), strings.NewReader(defaultBody)); err != nil {
+		if _, err := view.AddFile(ctx, newRepoFile(repoFoo, tag, "f.txt"), strings.NewReader(defaultBody)); err != nil {
 			t.Fatalf("AddFile %s: %v", tag, err)
 		}
 	}
@@ -518,21 +518,21 @@ func TestScopedNamespace_PackageIndex_PopulatedExactlyOnce(t *testing.T) {
 	}
 }
 
-func TestScopedNamespace_PackageIndex_MultipleRepos(t *testing.T) {
+func TestNamespaceView_PackageIndex_MultipleRepos(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
-	scoped := reg.For("alpha")
+	view := reg.View("alpha")
 
 	for _, repo := range []string{repoFoo, repoBar, "tools/cli"} {
-		if _, err := scoped.AddFile(ctx, newRepoFile(repo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+		if _, err := view.AddFile(ctx, newRepoFile(repo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
 			t.Fatalf("AddFile %s: %v", repo, err)
 		}
 	}
 
-	got, err := scoped.ListPackages(ctx)
+	got, err := view.ListPackages(ctx)
 	if err != nil {
 		t.Fatalf("ListPackages: %v", err)
 	}
@@ -543,10 +543,10 @@ func TestScopedNamespace_PackageIndex_MultipleRepos(t *testing.T) {
 	}
 }
 
-// TestScopedNamespace_PackageIndex_ConcurrentExactlyOneAddFile is
+// TestNamespaceView_PackageIndex_ConcurrentExactlyOneAddFile is
 // the concurrency stress: N goroutines hammering the same
 // (ns, owning-repo) must result in exactly ONE index-repo AddFile.
-func TestScopedNamespace_PackageIndex_ConcurrentExactlyOneAddFile(t *testing.T) {
+func TestNamespaceView_PackageIndex_ConcurrentExactlyOneAddFile(t *testing.T) {
 	t.Parallel()
 
 	counted := newCountingBackend()
@@ -554,7 +554,7 @@ func TestScopedNamespace_PackageIndex_ConcurrentExactlyOneAddFile(t *testing.T) 
 	reg := artifact.NewStore(counted, store, artifact.WithPolicyCacheTTL(0))
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
-	scoped := reg.For("alpha")
+	view := reg.View("alpha")
 
 	const n = 16
 	var wg sync.WaitGroup
@@ -564,7 +564,7 @@ func TestScopedNamespace_PackageIndex_ConcurrentExactlyOneAddFile(t *testing.T) 
 		go func(i int) {
 			defer wg.Done()
 			tag := fmt.Sprintf("v%d", i)
-			if _, err := scoped.AddFile(ctx, newRepoFile(repoFoo, tag, "f.txt"), strings.NewReader(defaultBody)); err != nil {
+			if _, err := view.AddFile(ctx, newRepoFile(repoFoo, tag, "f.txt"), strings.NewReader(defaultBody)); err != nil {
 				errs <- err
 			}
 		}(i)
@@ -578,7 +578,7 @@ func TestScopedNamespace_PackageIndex_ConcurrentExactlyOneAddFile(t *testing.T) 
 	if got := counted.indexAddCount("alpha"); got != 1 {
 		t.Errorf("index AddFile count = %d across %d concurrent writes, want 1", got, n)
 	}
-	pkgs, err := scoped.ListPackages(ctx)
+	pkgs, err := view.ListPackages(ctx)
 	if err != nil {
 		t.Fatalf("ListPackages: %v", err)
 	}
@@ -587,7 +587,7 @@ func TestScopedNamespace_PackageIndex_ConcurrentExactlyOneAddFile(t *testing.T) 
 	}
 }
 
-func TestScopedNamespace_PackageIndex_Isolated(t *testing.T) {
+func TestNamespaceView_PackageIndex_Isolated(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
@@ -595,11 +595,11 @@ func TestScopedNamespace_PackageIndex_Isolated(t *testing.T) {
 	putNamespace(t, store, "beta", allowAllSpec())
 	ctx := aliceCtx(t)
 
-	if _, err := reg.For("alpha").AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+	if _, err := reg.View("alpha").AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
 		t.Fatalf("AddFile alpha: %v", err)
 	}
 
-	betaPkgs, err := reg.For("beta").ListPackages(ctx)
+	betaPkgs, err := reg.View("beta").ListPackages(ctx)
 	if err != nil {
 		t.Fatalf("ListPackages beta: %v", err)
 	}
@@ -608,13 +608,13 @@ func TestScopedNamespace_PackageIndex_Isolated(t *testing.T) {
 	}
 }
 
-func TestScopedNamespace_Index_RoundTrip(t *testing.T) {
+func TestNamespaceView_Index_RoundTrip(t *testing.T) {
 	t.Parallel()
 
 	fake, reg, store := setup(t)
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
-	idx := reg.For("alpha").Index("python-packages")
+	idx := reg.View("alpha").Index("python-packages")
 
 	keys := []string{"requests", "foo_bar", "@scope/pkg"}
 	for _, key := range keys {
@@ -659,7 +659,7 @@ func TestScopedNamespace_Index_RoundTrip(t *testing.T) {
 	}
 }
 
-func TestScopedNamespace_Index_RejectsInvalidName(t *testing.T) {
+func TestNamespaceView_Index_RejectsInvalidName(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
@@ -669,7 +669,7 @@ func TestScopedNamespace_Index_RejectsInvalidName(t *testing.T) {
 	for _, name := range []string{"", "packages/foo", "../x", "ocifactory-packages", "prod-", "prod..east"} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			err := reg.For("alpha").Index(name).Mark(ctx, "key")
+			err := reg.View("alpha").Index(name).Mark(ctx, "key")
 			if err == nil {
 				t.Fatalf("Index(%q).Mark = nil, want error", name)
 			}
@@ -680,16 +680,16 @@ func TestScopedNamespace_Index_RejectsInvalidName(t *testing.T) {
 	}
 }
 
-// TestScopedNamespace_TagEncoding_RoundTrip pins the encoding
+// TestNamespaceView_TagEncoding_RoundTrip pins the encoding
 // properties: collision-free between names that differ only in '/'
 // vs '_'.
-func TestScopedNamespace_TagEncoding_RoundTrip(t *testing.T) {
+func TestNamespaceView_TagEncoding_RoundTrip(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
-	scoped := reg.For("alpha")
+	view := reg.View("alpha")
 
 	repos := []string{
 		"packages/requests",
@@ -700,12 +700,12 @@ func TestScopedNamespace_TagEncoding_RoundTrip(t *testing.T) {
 		"x.y.z",
 	}
 	for _, r := range repos {
-		if _, err := scoped.AddFile(ctx, newRepoFile(r, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+		if _, err := view.AddFile(ctx, newRepoFile(r, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
 			t.Fatalf("AddFile %s: %v", r, err)
 		}
 	}
 
-	got, err := scoped.ListPackages(ctx)
+	got, err := view.ListPackages(ctx)
 	if err != nil {
 		t.Fatalf("ListPackages: %v", err)
 	}
@@ -717,14 +717,14 @@ func TestScopedNamespace_TagEncoding_RoundTrip(t *testing.T) {
 	}
 }
 
-func TestScopedNamespace_ListPackages_EmptyOnUntouchedNamespace(t *testing.T) {
+func TestNamespaceView_ListPackages_EmptyOnUntouchedNamespace(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
 
-	got, err := reg.For("alpha").ListPackages(ctx)
+	got, err := reg.View("alpha").ListPackages(ctx)
 	if err != nil {
 		t.Fatalf("ListPackages: %v", err)
 	}
@@ -733,21 +733,21 @@ func TestScopedNamespace_ListPackages_EmptyOnUntouchedNamespace(t *testing.T) {
 	}
 }
 
-func TestScopedNamespace_ListTags_AndListFiles(t *testing.T) {
+func TestNamespaceView_ListTags_AndListFiles(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
-	scoped := reg.For("alpha")
+	view := reg.View("alpha")
 
 	for _, tag := range []string{"1.0.0", "2.0.0"} {
-		if _, err := scoped.AddFile(ctx, newRepoFile(repoFoo, tag, "f.txt"), strings.NewReader(defaultBody)); err != nil {
+		if _, err := view.AddFile(ctx, newRepoFile(repoFoo, tag, "f.txt"), strings.NewReader(defaultBody)); err != nil {
 			t.Fatalf("AddFile %s: %v", tag, err)
 		}
 	}
 
-	tags, err := scoped.ListTags(ctx, repoFoo)
+	tags, err := view.ListTags(ctx, repoFoo)
 	if err != nil {
 		t.Fatalf("ListTags: %v", err)
 	}
@@ -756,7 +756,7 @@ func TestScopedNamespace_ListTags_AndListFiles(t *testing.T) {
 		t.Errorf("ListTags mismatch (-want +got):\n%s", diff)
 	}
 
-	files, err := scoped.ListFiles(ctx, repoFoo)
+	files, err := view.ListFiles(ctx, repoFoo)
 	if err != nil {
 		t.Fatalf("ListFiles: %v", err)
 	}
@@ -770,19 +770,19 @@ func TestScopedNamespace_ListTags_AndListFiles(t *testing.T) {
 	}
 }
 
-func TestScopedNamespace_ListFiles_MultiSegmentRepo(t *testing.T) {
+func TestNamespaceView_ListFiles_MultiSegmentRepo(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
-	scoped := reg.For("alpha")
+	view := reg.View("alpha")
 
 	repo := "com/example/foo-bar"
-	if _, err := scoped.AddFile(ctx, newRepoFile(repo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+	if _, err := view.AddFile(ctx, newRepoFile(repo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
 		t.Fatalf("AddFile: %v", err)
 	}
-	files, err := scoped.ListFiles(ctx, repo)
+	files, err := view.ListFiles(ctx, repo)
 	if err != nil {
 		t.Fatalf("ListFiles: %v", err)
 	}
@@ -791,9 +791,9 @@ func TestScopedNamespace_ListFiles_MultiSegmentRepo(t *testing.T) {
 	}
 }
 
-// TestScopedNamespace_ListFiles_PrefixOfAnotherNamespace pins that
+// TestNamespaceView_ListFiles_PrefixOfAnotherNamespace pins that
 // "alpha" doesn't accidentally strip from "alpha-foo" repos.
-func TestScopedNamespace_ListFiles_PrefixOfAnotherNamespace(t *testing.T) {
+func TestNamespaceView_ListFiles_PrefixOfAnotherNamespace(t *testing.T) {
 	t.Parallel()
 
 	fake, reg, store := setup(t)
@@ -809,7 +809,7 @@ func TestScopedNamespace_ListFiles_PrefixOfAnotherNamespace(t *testing.T) {
 		t.Fatalf("seed: %v", err)
 	}
 
-	files, err := reg.For("alpha").ListFiles(ctx, repoFoo)
+	files, err := reg.View("alpha").ListFiles(ctx, repoFoo)
 	if err != nil {
 		t.Fatalf("ListFiles: %v", err)
 	}
@@ -818,18 +818,18 @@ func TestScopedNamespace_ListFiles_PrefixOfAnotherNamespace(t *testing.T) {
 	}
 }
 
-func TestScopedNamespace_AppendRefs_Forwards(t *testing.T) {
+func TestNamespaceView_AppendRefs_Forwards(t *testing.T) {
 	t.Parallel()
 
 	fake, reg, store := setup(t)
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
-	scoped := reg.For("alpha")
+	view := reg.View("alpha")
 
-	if _, err := scoped.AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+	if _, err := view.AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
 		t.Fatalf("AddFile: %v", err)
 	}
-	if err := scoped.AppendRefs(ctx, repoFoo, "1.0.0", "latest"); err != nil {
+	if err := view.AppendRefs(ctx, repoFoo, "1.0.0", "latest"); err != nil {
 		t.Fatalf("AppendRefs: %v", err)
 	}
 	if got, ok := fake.Aliases["alpha/"+repoFoo+"/latest"]; !ok || got != "1.0.0" {
@@ -837,18 +837,18 @@ func TestScopedNamespace_AppendRefs_Forwards(t *testing.T) {
 	}
 }
 
-func TestScopedNamespace_ResolveTag(t *testing.T) {
+func TestNamespaceView_ResolveTag(t *testing.T) {
 	t.Parallel()
 
 	_, reg, store := setup(t)
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
-	scoped := reg.For("alpha")
+	view := reg.View("alpha")
 
-	if _, err := scoped.AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+	if _, err := view.AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
 		t.Fatalf("AddFile: %v", err)
 	}
-	if err := scoped.AppendRefs(ctx, repoFoo, "1.0.0", "latest"); err != nil {
+	if err := view.AppendRefs(ctx, repoFoo, "1.0.0", "latest"); err != nil {
 		t.Fatalf("AppendRefs: %v", err)
 	}
 
@@ -864,7 +864,7 @@ func TestScopedNamespace_ResolveTag(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := scoped.ResolveTag(ctx, repoFoo, tc.tag)
+			got, err := view.ResolveTag(ctx, repoFoo, tc.tag)
 			if err != nil {
 				t.Fatalf("ResolveTag: %v", err)
 			}
@@ -875,21 +875,21 @@ func TestScopedNamespace_ResolveTag(t *testing.T) {
 	}
 }
 
-// TestScopedNamespace_DeleteRepoFiles_SweepsBackendIndex verifies
+// TestNamespaceView_DeleteRepoFiles_SweepsBackendIndex verifies
 // BOTH the in-process indexed marker AND the backend
 // ocifactory-packages tag are cleared.
-func TestScopedNamespace_DeleteRepoFiles_SweepsBackendIndex(t *testing.T) {
+func TestNamespaceView_DeleteRepoFiles_SweepsBackendIndex(t *testing.T) {
 	t.Parallel()
 
 	fake, reg, store := setup(t)
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
-	scoped := reg.For("alpha")
+	view := reg.View("alpha")
 
-	if _, err := scoped.AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+	if _, err := view.AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
 		t.Fatalf("AddFile: %v", err)
 	}
-	pkgs, err := scoped.ListPackages(ctx)
+	pkgs, err := view.ListPackages(ctx)
 	if err != nil {
 		t.Fatalf("ListPackages pre: %v", err)
 	}
@@ -897,7 +897,7 @@ func TestScopedNamespace_DeleteRepoFiles_SweepsBackendIndex(t *testing.T) {
 		t.Fatalf("ListPackages pre = %v, want to contain %q", pkgs, repoFoo)
 	}
 
-	if err := scoped.DeleteRepoFiles(ctx, repoFoo); err != nil {
+	if err := view.DeleteRepoFiles(ctx, repoFoo); err != nil {
 		t.Fatalf("DeleteRepoFiles: %v", err)
 	}
 	for k := range fake.Files {
@@ -905,7 +905,7 @@ func TestScopedNamespace_DeleteRepoFiles_SweepsBackendIndex(t *testing.T) {
 			t.Errorf("file %q remained after DeleteRepoFiles", k)
 		}
 	}
-	pkgs, err = scoped.ListPackages(ctx)
+	pkgs, err = view.ListPackages(ctx)
 	if err != nil {
 		t.Fatalf("ListPackages post: %v", err)
 	}
@@ -913,10 +913,10 @@ func TestScopedNamespace_DeleteRepoFiles_SweepsBackendIndex(t *testing.T) {
 		t.Errorf("ListPackages post = %v, want NOT to contain %q (backend index must be swept)", pkgs, repoFoo)
 	}
 
-	if _, err := scoped.AddFile(ctx, newRepoFile(repoFoo, "2.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+	if _, err := view.AddFile(ctx, newRepoFile(repoFoo, "2.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
 		t.Fatalf("AddFile after delete: %v", err)
 	}
-	pkgs, err = scoped.ListPackages(ctx)
+	pkgs, err = view.ListPackages(ctx)
 	if err != nil {
 		t.Fatalf("ListPackages re-add: %v", err)
 	}
@@ -938,9 +938,9 @@ func TestRegistry_PolicyCache_HotPathSkipsStore(t *testing.T) {
 
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
-	scoped := reg.For("alpha")
+	view := reg.View("alpha")
 
-	if _, err := scoped.AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+	if _, err := view.AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
 		t.Fatalf("AddFile: %v", err)
 	}
 	priming := counted.specReads("alpha")
@@ -950,7 +950,7 @@ func TestRegistry_PolicyCache_HotPathSkipsStore(t *testing.T) {
 
 	const iters = 50
 	for i := 0; i < iters; i++ {
-		_, _, err := scoped.ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"))
+		_, _, err := view.ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"))
 		if err != nil {
 			t.Fatalf("ReadFile %d: %v", i, err)
 		}
@@ -970,16 +970,16 @@ func TestRegistry_PolicyCache_TTLZero_DisablesCache(t *testing.T) {
 
 	putNamespace(t, store, "alpha", allowAllSpec())
 	ctx := aliceCtx(t)
-	scoped := reg.For("alpha")
+	view := reg.View("alpha")
 
-	if _, err := scoped.AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+	if _, err := view.AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
 		t.Fatalf("AddFile: %v", err)
 	}
 
 	before := counted.specReads("alpha")
 	const iters = 5
 	for i := 0; i < iters; i++ {
-		_, _, err := scoped.ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"))
+		_, _, err := view.ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"))
 		if err != nil {
 			t.Fatalf("ReadFile: %v", err)
 		}
@@ -1001,7 +1001,7 @@ func TestRegistry_PolicyCache_NegativeCaching(t *testing.T) {
 
 	const iters = 10
 	for i := 0; i < iters; i++ {
-		_, _, err := reg.For("ghost").ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"))
+		_, _, err := reg.View("ghost").ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"))
 		if !errors.Is(err, namespace.ErrNotFound) {
 			t.Fatalf("ReadFile(ghost) %d err = %v, want errors.Is(ErrNotFound)", i, err)
 		}
@@ -1011,7 +1011,7 @@ func TestRegistry_PolicyCache_NegativeCaching(t *testing.T) {
 	}
 
 	reg.InvalidatePolicy("ghost")
-	if _, _, err := reg.For("ghost").ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt")); !errors.Is(err, namespace.ErrNotFound) {
+	if _, _, err := reg.View("ghost").ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt")); !errors.Is(err, namespace.ErrNotFound) {
 		t.Fatalf("post-invalidate ReadFile = %v, want errors.Is(ErrNotFound)", err)
 	}
 	if got := counted.specReads("ghost"); got != 2 {
@@ -1034,12 +1034,12 @@ func TestRegistry_StorePut_InvalidatesCache(t *testing.T) {
 		Readers: []namespace.SubjectMatcher{{Email: otherEmail}},
 	}})
 	seedDirect(t, counted.FakeRegistry, "alpha")
-	if _, _, err := reg.For("alpha").ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt")); !errors.Is(err, auth.ErrUnauthorized) {
+	if _, _, err := reg.View("alpha").ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt")); !errors.Is(err, auth.ErrUnauthorized) {
 		t.Fatalf("pre-update ReadFile = %v, want errors.Is(auth.ErrUnauthorized)", err)
 	}
 
 	putNamespace(t, store, "alpha", allowAllSpec())
-	if _, _, err := reg.For("alpha").ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt")); err != nil {
+	if _, _, err := reg.View("alpha").ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt")); err != nil {
 		t.Errorf("post-update ReadFile = %v, want success (Store.Put must invalidate cache)", err)
 	}
 }
@@ -1069,7 +1069,7 @@ func TestRegistry_PolicyCache_Singleflight(t *testing.T) {
 	for i := 0; i < n; i++ {
 		go func() {
 			defer wg.Done()
-			_, _, _ = reg.For("alpha").ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"))
+			_, _, _ = reg.View("alpha").ReadFile(ctx, newRepoFile(repoFoo, "1.0.0", "foo.txt"))
 		}()
 	}
 	time.Sleep(50 * time.Millisecond)

--- a/pkg/artifact/store.go
+++ b/pkg/artifact/store.go
@@ -1,0 +1,251 @@
+package artifact
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/yolocs/ocifactory/pkg/namespace"
+	"github.com/yolocs/ocifactory/pkg/oci"
+)
+
+// Store adapts the namespace registry into the artifact noun API.
+type Store struct {
+	registry *namespace.Registry
+}
+
+// NewStore returns an artifact store backed by registry.
+func NewStore(registry *namespace.Registry) *Store {
+	return &Store{registry: registry}
+}
+
+// Namespace returns a namespace-scoped artifact view after validating
+// that the namespace metadata exists.
+func (s *Store) Namespace(ctx context.Context, name string) (Namespace, error) {
+	if s == nil || s.registry == nil {
+		return nil, errors.New("artifact store registry must not be nil")
+	}
+	scoped := s.registry.For(name)
+	if _, err := scoped.Spec(ctx); err != nil {
+		return nil, err
+	}
+	return artifactNamespace{scoped: scoped}, nil
+}
+
+type artifactNamespace struct {
+	scoped *namespace.ScopedRegistry
+}
+
+func (n artifactNamespace) Name() string {
+	return n.scoped.Namespace()
+}
+
+func (n artifactNamespace) Spec(ctx context.Context) (*namespace.Spec, error) {
+	return n.scoped.Spec(ctx)
+}
+
+func (n artifactNamespace) Package(name string) Package {
+	return artifactPackage{scoped: n.scoped, name: name}
+}
+
+func (n artifactNamespace) ListPackages(ctx context.Context) ([]string, error) {
+	return n.scoped.ListPackages(ctx)
+}
+
+type artifactPackage struct {
+	scoped *namespace.ScopedRegistry
+	name   string
+}
+
+func (p artifactPackage) Name() string {
+	return p.name
+}
+
+func (p artifactPackage) PutFile(ctx context.Context, version string, file FilePut, body io.Reader) (*FileDescriptor, error) {
+	return p.putFile(ctx, version, file, body, false)
+}
+
+func (p artifactPackage) PutCachedFile(ctx context.Context, version string, file FilePut, body io.Reader) (*FileDescriptor, error) {
+	return p.putFile(ctx, version, file, body, true)
+}
+
+func (p artifactPackage) putFile(ctx context.Context, version string, file FilePut, body io.Reader, cached bool) (*FileDescriptor, error) {
+	rf, err := p.repoFile(version, "", file.Name)
+	if err != nil {
+		return nil, err
+	}
+	rf.MediaType = file.MediaType
+	rf.Digest = file.Digest
+	rf.Size = file.Size
+	rf.AllowOverwrite = file.AllowOverwrite
+	if cached {
+		return p.scoped.AddCachedFile(ctx, rf, body)
+	}
+	return p.scoped.AddFile(ctx, rf, body)
+}
+
+func (p artifactPackage) GetFile(_ context.Context, version, name string) (FileHandle, error) {
+	rf, err := p.repoFile(version, "", name)
+	if err != nil {
+		return nil, err
+	}
+	return &fileHandle{
+		scoped: p.scoped,
+		file:   rf,
+		info: FileInfo{
+			Package: p.name,
+			Version: version,
+			Name:    name,
+		},
+	}, nil
+}
+
+func (p artifactPackage) GetFileByTag(_ context.Context, tag, name string) (FileHandle, error) {
+	rf, err := p.repoFile("", tag, name)
+	if err != nil {
+		return nil, err
+	}
+	return &fileHandle{
+		scoped: p.scoped,
+		file:   rf,
+		info: FileInfo{
+			Package: p.name,
+			Name:    name,
+		},
+	}, nil
+}
+
+func (p artifactPackage) ListVersions(ctx context.Context) ([]string, error) {
+	files, err := p.ListFiles(ctx, ListFilesOptions{})
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]struct{}{}
+	for _, file := range files {
+		if file.Version == "" {
+			continue
+		}
+		seen[file.Version] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for version := range seen {
+		out = append(out, version)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func (p artifactPackage) ListTags(ctx context.Context) ([]Tag, error) {
+	allTags, err := p.scoped.ListTags(ctx, p.name)
+	if err != nil {
+		return nil, err
+	}
+	versions, err := p.ListVersions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	versionSet := make(map[string]struct{}, len(versions))
+	for _, version := range versions {
+		versionSet[version] = struct{}{}
+	}
+	out := make([]Tag, 0, len(allTags))
+	for _, tag := range allTags {
+		if _, isVersion := versionSet[tag]; isVersion {
+			continue
+		}
+		out = append(out, Tag{Name: tag})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+func (p artifactPackage) ListFiles(ctx context.Context, opts ListFilesOptions) ([]FileInfo, error) {
+	files, err := p.scoped.ListFiles(ctx, p.name)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]FileInfo, 0, len(files))
+	for _, file := range files {
+		if opts.Version != "" && file.OwningTag != opts.Version {
+			continue
+		}
+		out = append(out, FileInfo{
+			Package: p.name,
+			Version: file.OwningTag,
+			Name:    file.Name,
+			Digest:  file.Digest,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Version != out[j].Version {
+			return out[i].Version < out[j].Version
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out, nil
+}
+
+func (p artifactPackage) Tag(ctx context.Context, tag, version string) error {
+	if tag == "" {
+		return errors.New("tag must not be empty")
+	}
+	return p.scoped.AppendRefs(ctx, p.name, version, tag)
+}
+
+func (p artifactPackage) repoFile(version, tag, name string) (*oci.RepoFile, error) {
+	if name == "" {
+		return nil, errors.New("file name must not be empty")
+	}
+	if version == "" && tag == "" {
+		return nil, errors.New("version or tag must not be empty")
+	}
+	if version != "" && tag != "" {
+		return nil, errors.New("version and tag are mutually exclusive")
+	}
+	return &oci.RepoFile{
+		OwningRepo: p.name,
+		OwningTag:  version,
+		RefTag:     tag,
+		Name:       name,
+	}, nil
+}
+
+type fileHandle struct {
+	scoped *namespace.ScopedRegistry
+	file   *oci.RepoFile
+	info   FileInfo
+}
+
+func (h *fileHandle) Info() FileInfo {
+	return h.info
+}
+
+func (h *fileHandle) DownloadURL(ctx context.Context) (string, error) {
+	if h == nil || h.file == nil {
+		return "", errors.New("file handle must not be nil")
+	}
+	return h.scoped.BlobRedirectURL(ctx, h.file)
+}
+
+func (h *fileHandle) Open(ctx context.Context) (io.ReadCloser, error) {
+	if h == nil || h.file == nil {
+		return nil, errors.New("file handle must not be nil")
+	}
+	desc, rc, err := h.scoped.ReadFile(ctx, h.file)
+	if err != nil {
+		return nil, err
+	}
+	h.info.Digest = desc.File.Digest.String()
+	h.info.Size = desc.File.Size
+	if h.file.OwningTag != "" {
+		h.info.Version = h.file.OwningTag
+	}
+	h.info.MediaType = desc.File.MediaType
+	return rc, nil
+}
+
+func (p artifactPackage) String() string {
+	return fmt.Sprintf("%s/%s", p.scoped.Namespace(), p.name)
+}

--- a/pkg/artifact/store.go
+++ b/pkg/artifact/store.go
@@ -12,28 +12,28 @@ import (
 )
 
 type artifactNamespace struct {
-	scoped *ScopedNamespace
+	view *NamespaceView
 }
 
 func (n artifactNamespace) Name() string {
-	return n.scoped.Namespace()
+	return n.view.Namespace()
 }
 
 func (n artifactNamespace) Spec(ctx context.Context) (*nsmeta.Spec, error) {
-	return n.scoped.Spec(ctx)
+	return n.view.Spec(ctx)
 }
 
 func (n artifactNamespace) Package(name string) Package {
-	return artifactPackage{scoped: n.scoped, name: name}
+	return artifactPackage{view: n.view, name: name}
 }
 
 func (n artifactNamespace) ListPackages(ctx context.Context) ([]string, error) {
-	return n.scoped.ListPackages(ctx)
+	return n.view.ListPackages(ctx)
 }
 
 type artifactPackage struct {
-	scoped *ScopedNamespace
-	name   string
+	view *NamespaceView
+	name string
 }
 
 func (p artifactPackage) Name() string {
@@ -58,9 +58,9 @@ func (p artifactPackage) putFile(ctx context.Context, version string, file FileP
 	rf.Size = file.Size
 	rf.AllowOverwrite = file.AllowOverwrite
 	if cached {
-		return p.scoped.AddCachedFile(ctx, rf, body)
+		return p.view.AddCachedFile(ctx, rf, body)
 	}
-	return p.scoped.AddFile(ctx, rf, body)
+	return p.view.AddFile(ctx, rf, body)
 }
 
 func (p artifactPackage) GetFile(_ context.Context, version, name string) (FileHandle, error) {
@@ -69,8 +69,8 @@ func (p artifactPackage) GetFile(_ context.Context, version, name string) (FileH
 		return nil, err
 	}
 	return &fileHandle{
-		scoped: p.scoped,
-		file:   rf,
+		view: p.view,
+		file: rf,
 		info: FileInfo{
 			Package: p.name,
 			Version: version,
@@ -85,8 +85,8 @@ func (p artifactPackage) GetFileByTag(_ context.Context, tag, name string) (File
 		return nil, err
 	}
 	return &fileHandle{
-		scoped: p.scoped,
-		file:   rf,
+		view: p.view,
+		file: rf,
 		info: FileInfo{
 			Package: p.name,
 			Name:    name,
@@ -115,7 +115,7 @@ func (p artifactPackage) ListVersions(ctx context.Context) ([]string, error) {
 }
 
 func (p artifactPackage) ListTags(ctx context.Context) ([]Tag, error) {
-	allTags, err := p.scoped.ListTags(ctx, p.name)
+	allTags, err := p.view.ListTags(ctx, p.name)
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +139,7 @@ func (p artifactPackage) ListTags(ctx context.Context) ([]Tag, error) {
 }
 
 func (p artifactPackage) ResolveTag(ctx context.Context, tag string) (Version, error) {
-	version, err := p.scoped.ResolveTag(ctx, p.name, tag)
+	version, err := p.view.ResolveTag(ctx, p.name, tag)
 	if err != nil {
 		return Version{}, err
 	}
@@ -147,7 +147,7 @@ func (p artifactPackage) ResolveTag(ctx context.Context, tag string) (Version, e
 }
 
 func (p artifactPackage) ListFiles(ctx context.Context, opts ListFilesOptions) ([]FileInfo, error) {
-	files, err := p.scoped.ListFiles(ctx, p.name)
+	files, err := p.view.ListFiles(ctx, p.name)
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +176,7 @@ func (p artifactPackage) Tag(ctx context.Context, tag, version string) error {
 	if tag == "" {
 		return errors.New("tag must not be empty")
 	}
-	return p.scoped.AppendRefs(ctx, p.name, version, tag)
+	return p.view.AppendRefs(ctx, p.name, version, tag)
 }
 
 func (p artifactPackage) repoFile(version, tag, name string) (*oci.RepoFile, error) {
@@ -198,9 +198,9 @@ func (p artifactPackage) repoFile(version, tag, name string) (*oci.RepoFile, err
 }
 
 type fileHandle struct {
-	scoped *ScopedNamespace
-	file   *oci.RepoFile
-	info   FileInfo
+	view *NamespaceView
+	file *oci.RepoFile
+	info FileInfo
 }
 
 func (h *fileHandle) Info() FileInfo {
@@ -211,14 +211,14 @@ func (h *fileHandle) DownloadURL(ctx context.Context) (string, error) {
 	if h == nil || h.file == nil {
 		return "", errors.New("file handle must not be nil")
 	}
-	return h.scoped.BlobRedirectURL(ctx, h.file)
+	return h.view.BlobRedirectURL(ctx, h.file)
 }
 
 func (h *fileHandle) Open(ctx context.Context) (io.ReadCloser, error) {
 	if h == nil || h.file == nil {
 		return nil, errors.New("file handle must not be nil")
 	}
-	desc, rc, err := h.scoped.ReadFile(ctx, h.file)
+	desc, rc, err := h.view.ReadFile(ctx, h.file)
 	if err != nil {
 		return nil, err
 	}
@@ -232,5 +232,5 @@ func (h *fileHandle) Open(ctx context.Context) (io.ReadCloser, error) {
 }
 
 func (p artifactPackage) String() string {
-	return fmt.Sprintf("%s/%s", p.scoped.Namespace(), p.name)
+	return fmt.Sprintf("%s/%s", p.view.Namespace(), p.name)
 }

--- a/pkg/artifact/store.go
+++ b/pkg/artifact/store.go
@@ -161,6 +161,14 @@ func (p artifactPackage) ListTags(ctx context.Context) ([]Tag, error) {
 	return out, nil
 }
 
+func (p artifactPackage) ResolveTag(ctx context.Context, tag string) (Version, error) {
+	version, err := p.scoped.ResolveTag(ctx, p.name, tag)
+	if err != nil {
+		return Version{}, err
+	}
+	return Version{Name: version}, nil
+}
+
 func (p artifactPackage) ListFiles(ctx context.Context, opts ListFilesOptions) ([]FileInfo, error) {
 	files, err := p.scoped.ListFiles(ctx, p.name)
 	if err != nil {

--- a/pkg/artifact/store.go
+++ b/pkg/artifact/store.go
@@ -7,42 +7,19 @@ import (
 	"io"
 	"sort"
 
-	"github.com/yolocs/ocifactory/pkg/namespace"
+	nsmeta "github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
 )
 
-// Store adapts the namespace registry into the artifact noun API.
-type Store struct {
-	registry *namespace.Registry
-}
-
-// NewStore returns an artifact store backed by registry.
-func NewStore(registry *namespace.Registry) *Store {
-	return &Store{registry: registry}
-}
-
-// Namespace returns a namespace-scoped artifact view after validating
-// that the namespace metadata exists.
-func (s *Store) Namespace(ctx context.Context, name string) (Namespace, error) {
-	if s == nil || s.registry == nil {
-		return nil, errors.New("artifact store registry must not be nil")
-	}
-	scoped := s.registry.For(name)
-	if _, err := scoped.Spec(ctx); err != nil {
-		return nil, err
-	}
-	return artifactNamespace{scoped: scoped}, nil
-}
-
 type artifactNamespace struct {
-	scoped *namespace.ScopedRegistry
+	scoped *ScopedNamespace
 }
 
 func (n artifactNamespace) Name() string {
 	return n.scoped.Namespace()
 }
 
-func (n artifactNamespace) Spec(ctx context.Context) (*namespace.Spec, error) {
+func (n artifactNamespace) Spec(ctx context.Context) (*nsmeta.Spec, error) {
 	return n.scoped.Spec(ctx)
 }
 
@@ -55,7 +32,7 @@ func (n artifactNamespace) ListPackages(ctx context.Context) ([]string, error) {
 }
 
 type artifactPackage struct {
-	scoped *namespace.ScopedRegistry
+	scoped *ScopedNamespace
 	name   string
 }
 
@@ -221,7 +198,7 @@ func (p artifactPackage) repoFile(version, tag, name string) (*oci.RepoFile, err
 }
 
 type fileHandle struct {
-	scoped *namespace.ScopedRegistry
+	scoped *ScopedNamespace
 	file   *oci.RepoFile
 	info   FileInfo
 }

--- a/pkg/commands/admin.go
+++ b/pkg/commands/admin.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"github.com/yolocs/ocifactory/pkg/artifact"
 	"github.com/yolocs/ocifactory/pkg/auth/backend"
 	"github.com/yolocs/ocifactory/pkg/handler"
 	adminhandler "github.com/yolocs/ocifactory/pkg/handler/admin"
@@ -151,11 +152,11 @@ func runAdminServe(ctx context.Context, cfg *adminServeConfig) error {
 	}
 	store := namespace.NewStore(reg, namespace.WithPrefix(cfg.NamespacePrefix))
 	// The admin service does not authorize data-plane requests, but
-	// namespace.Registry already owns the package-index decoding logic
+	// artifact.Store owns the package-index decoding logic
 	// needed for soft-delete emptiness checks. Keep it here only as a
 	// control-plane PackageLister.
-	nsReg := namespace.NewRegistry(reg, store)
-	ah, err := adminhandler.NewHandler(store, nsReg)
+	artifacts := artifact.NewStore(reg, store)
+	ah, err := adminhandler.NewHandler(store, artifacts)
 	if err != nil {
 		return fmt.Errorf("failed to create admin handler: %w", err)
 	}

--- a/pkg/commands/serve.go
+++ b/pkg/commands/serve.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"github.com/yolocs/ocifactory/pkg/artifact"
 	"github.com/yolocs/ocifactory/pkg/auth"
 	"github.com/yolocs/ocifactory/pkg/auth/backend"
 	"github.com/yolocs/ocifactory/pkg/auth/chain"
@@ -399,9 +400,9 @@ func runServe(ctx context.Context, cfg *serveConfig) error {
 		if err != nil {
 			return fmt.Errorf("failed to create namespace registry: %w", err)
 		}
-		nsReg := namespace.NewRegistry(r, namespace.NewStore(storeReg))
+		artifacts := artifact.NewStore(r, namespace.NewStore(storeReg))
 		negCache := indexcache.NewNegativeCache()
-		mh, err := maven.NewHandler(nsReg,
+		mh, err := maven.NewHandler(artifacts,
 			maven.WithAuthMiddleware(authMW),
 			maven.WithMaxUploadBytes(cfg.MavenMaxUploadBytes),
 			maven.WithProxyNegativeCache(negCache),
@@ -422,7 +423,7 @@ func runServe(ctx context.Context, cfg *serveConfig) error {
 		if err != nil {
 			return fmt.Errorf("failed to create namespace registry: %w", err)
 		}
-		nsReg := namespace.NewRegistry(r, namespace.NewStore(storeReg))
+		artifacts := artifact.NewStore(r, namespace.NewStore(storeReg))
 		idxCache, err := indexcache.NewCache(cfg.RegistryURL,
 			indexcache.WithBackendAuth(bp),
 			indexcache.WithRepoPrefix(cfg.RepoPrefix),
@@ -431,7 +432,7 @@ func runServe(ctx context.Context, cfg *serveConfig) error {
 			return fmt.Errorf("failed to create proxy index cache: %w", err)
 		}
 		negCache := indexcache.NewNegativeCache()
-		nh, err := npm.NewHandler(nsReg,
+		nh, err := npm.NewHandler(artifacts,
 			npm.WithMaxUploadBytes(cfg.NPMMaxUploadBytes),
 			npm.WithAuthMiddleware(authMW),
 			npm.WithProxyIndexCache(idxCache),
@@ -453,7 +454,7 @@ func runServe(ctx context.Context, cfg *serveConfig) error {
 		if err != nil {
 			return fmt.Errorf("failed to create namespace registry: %w", err)
 		}
-		nsReg := namespace.NewRegistry(r, namespace.NewStore(storeReg))
+		artifacts := artifact.NewStore(r, namespace.NewStore(storeReg))
 		// Proxy plumbing: shared across every namespace served by
 		// this process. Hosted-only deployments still construct
 		// these (cheap — no I/O on construction); a proxy namespace
@@ -467,7 +468,7 @@ func runServe(ctx context.Context, cfg *serveConfig) error {
 			return fmt.Errorf("failed to create proxy index cache: %w", err)
 		}
 		negCache := indexcache.NewNegativeCache()
-		ph, err := python.NewHandler(nsReg,
+		ph, err := python.NewHandler(artifacts,
 			python.WithSimpleIndexCacheTTL(cfg.SimpleIndexCacheTTL),
 			python.WithMaxUploadBytes(cfg.PythonMaxUploadBytes),
 			python.WithAuthMiddleware(authMW),

--- a/pkg/handler/admin/handler_test.go
+++ b/pkg/handler/admin/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/yolocs/ocifactory/pkg/artifact"
 	"github.com/yolocs/ocifactory/pkg/handler/admin"
 	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
@@ -243,8 +244,8 @@ func TestHandler_NamespaceCRUD(t *testing.T) {
 			t.Parallel()
 			reg := oci.NewFakeRegistry()
 			store := namespace.NewStore(reg)
-			nsReg := namespace.NewRegistry(reg, store)
-			h, err := admin.NewHandler(store, nsReg)
+			artifacts := artifact.NewStore(reg, store)
+			h, err := admin.NewHandler(store, artifacts)
 			if err != nil {
 				t.Fatalf("NewHandler: %v", err)
 			}
@@ -294,8 +295,8 @@ func TestHandler_PutStampsSchemaVersionOnDisk(t *testing.T) {
 
 	reg := oci.NewFakeRegistry()
 	store := namespace.NewStore(reg)
-	nsReg := namespace.NewRegistry(reg, store)
-	h, err := admin.NewHandler(store, nsReg)
+	artifacts := artifact.NewStore(reg, store)
+	h, err := admin.NewHandler(store, artifacts)
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)
 	}
@@ -330,7 +331,7 @@ func TestNewHandler_RequiresDependencies(t *testing.T) {
 
 	reg := oci.NewFakeRegistry()
 	store := namespace.NewStore(reg)
-	nsReg := namespace.NewRegistry(reg, store)
+	artifacts := artifact.NewStore(reg, store)
 
 	tests := []struct {
 		name      string
@@ -338,7 +339,7 @@ func TestNewHandler_RequiresDependencies(t *testing.T) {
 		packages  admin.PackageLister
 		wantError string
 	}{
-		{name: "missing store", packages: nsReg, wantError: "store is required"},
+		{name: "missing store", packages: artifacts, wantError: "store is required"},
 		{name: "missing package lister", store: store, wantError: "package lister is required"},
 	}
 

--- a/pkg/handler/maven/auth_test.go
+++ b/pkg/handler/maven/auth_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/yolocs/ocifactory/pkg/artifact"
 	"github.com/yolocs/ocifactory/pkg/auth"
 	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
@@ -25,7 +26,7 @@ func TestMux_AuthGating(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	h, err := NewHandler(reg, WithAuthMiddleware(denyAll))
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)
@@ -58,13 +59,13 @@ func TestMux_AuthGating(t *testing.T) {
 // TestMux_NoAuthMiddleware confirms that omitting WithAuthMiddleware
 // leaves the chain ungated at the middleware layer — production
 // wiring (cmd/ocifactory serve) always supplies one. With no
-// AuthContext on the request the namespace wrapper denies at 403.
+// AuthContext on the request the artifact data-plane wrapper denies at 403.
 func TestMux_NoAuthMiddleware(t *testing.T) {
 	t.Parallel()
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	putNamespace(t, store, testNS, namespace.Spec{Policy: allowAllPolicy()})
 
 	h, err := NewHandler(reg)
@@ -76,7 +77,7 @@ func TestMux_NoAuthMiddleware(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.Mux().ServeHTTP(w, r)
 	if got := w.Code; got == http.StatusUnauthorized {
-		t.Errorf("status = 401 with no middleware configured; the namespace wrapper, not the middleware, should deny")
+		t.Errorf("status = 401 with no middleware configured; the artifact data-plane wrapper, not the middleware, should deny")
 	}
 	if got, want := w.Code, http.StatusForbidden; got != want {
 		t.Errorf("status = %d, want %d (no AuthContext → wrapper denies)", got, want)
@@ -94,7 +95,7 @@ func TestMux_AuthChainsBeforeHandler(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	putNamespace(t, store, testNS, namespace.Spec{Policy: allowAllPolicy()})
 
 	h, err := NewHandler(reg, WithAuthMiddleware(installer))

--- a/pkg/handler/maven/handler.go
+++ b/pkg/handler/maven/handler.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
+	"github.com/yolocs/ocifactory/pkg/artifact"
 	"github.com/yolocs/ocifactory/pkg/handler"
 	"github.com/yolocs/ocifactory/pkg/logging"
-	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
 	"github.com/yolocs/ocifactory/pkg/proxy/indexcache"
 	"oras.land/oras-go/v2/errdef"
@@ -55,7 +55,7 @@ var (
 )
 
 type Handler struct {
-	registry       *namespace.Registry
+	artifacts      *artifact.Store
 	authMW         func(http.Handler) http.Handler
 	maxUploadBytes int64
 	proxy          *proxyState
@@ -91,11 +91,11 @@ func WithMaxUploadBytes(n int64) Option {
 
 // NewHandler creates a new Handler.
 //
-// registry is the data-plane wrapper that hands out per-request
-// [*namespace.ScopedRegistry] views via [registry.For]. Every routed
+// artifacts is the data-plane wrapper that hands out per-request
+// [*artifact.ScopedNamespace] views via [artifact.Store.For]. Every routed
 // handler func resolves the namespace from the request URL
 // (`/{namespace}/maven2/...`) and obtains a scoped view at the top.
-func NewHandler(registry *namespace.Registry, opts ...Option) (*Handler, error) {
+func NewHandler(artifacts *artifact.Store, opts ...Option) (*Handler, error) {
 	cfg := handlerConfig{
 		maxUploadBytes: DefaultMaxUploadBytes,
 	}
@@ -103,7 +103,7 @@ func NewHandler(registry *namespace.Registry, opts ...Option) (*Handler, error) 
 		opt(&cfg)
 	}
 	h := &Handler{
-		registry:       registry,
+		artifacts:      artifacts,
 		authMW:         cfg.authMW,
 		maxUploadBytes: cfg.maxUploadBytes,
 	}
@@ -159,10 +159,10 @@ func (h *Handler) Mux() http.Handler {
 	return router
 }
 
-// scopedFor returns the per-request [*namespace.ScopedRegistry] for
+// scopedFor returns the per-request [*artifact.ScopedNamespace] for
 // the namespace in req's URL. Cheap to construct; called per request.
-func (h *Handler) scopedFor(req *http.Request) *namespace.ScopedRegistry {
-	return h.registry.For(mux.Vars(req)["namespace"])
+func (h *Handler) scopedFor(req *http.Request) *artifact.ScopedNamespace {
+	return h.artifacts.For(mux.Vars(req)["namespace"])
 }
 
 // handleArchetypeCatalog handles requests for archetype-catalog.xml.
@@ -436,7 +436,7 @@ func (h *Handler) handlePut(w http.ResponseWriter, req *http.Request, scoped han
 // req.ContentLength via f.Size so AddFile keeps its streaming fast path.
 // For checksum filenames it buffers the (always tiny) body, validates it
 // against the previously-uploaded companion artifact (looked up through
-// the per-request scoped registry view), and returns a reader over the
+// the per-request scoped artifact view), and returns a reader over the
 // buffered bytes so AddFile still sees an io.Reader.
 func (h *Handler) maybeVerifyChecksum(req *http.Request, scoped handler.Registry, f *oci.RepoFile) (io.Reader, error) {
 	if ext, _, _ := checksumExt(f.Name); ext == "" {

--- a/pkg/handler/maven/handler.go
+++ b/pkg/handler/maven/handler.go
@@ -92,9 +92,9 @@ func WithMaxUploadBytes(n int64) Option {
 // NewHandler creates a new Handler.
 //
 // artifacts is the data-plane wrapper that hands out per-request
-// [*artifact.ScopedNamespace] views via [artifact.Store.For]. Every routed
+// [*artifact.NamespaceView] views via [artifact.Store.View]. Every routed
 // handler func resolves the namespace from the request URL
-// (`/{namespace}/maven2/...`) and obtains a scoped view at the top.
+// (`/{namespace}/maven2/...`) and obtains a view view at the top.
 func NewHandler(artifacts *artifact.Store, opts ...Option) (*Handler, error) {
 	cfg := handlerConfig{
 		maxUploadBytes: DefaultMaxUploadBytes,
@@ -159,16 +159,16 @@ func (h *Handler) Mux() http.Handler {
 	return router
 }
 
-// scopedFor returns the per-request [*artifact.ScopedNamespace] for
+// namespaceViewFor returns the per-request [*artifact.NamespaceView] for
 // the namespace in req's URL. Cheap to construct; called per request.
-func (h *Handler) scopedFor(req *http.Request) *artifact.ScopedNamespace {
-	return h.artifacts.For(mux.Vars(req)["namespace"])
+func (h *Handler) namespaceViewFor(req *http.Request) *artifact.NamespaceView {
+	return h.artifacts.View(mux.Vars(req)["namespace"])
 }
 
 // handleArchetypeCatalog handles requests for archetype-catalog.xml.
 func (h *Handler) handleArchetypeCatalog(w http.ResponseWriter, req *http.Request) {
-	scoped := h.scopedFor(req)
-	if _, isProxy, ok := h.dispatchProxy(w, req, scoped); !ok {
+	view := h.namespaceViewFor(req)
+	if _, isProxy, ok := h.dispatchProxy(w, req, view); !ok {
 		return
 	} else if isProxy && (req.Method == http.MethodPut || req.Method == http.MethodPost) {
 		http.Error(w, "uploads disabled on proxy namespaces", http.StatusMethodNotAllowed)
@@ -181,9 +181,9 @@ func (h *Handler) handleArchetypeCatalog(w http.ResponseWriter, req *http.Reques
 		MediaType:  "text/xml",
 	}
 	if req.Method == http.MethodPut || req.Method == http.MethodPost {
-		h.handlePut(w, req, scoped, f)
+		h.handlePut(w, req, view, f)
 	} else { // GET, HEAD
-		h.handleGet(w, req, scoped, f)
+		h.handleGet(w, req, view, f)
 	}
 }
 
@@ -198,7 +198,7 @@ func (h *Handler) handleSnapshotMetadata(w http.ResponseWriter, req *http.Reques
 		return
 	}
 
-	scoped := h.scopedFor(req)
+	view := h.namespaceViewFor(req)
 	f := &oci.RepoFile{
 		OwningRepo: packageOwningRepo(repoParts),
 		OwningTag:  versionSnapshot + "-metadata", // e.g., 1.0-SNAPSHOT-metadata
@@ -210,20 +210,20 @@ func (h *Handler) handleSnapshotMetadata(w http.ResponseWriter, req *http.Reques
 		// snapshot doesn't 409 on the metadata write.
 		AllowOverwrite: true,
 	}
-	if spec, isProxy, ok := h.dispatchProxy(w, req, scoped); !ok {
+	if spec, isProxy, ok := h.dispatchProxy(w, req, view); !ok {
 		return
 	} else if isProxy {
 		if req.Method == http.MethodPut || req.Method == http.MethodPost {
 			http.Error(w, "uploads disabled on proxy namespaces", http.StatusMethodNotAllowed)
 			return
 		}
-		h.handleMetadataProxy(w, req, scoped, spec, repoParts+"/"+versionSnapshot)
+		h.handleMetadataProxy(w, req, view, spec, repoParts+"/"+versionSnapshot)
 		return
 	}
 	if req.Method == http.MethodPut || req.Method == http.MethodPost {
-		h.handlePut(w, req, scoped, f)
+		h.handlePut(w, req, view, f)
 	} else { // GET, HEAD
-		h.handleGet(w, req, scoped, f)
+		h.handleGet(w, req, view, f)
 	}
 }
 
@@ -238,7 +238,7 @@ func (h *Handler) handleSnapshotMetadataSidecar(w http.ResponseWriter, req *http
 		return
 	}
 
-	scoped := h.scopedFor(req)
+	view := h.namespaceViewFor(req)
 	f := &oci.RepoFile{
 		OwningRepo:     packageOwningRepo(repoParts),
 		OwningTag:      versionSnapshot + "-metadata",
@@ -246,20 +246,20 @@ func (h *Handler) handleSnapshotMetadataSidecar(w http.ResponseWriter, req *http
 		MediaType:      detectMediaType(filename),
 		AllowOverwrite: true,
 	}
-	if spec, isProxy, ok := h.dispatchProxy(w, req, scoped); !ok {
+	if spec, isProxy, ok := h.dispatchProxy(w, req, view); !ok {
 		return
 	} else if isProxy {
 		if req.Method == http.MethodPut || req.Method == http.MethodPost {
 			http.Error(w, "uploads disabled on proxy namespaces", http.StatusMethodNotAllowed)
 			return
 		}
-		h.handleMetadataSidecarProxy(w, req, scoped, spec, f, repoParts+"/"+versionSnapshot)
+		h.handleMetadataSidecarProxy(w, req, view, spec, f, repoParts+"/"+versionSnapshot)
 		return
 	}
 	if req.Method == http.MethodPut || req.Method == http.MethodPost {
-		h.handlePut(w, req, scoped, f)
+		h.handlePut(w, req, view, f)
 	} else {
-		h.handleGet(w, req, scoped, f)
+		h.handleGet(w, req, view, f)
 	}
 }
 
@@ -273,27 +273,27 @@ func (h *Handler) handleArtifactMetadata(w http.ResponseWriter, req *http.Reques
 		return
 	}
 
-	scoped := h.scopedFor(req)
+	view := h.namespaceViewFor(req)
 	f := &oci.RepoFile{
 		OwningRepo: packageOwningRepo(repoParts),
 		OwningTag:  "metadata", // For release artifact or version metadata
 		Name:       "maven-metadata.xml",
 		MediaType:  "text/xml",
 	}
-	if spec, isProxy, ok := h.dispatchProxy(w, req, scoped); !ok {
+	if spec, isProxy, ok := h.dispatchProxy(w, req, view); !ok {
 		return
 	} else if isProxy {
 		if req.Method == http.MethodPut || req.Method == http.MethodPost {
 			http.Error(w, "uploads disabled on proxy namespaces", http.StatusMethodNotAllowed)
 			return
 		}
-		h.handleMetadataProxy(w, req, scoped, spec, repoParts)
+		h.handleMetadataProxy(w, req, view, spec, repoParts)
 		return
 	}
 	if req.Method == http.MethodPut || req.Method == http.MethodPost {
-		h.handlePut(w, req, scoped, f)
+		h.handlePut(w, req, view, f)
 	} else { // GET, HEAD
-		h.handleGet(w, req, scoped, f)
+		h.handleGet(w, req, view, f)
 	}
 }
 
@@ -307,27 +307,27 @@ func (h *Handler) handleArtifactMetadataSidecar(w http.ResponseWriter, req *http
 		return
 	}
 
-	scoped := h.scopedFor(req)
+	view := h.namespaceViewFor(req)
 	f := &oci.RepoFile{
 		OwningRepo: packageOwningRepo(repoParts),
 		OwningTag:  "metadata",
 		Name:       filename,
 		MediaType:  detectMediaType(filename),
 	}
-	if spec, isProxy, ok := h.dispatchProxy(w, req, scoped); !ok {
+	if spec, isProxy, ok := h.dispatchProxy(w, req, view); !ok {
 		return
 	} else if isProxy {
 		if req.Method == http.MethodPut || req.Method == http.MethodPost {
 			http.Error(w, "uploads disabled on proxy namespaces", http.StatusMethodNotAllowed)
 			return
 		}
-		h.handleMetadataSidecarProxy(w, req, scoped, spec, f, repoParts)
+		h.handleMetadataSidecarProxy(w, req, view, spec, f, repoParts)
 		return
 	}
 	if req.Method == http.MethodPut || req.Method == http.MethodPost {
-		h.handlePut(w, req, scoped, f)
+		h.handlePut(w, req, view, f)
 	} else {
-		h.handleGet(w, req, scoped, f)
+		h.handleGet(w, req, view, f)
 	}
 }
 
@@ -343,7 +343,7 @@ func (h *Handler) handleRegularArtifact(w http.ResponseWriter, req *http.Request
 		return
 	}
 
-	scoped := h.scopedFor(req)
+	view := h.namespaceViewFor(req)
 	f := &oci.RepoFile{
 		OwningRepo: packageOwningRepo(repoParts),
 		OwningTag:  version,
@@ -357,25 +357,25 @@ func (h *Handler) handleRegularArtifact(w http.ResponseWriter, req *http.Request
 		// registry-level --allow-overwrite default.
 		AllowOverwrite: isSnapshotVersion(version),
 	}
-	if spec, isProxy, ok := h.dispatchProxy(w, req, scoped); !ok {
+	if spec, isProxy, ok := h.dispatchProxy(w, req, view); !ok {
 		return
 	} else if isProxy {
 		if req.Method == http.MethodPut || req.Method == http.MethodPost {
 			http.Error(w, "uploads disabled on proxy namespaces", http.StatusMethodNotAllowed)
 			return
 		}
-		h.handleFileGetProxy(w, req, scoped, spec, f)
+		h.handleFileGetProxy(w, req, view, spec, f)
 		return
 	}
 	if req.Method == http.MethodPut || req.Method == http.MethodPost {
-		h.handlePut(w, req, scoped, f)
+		h.handlePut(w, req, view, f)
 	} else { // GET, HEAD
-		h.handleGet(w, req, scoped, f)
+		h.handleGet(w, req, view, f)
 	}
 }
 
 // handlePut processes PUT/POST requests to add a file.
-func (h *Handler) handlePut(w http.ResponseWriter, req *http.Request, scoped handler.Registry, f *oci.RepoFile) {
+func (h *Handler) handlePut(w http.ResponseWriter, req *http.Request, view handler.Registry, f *oci.RepoFile) {
 	logger := logging.FromContext(req.Context())
 
 	if h.maxUploadBytes > 0 {
@@ -384,7 +384,7 @@ func (h *Handler) handlePut(w http.ResponseWriter, req *http.Request, scoped han
 
 	defer req.Body.Close()
 
-	body, err := h.maybeVerifyChecksum(req, scoped, f)
+	body, err := h.maybeVerifyChecksum(req, view, f)
 	if err != nil {
 		logger.DebugContext(req.Context(), "checksum verification failed", "error", err)
 		if handler.WriteNamespaceError(w, err) {
@@ -406,7 +406,7 @@ func (h *Handler) handlePut(w http.ResponseWriter, req *http.Request, scoped han
 		return
 	}
 
-	desc, err := scoped.AddFile(req.Context(), f, body)
+	desc, err := view.AddFile(req.Context(), f, body)
 	if err != nil {
 		logger.DebugContext(req.Context(), "failed to add file", "error", err)
 		if handler.WriteNamespaceError(w, err) {
@@ -436,9 +436,9 @@ func (h *Handler) handlePut(w http.ResponseWriter, req *http.Request, scoped han
 // req.ContentLength via f.Size so AddFile keeps its streaming fast path.
 // For checksum filenames it buffers the (always tiny) body, validates it
 // against the previously-uploaded companion artifact (looked up through
-// the per-request scoped artifact view), and returns a reader over the
+// the per-request view artifact view), and returns a reader over the
 // buffered bytes so AddFile still sees an io.Reader.
-func (h *Handler) maybeVerifyChecksum(req *http.Request, scoped handler.Registry, f *oci.RepoFile) (io.Reader, error) {
+func (h *Handler) maybeVerifyChecksum(req *http.Request, view handler.Registry, f *oci.RepoFile) (io.Reader, error) {
 	if ext, _, _ := checksumExt(f.Name); ext == "" {
 		// Forward the HTTP Content-Length so AddFile can short-circuit
 		// the peek-and-decide buffer for sized uploads (mvn deploy
@@ -457,7 +457,7 @@ func (h *Handler) maybeVerifyChecksum(req *http.Request, scoped handler.Registry
 		return nil, badRequest("checksum body exceeds %d bytes", maxChecksumBodyBytes)
 	}
 
-	if err := verifyChecksumUpload(req.Context(), scoped, f, body); err != nil {
+	if err := verifyChecksumUpload(req.Context(), view, f, body); err != nil {
 		return nil, err
 	}
 
@@ -465,14 +465,14 @@ func (h *Handler) maybeVerifyChecksum(req *http.Request, scoped handler.Registry
 	return bytes.NewReader(body), nil
 }
 
-func (h *Handler) handleGet(w http.ResponseWriter, req *http.Request, scoped handler.Registry, f *oci.RepoFile) {
+func (h *Handler) handleGet(w http.ResponseWriter, req *http.Request, view handler.Registry, f *oci.RepoFile) {
 	logger := logging.FromContext(req.Context())
 
 	// HEAD wants headers only — never redirect. The redirect path is
 	// only worth taking when the response would otherwise transfer
 	// bytes; HEAD has no egress to save.
 	if req.Method != http.MethodHead {
-		if redirectURL, err := scoped.BlobRedirectURL(req.Context(), f); err == nil && redirectURL != "" {
+		if redirectURL, err := view.BlobRedirectURL(req.Context(), f); err == nil && redirectURL != "" {
 			logger.DebugContext(req.Context(), "redirecting blob fetch to backend", "url", redirectURL)
 			http.Redirect(w, req, redirectURL, http.StatusTemporaryRedirect)
 			return
@@ -485,7 +485,7 @@ func (h *Handler) handleGet(w http.ResponseWriter, req *http.Request, scoped han
 		}
 	}
 
-	desc, r, err := scoped.ReadFile(req.Context(), f)
+	desc, r, err := view.ReadFile(req.Context(), f)
 	if err != nil {
 		logger.DebugContext(req.Context(), "failed to read file", "error", err)
 		if handler.WriteNamespaceError(w, err) {

--- a/pkg/handler/maven/namespace_test.go
+++ b/pkg/handler/maven/namespace_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/yolocs/ocifactory/pkg/artifact"
 	"github.com/yolocs/ocifactory/pkg/auth"
 	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
@@ -22,7 +23,7 @@ func TestNamespace_UnknownNamespace404(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	authMW := auth.Middleware(auth.AlwaysAnonymous)
 	h, err := NewHandler(reg, WithAuthMiddleware(authMW))
 	if err != nil {
@@ -60,7 +61,7 @@ func TestNamespace_InvalidNamespaceName400(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	authMW := auth.Middleware(auth.AlwaysAnonymous)
 	h, err := NewHandler(reg, WithAuthMiddleware(authMW))
 	if err != nil {
@@ -94,13 +95,13 @@ func TestNamespace_AuthzErrorFailsClosed(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store,
-		namespace.WithAuthzFactory(func(_ namespace.Policy) (auth.Authorizer, error) {
+	reg := artifact.NewStore(fake, store,
+		artifact.WithAuthzFactory(func(_ namespace.Policy) (auth.Authorizer, error) {
 			return auth.AuthorizerFunc(func(_ context.Context, _ *auth.AuthContext, _ auth.Op) error {
 				return errors.New("transient backend lookup failure")
 			}), nil
 		}),
-		namespace.WithPolicyCacheTTL(0),
+		artifact.WithPolicyCacheTTL(0),
 	)
 	putNamespace(t, store, testNS, namespace.Spec{Policy: allowAllPolicy()})
 
@@ -134,7 +135,7 @@ func TestNamespace_NotInReadersForbidden(t *testing.T) {
 		t.Fatalf("seed: %v", err)
 	}
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	putNamespace(t, store, testNS, namespace.Spec{Policy: namespace.Policy{
 		Readers: []namespace.SubjectMatcher{{Issuer: "https://accounts.google.com"}},
 		Writers: []namespace.SubjectMatcher{{Issuer: "https://accounts.google.com"}},
@@ -161,7 +162,7 @@ func TestNamespace_NotInWritersForbidden(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	putNamespace(t, store, testNS, namespace.Spec{Policy: namespace.Policy{
 		Readers: []namespace.SubjectMatcher{{Issuer: "anonymous"}},
 		Writers: []namespace.SubjectMatcher{{Issuer: "https://accounts.google.com"}},
@@ -188,7 +189,7 @@ func TestNamespace_CrossNamespaceIsolation_Artifact(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	putNamespace(t, store, "alpha", namespace.Spec{Policy: allowAllPolicy()})
 	putNamespace(t, store, "beta", namespace.Spec{Policy: allowAllPolicy()})
 
@@ -233,7 +234,7 @@ func TestNamespace_CrossNamespaceIsolation_Checksum(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	putNamespace(t, store, "alpha", namespace.Spec{Policy: allowAllPolicy()})
 	putNamespace(t, store, "beta", namespace.Spec{Policy: allowAllPolicy()})
 
@@ -277,7 +278,7 @@ func TestNamespace_ReservedIndexNameIsPackageScoped(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	putNamespace(t, store, testNS, namespace.Spec{Policy: allowAllPolicy()})
 
 	authMW := auth.Middleware(auth.AlwaysAnonymous)
@@ -306,9 +307,9 @@ func TestNamespace_NoAuthForbiddenAtWrapper(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store,
-		namespace.WithAuthzFactory(func(_ namespace.Policy) (auth.Authorizer, error) { return auth.AllowAll, nil }),
-		namespace.WithPolicyCacheTTL(0),
+	reg := artifact.NewStore(fake, store,
+		artifact.WithAuthzFactory(func(_ namespace.Policy) (auth.Authorizer, error) { return auth.AllowAll, nil }),
+		artifact.WithPolicyCacheTTL(0),
 	)
 	putNamespace(t, store, testNS, namespace.Spec{Policy: allowAllPolicy()})
 

--- a/pkg/handler/maven/proxy.go
+++ b/pkg/handler/maven/proxy.go
@@ -87,8 +87,8 @@ func (p *proxyState) fetcherFor(upstream string) (ProxyFetcher, error) {
 	return actual.(ProxyFetcher), nil
 }
 
-func (h *Handler) dispatchProxy(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace) (*namespace.Spec, bool, bool) {
-	spec, err := scoped.Spec(req.Context())
+func (h *Handler) dispatchProxy(w http.ResponseWriter, req *http.Request, view *artifact.NamespaceView) (*namespace.Spec, bool, bool) {
+	spec, err := view.Spec(req.Context())
 	if err != nil {
 		if handler.WriteNamespaceError(w, err) {
 			return nil, false, false
@@ -100,9 +100,9 @@ func (h *Handler) dispatchProxy(w http.ResponseWriter, req *http.Request, scoped
 	return spec, isProxy, true
 }
 
-func (h *Handler) handleMetadataProxy(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, spec *namespace.Spec, repoPath string) {
+func (h *Handler) handleMetadataProxy(w http.ResponseWriter, req *http.Request, view *artifact.NamespaceView, spec *namespace.Spec, repoPath string) {
 	ctx := req.Context()
-	if err := scoped.Authorize(ctx, auth.OpRead); err != nil {
+	if err := view.Authorize(ctx, auth.OpRead); err != nil {
 		if handler.WriteNamespaceError(w, err) {
 			return
 		}
@@ -132,10 +132,10 @@ func (h *Handler) handleMetadataProxy(w http.ResponseWriter, req *http.Request, 
 	writeProxyBytes(w, req, resp.Body, resp.ContentType)
 }
 
-func (h *Handler) handleMetadataSidecarProxy(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, spec *namespace.Spec, f *oci.RepoFile, repoPath string) {
+func (h *Handler) handleMetadataSidecarProxy(w http.ResponseWriter, req *http.Request, view *artifact.NamespaceView, spec *namespace.Spec, f *oci.RepoFile, repoPath string) {
 	ctx := req.Context()
 
-	if h.tryServeFromRegistry(w, req, scoped, f) {
+	if h.tryServeFromRegistry(w, req, view, f) {
 		return
 	}
 	fetcher, err := h.proxy.fetcherFor(spec.Proxy.Upstream)
@@ -144,13 +144,13 @@ func (h *Handler) handleMetadataSidecarProxy(w http.ResponseWriter, req *http.Re
 		return
 	}
 
-	key := scoped.Namespace() + "|" + f.OwningRepo + "|" + f.OwningTag + "|" + f.Name
+	key := view.Namespace() + "|" + f.OwningRepo + "|" + f.OwningTag + "|" + f.Name
 	isHead := req.Method == http.MethodHead
 	amLeader := false
 	var teeRef *tolerantWriter
 	resultV, err, _ := h.proxy.fileFlight.Do(key, func() (any, error) {
 		amLeader = true
-		if hit, hitErr := h.peekRegistry(ctx, scoped, f); hitErr == nil && hit {
+		if hit, hitErr := h.peekRegistry(ctx, view, f); hitErr == nil && hit {
 			return fileFlightResult{cached: true}, nil
 		}
 		fileResp, ferr := fetcher.FetchPath(ctx, repoPath, f.Name)
@@ -179,7 +179,7 @@ func (h *Handler) handleMetadataSidecarProxy(w http.ResponseWriter, req *http.Re
 			teeRef = &tolerantWriter{w: w}
 			body = io.TeeReader(body, teeRef)
 		}
-		if _, addErr := scoped.AddCachedFile(ctx, populated, body); addErr != nil {
+		if _, addErr := view.AddCachedFile(ctx, populated, body); addErr != nil {
 			if errors.Is(addErr, oci.ErrAlreadyExists) {
 				return fileFlightResult{cached: true}, nil
 			}
@@ -196,17 +196,17 @@ func (h *Handler) handleMetadataSidecarProxy(w http.ResponseWriter, req *http.Re
 	if result.streamed && amLeader && !isHead {
 		return
 	}
-	if h.tryServeFromRegistry(w, req, scoped, f) {
+	if h.tryServeFromRegistry(w, req, view, f) {
 		return
 	}
 	handler.WriteError(ctx, w, http.StatusBadGateway, nil, "proxy fill reported success but cache miss on re-read")
 }
 
-func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, spec *namespace.Spec, f *oci.RepoFile) {
+func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, view *artifact.NamespaceView, spec *namespace.Spec, f *oci.RepoFile) {
 	ctx := req.Context()
 	logger := logging.FromContext(ctx)
 
-	if h.tryServeFromRegistry(w, req, scoped, f) {
+	if h.tryServeFromRegistry(w, req, view, f) {
 		return
 	}
 
@@ -215,7 +215,7 @@ func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, s
 	version := f.OwningTag
 	filename := f.Name
 	if h.proxy.negCache != nil {
-		key := negativeKey(scoped.Namespace(), f.OwningRepo, version, filename)
+		key := negativeKey(view.Namespace(), f.OwningRepo, version, filename)
 		if h.proxy.negCache.IsKnownMissing(key) {
 			http.Error(w, "not found", http.StatusNotFound)
 			return
@@ -239,13 +239,13 @@ func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, s
 		return
 	}
 
-	key := scoped.Namespace() + "|" + f.OwningRepo + "|" + version + "|" + filename
+	key := view.Namespace() + "|" + f.OwningRepo + "|" + version + "|" + filename
 	isHead := req.Method == http.MethodHead
 	amLeader := false
 	var teeRef *tolerantWriter
 	resultV, err, _ := h.proxy.fileFlight.Do(key, func() (any, error) {
 		amLeader = true
-		if hit, hitErr := h.peekRegistry(ctx, scoped, f); hitErr == nil && hit {
+		if hit, hitErr := h.peekRegistry(ctx, view, f); hitErr == nil && hit {
 			return fileFlightResult{cached: true}, nil
 		}
 
@@ -297,7 +297,7 @@ func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, s
 			teeRef = &tolerantWriter{w: w}
 			body = io.TeeReader(body, teeRef)
 		}
-		if _, addErr := scoped.AddCachedFile(ctx, populated, body); addErr != nil {
+		if _, addErr := view.AddCachedFile(ctx, populated, body); addErr != nil {
 			if errors.Is(addErr, oci.ErrAlreadyExists) {
 				return fileFlightResult{cached: true}, nil
 			}
@@ -314,7 +314,7 @@ func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, s
 		switch {
 		case errors.Is(err, proxy.ErrNotFound):
 			if h.proxy.negCache != nil {
-				h.proxy.negCache.RecordMiss(negativeKey(scoped.Namespace(), f.OwningRepo, version, filename))
+				h.proxy.negCache.RecordMiss(negativeKey(view.Namespace(), f.OwningRepo, version, filename))
 			}
 			http.Error(w, "not found", http.StatusNotFound)
 		case errors.Is(err, proxy.ErrUpstreamMalformed):
@@ -341,7 +341,7 @@ func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, s
 	if result.streamed && amLeader && !isHead {
 		return
 	}
-	if h.tryServeFromRegistry(w, req, scoped, f) {
+	if h.tryServeFromRegistry(w, req, view, f) {
 		return
 	}
 	handler.WriteError(ctx, w, http.StatusBadGateway, nil, "proxy fill reported success but cache miss on re-read")
@@ -429,8 +429,8 @@ func (h *Handler) writeProxyFileError(w http.ResponseWriter, req *http.Request, 
 	}
 }
 
-func (h *Handler) peekRegistry(ctx context.Context, scoped *artifact.ScopedNamespace, f *oci.RepoFile) (bool, error) {
-	_, rc, err := scoped.ReadFile(ctx, f)
+func (h *Handler) peekRegistry(ctx context.Context, view *artifact.NamespaceView, f *oci.RepoFile) (bool, error) {
+	_, rc, err := view.ReadFile(ctx, f)
 	if err != nil {
 		if errors.Is(err, errdef.ErrNotFound) {
 			return false, nil
@@ -441,19 +441,19 @@ func (h *Handler) peekRegistry(ctx context.Context, scoped *artifact.ScopedNames
 	return true, nil
 }
 
-func (h *Handler) tryServeFromRegistry(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, f *oci.RepoFile) bool {
+func (h *Handler) tryServeFromRegistry(w http.ResponseWriter, req *http.Request, view *artifact.NamespaceView, f *oci.RepoFile) bool {
 	ctx := req.Context()
 	logger := logging.FromContext(ctx)
 
 	if req.Method != http.MethodHead {
-		if redirectURL, err := scoped.BlobRedirectURL(ctx, f); err == nil && redirectURL != "" {
+		if redirectURL, err := view.BlobRedirectURL(ctx, f); err == nil && redirectURL != "" {
 			http.Redirect(w, req, redirectURL, http.StatusTemporaryRedirect)
 			return true
 		} else if err != nil {
 			logger.DebugContext(ctx, "maven proxy redirect probe failed; streaming", "error", err)
 		}
 	}
-	desc, rc, err := scoped.ReadFile(ctx, f)
+	desc, rc, err := view.ReadFile(ctx, f)
 	if err != nil {
 		if errors.Is(err, errdef.ErrNotFound) {
 			return false

--- a/pkg/handler/maven/proxy.go
+++ b/pkg/handler/maven/proxy.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/sync/singleflight"
 	"oras.land/oras-go/v2/errdef"
 
+	"github.com/yolocs/ocifactory/pkg/artifact"
 	"github.com/yolocs/ocifactory/pkg/auth"
 	"github.com/yolocs/ocifactory/pkg/handler"
 	"github.com/yolocs/ocifactory/pkg/logging"
@@ -86,7 +87,7 @@ func (p *proxyState) fetcherFor(upstream string) (ProxyFetcher, error) {
 	return actual.(ProxyFetcher), nil
 }
 
-func (h *Handler) dispatchProxy(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry) (*namespace.Spec, bool, bool) {
+func (h *Handler) dispatchProxy(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace) (*namespace.Spec, bool, bool) {
 	spec, err := scoped.Spec(req.Context())
 	if err != nil {
 		if handler.WriteNamespaceError(w, err) {
@@ -99,7 +100,7 @@ func (h *Handler) dispatchProxy(w http.ResponseWriter, req *http.Request, scoped
 	return spec, isProxy, true
 }
 
-func (h *Handler) handleMetadataProxy(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry, spec *namespace.Spec, repoPath string) {
+func (h *Handler) handleMetadataProxy(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, spec *namespace.Spec, repoPath string) {
 	ctx := req.Context()
 	if err := scoped.Authorize(ctx, auth.OpRead); err != nil {
 		if handler.WriteNamespaceError(w, err) {
@@ -131,7 +132,7 @@ func (h *Handler) handleMetadataProxy(w http.ResponseWriter, req *http.Request, 
 	writeProxyBytes(w, req, resp.Body, resp.ContentType)
 }
 
-func (h *Handler) handleMetadataSidecarProxy(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry, spec *namespace.Spec, f *oci.RepoFile, repoPath string) {
+func (h *Handler) handleMetadataSidecarProxy(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, spec *namespace.Spec, f *oci.RepoFile, repoPath string) {
 	ctx := req.Context()
 
 	if h.tryServeFromRegistry(w, req, scoped, f) {
@@ -201,7 +202,7 @@ func (h *Handler) handleMetadataSidecarProxy(w http.ResponseWriter, req *http.Re
 	handler.WriteError(ctx, w, http.StatusBadGateway, nil, "proxy fill reported success but cache miss on re-read")
 }
 
-func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry, spec *namespace.Spec, f *oci.RepoFile) {
+func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, spec *namespace.Spec, f *oci.RepoFile) {
 	ctx := req.Context()
 	logger := logging.FromContext(ctx)
 
@@ -428,7 +429,7 @@ func (h *Handler) writeProxyFileError(w http.ResponseWriter, req *http.Request, 
 	}
 }
 
-func (h *Handler) peekRegistry(ctx context.Context, scoped *namespace.ScopedRegistry, f *oci.RepoFile) (bool, error) {
+func (h *Handler) peekRegistry(ctx context.Context, scoped *artifact.ScopedNamespace, f *oci.RepoFile) (bool, error) {
 	_, rc, err := scoped.ReadFile(ctx, f)
 	if err != nil {
 		if errors.Is(err, errdef.ErrNotFound) {
@@ -440,7 +441,7 @@ func (h *Handler) peekRegistry(ctx context.Context, scoped *namespace.ScopedRegi
 	return true, nil
 }
 
-func (h *Handler) tryServeFromRegistry(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry, f *oci.RepoFile) bool {
+func (h *Handler) tryServeFromRegistry(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, f *oci.RepoFile) bool {
 	ctx := req.Context()
 	logger := logging.FromContext(ctx)
 

--- a/pkg/handler/maven/proxy_test.go
+++ b/pkg/handler/maven/proxy_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/yolocs/ocifactory/pkg/artifact"
 	"github.com/yolocs/ocifactory/pkg/auth"
 	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
@@ -94,7 +95,7 @@ func newProxyTestHandler(t *testing.T, fetcher ProxyFetcher, spec namespace.Spec
 	t.Helper()
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 
 	if spec.Mode == "" {
 		spec.Mode = namespace.ModeProxy

--- a/pkg/handler/maven/testutil_test.go
+++ b/pkg/handler/maven/testutil_test.go
@@ -3,6 +3,7 @@ package maven
 import (
 	"testing"
 
+	"github.com/yolocs/ocifactory/pkg/artifact"
 	"github.com/yolocs/ocifactory/pkg/auth"
 	"github.com/yolocs/ocifactory/pkg/namespace"
 )
@@ -24,14 +25,14 @@ func allowAllPolicy() namespace.Policy {
 }
 
 // newTestHandler builds a maven [*Handler] wired to a
-// [*namespace.Registry] backed by inner. The "test-ns" namespace
+// [*artifact.Store] backed by inner. The "test-ns" namespace
 // receives an allow-all policy and the auth middleware installs the
 // [auth.AlwaysAnonymous] AuthContext on every request so the wrapper
 // has a subject to authorize.
-func newTestHandler(t *testing.T, inner namespace.RegistryBackend, opts ...Option) (*Handler, *namespace.Store) {
+func newTestHandler(t *testing.T, inner artifact.Backend, opts ...Option) (*Handler, *namespace.Store) {
 	t.Helper()
 	store := namespace.NewStore(inner)
-	reg := namespace.NewRegistry(inner, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(inner, store, artifact.WithPolicyCacheTTL(0))
 	if err := store.Put(t.Context(), &namespace.Namespace{Name: testNS, Spec: namespace.Spec{Policy: allowAllPolicy()}}); err != nil {
 		t.Fatalf("Put namespace: %v", err)
 	}

--- a/pkg/handler/npm/auth_test.go
+++ b/pkg/handler/npm/auth_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/yolocs/ocifactory/pkg/artifact"
 	"github.com/yolocs/ocifactory/pkg/auth"
 	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
@@ -13,7 +14,7 @@ import (
 
 // TestMux_AuthGating wires an npm handler with an auth middleware
 // that always 401s and confirms every namespaced route hits the gate
-// — i.e. the handler itself is NOT reached, and the namespace wrapper
+// — i.e. the handler itself is NOT reached, and the artifact data-plane wrapper
 // has no chance to deny first. Mirrors the python and maven
 // equivalents.
 func TestMux_AuthGating(t *testing.T) {
@@ -27,7 +28,7 @@ func TestMux_AuthGating(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	h, err := NewHandler(reg, WithAuthMiddleware(denyAll))
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)
@@ -74,13 +75,13 @@ func TestMux_AuthGating(t *testing.T) {
 // TestMux_NoAuthMiddleware confirms that omitting WithAuthMiddleware
 // leaves the chain ungated at the middleware layer — production
 // wiring (cmd/ocifactory serve) always supplies one. With no
-// AuthContext on the request, the namespace wrapper denies at 403.
+// AuthContext on the request, the artifact data-plane wrapper denies at 403.
 func TestMux_NoAuthMiddleware(t *testing.T) {
 	t.Parallel()
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	putNamespace(t, store, testNS, namespace.Spec{Policy: allowAllPolicy()})
 
 	h, err := NewHandler(reg)
@@ -92,7 +93,7 @@ func TestMux_NoAuthMiddleware(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.Mux().ServeHTTP(w, r)
 	if got := w.Code; got == http.StatusUnauthorized {
-		t.Errorf("status=401 with no middleware configured; the namespace wrapper, not the middleware, should deny")
+		t.Errorf("status=401 with no middleware configured; the artifact data-plane wrapper, not the middleware, should deny")
 	}
 	if got, want := w.Code, http.StatusForbidden; got != want {
 		t.Errorf("status=%d, want %d (no AuthContext → wrapper denies)", got, want)
@@ -110,7 +111,7 @@ func TestMux_AuthChainsBeforeHandler(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	putNamespace(t, store, testNS, namespace.Spec{Policy: allowAllPolicy()})
 
 	h, err := NewHandler(reg, WithAuthMiddleware(installer))

--- a/pkg/handler/npm/handler.go
+++ b/pkg/handler/npm/handler.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/yolocs/ocifactory/pkg/artifact"
 	"github.com/yolocs/ocifactory/pkg/handler"
 	"github.com/yolocs/ocifactory/pkg/logging"
 	"github.com/yolocs/ocifactory/pkg/namespace"
@@ -84,6 +85,7 @@ const (
 // register its mux via [Handler.Mux].
 type Handler struct {
 	registry       *namespace.Registry
+	artifacts      *artifact.Store
 	authMW         func(http.Handler) http.Handler
 	maxUploadBytes int64
 	proxy          *proxyState
@@ -147,6 +149,7 @@ func NewHandler(registry *namespace.Registry, opts ...Option) (*Handler, error) 
 	}
 	h := &Handler{
 		registry:       registry,
+		artifacts:      artifact.NewStore(registry),
 		authMW:         cfg.authMW,
 		maxUploadBytes: cfg.maxUploadBytes,
 	}
@@ -208,6 +211,10 @@ func (h *Handler) Mux() http.Handler {
 // the namespace in req's URL. Cheap to construct; called per request.
 func (h *Handler) scopedFor(req *http.Request) *namespace.ScopedRegistry {
 	return h.registry.For(mux.Vars(req)["namespace"])
+}
+
+func (h *Handler) artifactNamespaceFor(req *http.Request) (artifact.Namespace, error) {
+	return h.artifacts.Namespace(req.Context(), mux.Vars(req)["namespace"])
 }
 
 // handlePing answers npm's registry-root probe. The body shape is
@@ -416,26 +423,28 @@ func (h *Handler) handlePublish(w http.ResponseWriter, req *http.Request) {
 	// remains. A partial-publish across multiple versions in this
 	// loop is unrecoverable; npm publishes are single-version in
 	// practice, so the staged map almost always has size 1.
+	artifactNS, err := h.artifactNamespaceFor(req)
+	if err != nil {
+		h.writeRegistryError(ctx, w, err, "failed to resolve namespace")
+		return
+	}
+	artifactPkg := artifactNS.Package(repo)
 	for version, s := range staged {
-		tarballRF := &oci.RepoFile{
-			OwningRepo: repo,
-			OwningTag:  version,
-			Name:       s.tarballName,
-			MediaType:  "application/octet-stream",
-			Size:       int64(len(s.tarball)),
+		tarballFile := artifact.FilePut{
+			Name:      s.tarballName,
+			MediaType: "application/octet-stream",
+			Size:      int64(len(s.tarball)),
 		}
-		if !h.addFile(ctx, scoped, w, tarballRF, bytes.NewReader(s.tarball)) {
+		if !h.addFile(ctx, artifactPkg, version, w, tarballFile, bytes.NewReader(s.tarball)) {
 			return
 		}
 
-		metaRF := &oci.RepoFile{
-			OwningRepo: repo,
-			OwningTag:  version,
-			Name:       versionMetaName,
-			MediaType:  "application/json",
-			Size:       int64(len(s.raw)),
+		metaFile := artifact.FilePut{
+			Name:      versionMetaName,
+			MediaType: "application/json",
+			Size:      int64(len(s.raw)),
 		}
-		if !h.addFile(ctx, scoped, w, metaRF, bytes.NewReader(s.raw)) {
+		if !h.addFile(ctx, artifactPkg, version, w, metaFile, bytes.NewReader(s.raw)) {
 			return
 		}
 	}
@@ -443,7 +452,7 @@ func (h *Handler) handlePublish(w http.ResponseWriter, req *http.Request) {
 	// Phase 3: dist-tag updates. Each target is already known to
 	// reference a staged (and now-written) canonical version.
 	for tag, version := range doc.DistTags {
-		if err := scoped.AppendRefs(ctx, repo, version, tag); err != nil {
+		if err := artifactPkg.Tag(ctx, tag, version); err != nil {
 			h.writeRegistryError(ctx, w, err, "failed to update dist-tag")
 			return
 		}
@@ -468,12 +477,12 @@ func (h *Handler) handlePublish(w http.ResponseWriter, req *http.Request) {
 	})
 }
 
-// addFile wraps scoped.AddFile with the standard error → HTTP
+// addFile wraps package.PutFile with the standard error → HTTP
 // translation used by every npm publish step. Returns true on success
 // and writes the appropriate error response (and returns false) on
 // failure.
-func (h *Handler) addFile(ctx context.Context, scoped handler.Registry, w http.ResponseWriter, f *oci.RepoFile, body io.Reader) bool {
-	if _, err := scoped.AddFile(ctx, f, body); err != nil {
+func (h *Handler) addFile(ctx context.Context, pkg artifact.Package, version string, w http.ResponseWriter, file artifact.FilePut, body io.Reader) bool {
+	if _, err := pkg.PutFile(ctx, version, file, body); err != nil {
 		h.writeRegistryError(ctx, w, err, "failed to add file")
 		return false
 	}
@@ -905,8 +914,12 @@ func (h *Handler) handleDistTagPut(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	repo := packageOwningRepo(pkg)
-	if err := scoped.AppendRefs(ctx, repo, version, tag); err != nil {
+	artifactNS, err := h.artifactNamespaceFor(req)
+	if err != nil {
+		h.writeRegistryError(ctx, w, err, "failed to resolve namespace")
+		return
+	}
+	if err := artifactNS.Package(packageOwningRepo(pkg)).Tag(ctx, tag, version); err != nil {
 		if errors.Is(err, errdef.ErrNotFound) {
 			http.Error(w, fmt.Sprintf("version %q not found", version), http.StatusNotFound)
 			return

--- a/pkg/handler/npm/handler.go
+++ b/pkg/handler/npm/handler.go
@@ -132,9 +132,9 @@ func WithMaxUploadBytes(n int64) Option {
 // NewHandler constructs a new npm format handler.
 //
 // artifacts is the data-plane wrapper that hands out per-request
-// [*artifact.ScopedNamespace] views via [artifact.Store.For]. Every
+// [*artifact.NamespaceView] views via [artifact.Store.View]. Every
 // routed handler resolves the namespace from the request URL
-// (`/{namespace}/...`) and obtains a scoped view at the top.
+// (`/{namespace}/...`) and obtains a namespace view at the top.
 func NewHandler(artifacts *artifact.Store, opts ...Option) (*Handler, error) {
 	if artifacts == nil {
 		return nil, errors.New("artifact store must not be nil")
@@ -156,7 +156,7 @@ func NewHandler(artifacts *artifact.Store, opts ...Option) (*Handler, error) {
 
 // Mux returns the npm handler's router. Every npm route lives under
 // `/{namespace}/...` so the handler resolves the namespace from the
-// URL on each request and routes through the namespace-scoped
+// URL on each request and routes through the namespaced
 // artifact view.
 func (h *Handler) Mux() http.Handler {
 	router := mux.NewRouter()
@@ -204,10 +204,10 @@ func (h *Handler) Mux() http.Handler {
 	return router
 }
 
-// scopedFor returns the per-request [*artifact.ScopedNamespace] for
+// namespaceViewFor returns the per-request [*artifact.NamespaceView] for
 // the namespace in req's URL. Cheap to construct; called per request.
-func (h *Handler) scopedFor(req *http.Request) *artifact.ScopedNamespace {
-	return h.artifacts.For(mux.Vars(req)["namespace"])
+func (h *Handler) namespaceViewFor(req *http.Request) *artifact.NamespaceView {
+	return h.artifacts.View(mux.Vars(req)["namespace"])
 }
 
 func (h *Handler) artifactNamespaceFor(req *http.Request) (artifact.Namespace, error) {
@@ -232,8 +232,8 @@ func (h *Handler) handlePing(w http.ResponseWriter, req *http.Request) {
 // behaves as though the feature isn't available.
 func (h *Handler) handleUnsupported(w http.ResponseWriter, req *http.Request) {
 	if req.Method == http.MethodDelete {
-		scoped := h.scopedFor(req)
-		if _, isProxy, ok := h.dispatchProxy(w, req, scoped); !ok {
+		view := h.namespaceViewFor(req)
+		if _, isProxy, ok := h.dispatchProxy(w, req, view); !ok {
 			return
 		} else if isProxy {
 			http.Error(w, "writes disabled on proxy namespaces", http.StatusMethodNotAllowed)
@@ -266,9 +266,9 @@ func (h *Handler) handleUnsupported(w http.ResponseWriter, req *http.Request) {
 func (h *Handler) handlePublish(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	logger := logging.FromContext(ctx)
-	scoped := h.scopedFor(req)
+	view := h.namespaceViewFor(req)
 
-	if _, isProxy, ok := h.dispatchProxy(w, req, scoped); !ok {
+	if _, isProxy, ok := h.dispatchProxy(w, req, view); !ok {
 		return
 	} else if isProxy {
 		http.Error(w, "publishes disabled on proxy namespaces", http.StatusMethodNotAllowed)
@@ -455,7 +455,7 @@ func (h *Handler) handlePublish(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	if err := h.ensureIndexSentinel(ctx, scoped, pkgFromURL); err != nil {
+	if err := h.ensureIndexSentinel(ctx, view, pkgFromURL); err != nil {
 		// Best-effort — the package is published either way. Log
 		// at WARN so the operator notices a systematic problem
 		// (e.g. a permissions error on the index repo) but don't
@@ -486,7 +486,7 @@ func (h *Handler) addFile(ctx context.Context, pkg artifact.Package, version str
 	return true
 }
 
-// writeRegistryError translates a scoped-registry error into a
+// writeRegistryError translates a artifact-view error into a
 // canonical HTTP status. Mirrors the python / maven handler's mapping
 // table so an operator triaging an npm publish sees the same status
 // codes they would for an analogous failure in another format.
@@ -525,7 +525,7 @@ func (h *Handler) writeRegistryError(ctx context.Context, w http.ResponseWriter,
 // back to us, not to npmjs.org.
 func (h *Handler) handlePackument(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
-	scoped := h.scopedFor(req)
+	view := h.namespaceViewFor(req)
 	pkg := mux.Vars(req)["package"]
 
 	if err := validatePackageName(pkg); err != nil {
@@ -533,10 +533,10 @@ func (h *Handler) handlePackument(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if spec, isProxy, ok := h.dispatchProxy(w, req, scoped); !ok {
+	if spec, isProxy, ok := h.dispatchProxy(w, req, view); !ok {
 		return
 	} else if isProxy {
-		h.handlePackumentProxy(w, req, scoped, spec, pkg)
+		h.handlePackumentProxy(w, req, view, spec, pkg)
 		return
 	}
 
@@ -715,7 +715,7 @@ func (h *Handler) buildPackument(ctx context.Context, req *http.Request, artifac
 // the maven / python file-get flow: try a backend redirect, fall back
 // to streaming through ocifactory.
 func (h *Handler) handleTarballGet(w http.ResponseWriter, req *http.Request) {
-	scoped := h.scopedFor(req)
+	view := h.namespaceViewFor(req)
 	vars := mux.Vars(req)
 	pkg := vars["package"]
 	filename := vars["filename"]
@@ -741,14 +741,14 @@ func (h *Handler) handleTarballGet(w http.ResponseWriter, req *http.Request) {
 		MediaType:  "application/octet-stream",
 	}
 
-	if spec, isProxy, ok := h.dispatchProxy(w, req, scoped); !ok {
+	if spec, isProxy, ok := h.dispatchProxy(w, req, view); !ok {
 		return
 	} else if isProxy {
-		h.handleTarballGetProxy(w, req, scoped, spec, f)
+		h.handleTarballGetProxy(w, req, view, spec, f)
 		return
 	}
 
-	if !h.tryServeTarballFromRegistry(w, req, scoped, f) {
+	if !h.tryServeTarballFromRegistry(w, req, view, f) {
 		http.Error(w, "tarball not found", http.StatusNotFound)
 		return
 	}
@@ -758,17 +758,17 @@ func (h *Handler) handleTarballGet(w http.ResponseWriter, req *http.Request) {
 // alias-target map the same way [handlePackument] does.
 func (h *Handler) handleDistTagList(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
-	scoped := h.scopedFor(req)
+	view := h.namespaceViewFor(req)
 	pkg := mux.Vars(req)["package"]
 	if err := validatePackageName(pkg); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	if spec, isProxy, ok := h.dispatchProxy(w, req, scoped); !ok {
+	if spec, isProxy, ok := h.dispatchProxy(w, req, view); !ok {
 		return
 	} else if isProxy {
-		h.handleDistTagListProxy(w, req, scoped, spec, pkg)
+		h.handleDistTagListProxy(w, req, view, spec, pkg)
 		return
 	}
 
@@ -838,12 +838,12 @@ func (h *Handler) handleDistTagList(w http.ResponseWriter, req *http.Request) {
 // Body is a JSON-encoded version string ("1.2.3", quoted).
 func (h *Handler) handleDistTagPut(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
-	scoped := h.scopedFor(req)
+	view := h.namespaceViewFor(req)
 	vars := mux.Vars(req)
 	pkg := vars["package"]
 	tag := vars["tag"]
 
-	if _, isProxy, ok := h.dispatchProxy(w, req, scoped); !ok {
+	if _, isProxy, ok := h.dispatchProxy(w, req, view); !ok {
 		return
 	} else if isProxy {
 		http.Error(w, "dist-tag writes disabled on proxy namespaces", http.StatusMethodNotAllowed)
@@ -909,8 +909,8 @@ func (h *Handler) handleDistTagPut(w http.ResponseWriter, req *http.Request) {
 // removal is more surface than the v1 issue justifies. Operators
 // re-point unwanted dist-tags to a known version instead.
 func (h *Handler) handleDistTagDelete(w http.ResponseWriter, req *http.Request) {
-	scoped := h.scopedFor(req)
-	if _, isProxy, ok := h.dispatchProxy(w, req, scoped); !ok {
+	view := h.namespaceViewFor(req)
+	if _, isProxy, ok := h.dispatchProxy(w, req, view); !ok {
 		return
 	} else if isProxy {
 		http.Error(w, "dist-tag writes disabled on proxy namespaces", http.StatusMethodNotAllowed)
@@ -921,8 +921,8 @@ func (h *Handler) handleDistTagDelete(w http.ResponseWriter, req *http.Request) 
 
 // ensureIndexSentinel marks the package name in the per-format
 // namespace index.
-func (h *Handler) ensureIndexSentinel(ctx context.Context, scoped *artifact.ScopedNamespace, npmName string) error {
-	return scoped.Index(packageIndexName).Mark(ctx, npmName)
+func (h *Handler) ensureIndexSentinel(ctx context.Context, view *artifact.NamespaceView, npmName string) error {
+	return view.Index(packageIndexName).Mark(ctx, npmName)
 }
 
 // verifyChecksums recomputes the sha1 (dist.shasum) and sha512

--- a/pkg/handler/npm/handler.go
+++ b/pkg/handler/npm/handler.go
@@ -25,7 +25,6 @@ import (
 	"github.com/yolocs/ocifactory/pkg/artifact"
 	"github.com/yolocs/ocifactory/pkg/handler"
 	"github.com/yolocs/ocifactory/pkg/logging"
-	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
 	"github.com/yolocs/ocifactory/pkg/proxy/indexcache"
 	"oras.land/oras-go/v2/errdef"
@@ -84,7 +83,6 @@ const (
 // Handler is the npm format handler. Build one with [NewHandler] and
 // register its mux via [Handler.Mux].
 type Handler struct {
-	registry       *namespace.Registry
 	artifacts      *artifact.Store
 	authMW         func(http.Handler) http.Handler
 	maxUploadBytes int64
@@ -133,13 +131,13 @@ func WithMaxUploadBytes(n int64) Option {
 
 // NewHandler constructs a new npm format handler.
 //
-// registry is the data-plane wrapper that hands out per-request
-// [*namespace.ScopedRegistry] views via [namespace.Registry.For]. Every
+// artifacts is the data-plane wrapper that hands out per-request
+// [*artifact.ScopedNamespace] views via [artifact.Store.For]. Every
 // routed handler resolves the namespace from the request URL
 // (`/{namespace}/...`) and obtains a scoped view at the top.
-func NewHandler(registry *namespace.Registry, opts ...Option) (*Handler, error) {
-	if registry == nil {
-		return nil, errors.New("registry must not be nil")
+func NewHandler(artifacts *artifact.Store, opts ...Option) (*Handler, error) {
+	if artifacts == nil {
+		return nil, errors.New("artifact store must not be nil")
 	}
 	cfg := handlerConfig{
 		maxUploadBytes: DefaultMaxUploadBytes,
@@ -148,8 +146,7 @@ func NewHandler(registry *namespace.Registry, opts ...Option) (*Handler, error) 
 		opt(&cfg)
 	}
 	h := &Handler{
-		registry:       registry,
-		artifacts:      artifact.NewStore(registry),
+		artifacts:      artifacts,
 		authMW:         cfg.authMW,
 		maxUploadBytes: cfg.maxUploadBytes,
 	}
@@ -160,7 +157,7 @@ func NewHandler(registry *namespace.Registry, opts ...Option) (*Handler, error) 
 // Mux returns the npm handler's router. Every npm route lives under
 // `/{namespace}/...` so the handler resolves the namespace from the
 // URL on each request and routes through the namespace-scoped
-// registry view.
+// artifact view.
 func (h *Handler) Mux() http.Handler {
 	router := mux.NewRouter()
 	router.Use(mux.MiddlewareFunc(handler.RouteNameOpMiddleware))
@@ -207,10 +204,10 @@ func (h *Handler) Mux() http.Handler {
 	return router
 }
 
-// scopedFor returns the per-request [*namespace.ScopedRegistry] for
+// scopedFor returns the per-request [*artifact.ScopedNamespace] for
 // the namespace in req's URL. Cheap to construct; called per request.
-func (h *Handler) scopedFor(req *http.Request) *namespace.ScopedRegistry {
-	return h.registry.For(mux.Vars(req)["namespace"])
+func (h *Handler) scopedFor(req *http.Request) *artifact.ScopedNamespace {
+	return h.artifacts.For(mux.Vars(req)["namespace"])
 }
 
 func (h *Handler) artifactNamespaceFor(req *http.Request) (artifact.Namespace, error) {
@@ -907,7 +904,7 @@ func (h *Handler) handleDistTagPut(w http.ResponseWriter, req *http.Request) {
 }
 
 // handleDistTagDelete drops a dist-tag alias. v1 returns 501 with a
-// JSON body — the namespace wrapper does not yet expose a single-tag
+// JSON body — the artifact data-plane wrapper does not yet expose a single-tag
 // delete from the data plane, and adding one purely for dist-tag
 // removal is more surface than the v1 issue justifies. Operators
 // re-point unwanted dist-tags to a known version instead.
@@ -924,7 +921,7 @@ func (h *Handler) handleDistTagDelete(w http.ResponseWriter, req *http.Request) 
 
 // ensureIndexSentinel marks the package name in the per-format
 // namespace index.
-func (h *Handler) ensureIndexSentinel(ctx context.Context, scoped *namespace.ScopedRegistry, npmName string) error {
+func (h *Handler) ensureIndexSentinel(ctx context.Context, scoped *artifact.ScopedNamespace, npmName string) error {
 	return scoped.Index(packageIndexName).Mark(ctx, npmName)
 }
 

--- a/pkg/handler/npm/handler.go
+++ b/pkg/handler/npm/handler.go
@@ -543,7 +543,12 @@ func (h *Handler) handlePackument(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	out, status, err := h.buildPackument(ctx, req, scoped, pkg)
+	artifactNS, err := h.artifactNamespaceFor(req)
+	if err != nil {
+		h.writeRegistryError(ctx, w, err, "failed to resolve namespace")
+		return
+	}
+	out, status, err := h.buildPackument(ctx, req, artifactNS.Package(packageOwningRepo(pkg)), pkg)
 	if err != nil {
 		if status == http.StatusNotFound {
 			http.Error(w, "package not found", http.StatusNotFound)
@@ -569,10 +574,8 @@ func (h *Handler) handlePackument(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
-func (h *Handler) buildPackument(ctx context.Context, req *http.Request, scoped handler.Registry, pkg string) (*packument, int, error) {
-	repo := packageOwningRepo(pkg)
-
-	files, err := scoped.ListFiles(ctx, repo)
+func (h *Handler) buildPackument(ctx context.Context, req *http.Request, artifactPkg artifact.Package, pkg string) (*packument, int, error) {
+	files, err := artifactPkg.ListFiles(ctx, artifact.ListFilesOptions{})
 	if err != nil {
 		if errors.Is(err, errdef.ErrNotFound) {
 			return nil, http.StatusNotFound, err
@@ -594,10 +597,10 @@ func (h *Handler) buildPackument(ctx context.Context, req *http.Request, scoped 
 	}
 	byVersion := map[string]*versionFiles{}
 	for _, f := range files {
-		vf, ok := byVersion[f.OwningTag]
+		vf, ok := byVersion[f.Version]
 		if !ok {
 			vf = &versionFiles{}
-			byVersion[f.OwningTag] = vf
+			byVersion[f.Version] = vf
 		}
 		switch {
 		case f.Name == versionMetaName:
@@ -626,13 +629,11 @@ func (h *Handler) buildPackument(ctx context.Context, req *http.Request, scoped 
 		}
 		canonicalSet[version] = struct{}{}
 
-		metaRF := &oci.RepoFile{
-			OwningRepo: repo,
-			OwningTag:  version,
-			Name:       versionMetaName,
-			MediaType:  "application/json",
+		handle, err := artifactPkg.GetFile(ctx, version, versionMetaName)
+		if err != nil {
+			return nil, 0, err
 		}
-		_, rc, err := scoped.ReadFile(ctx, metaRF)
+		rc, err := handle.Open(ctx)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -684,43 +685,23 @@ func (h *Handler) buildPackument(ctx context.Context, req *http.Request, scoped 
 		return nil, http.StatusNotFound, errdef.ErrNotFound
 	}
 
-	// Resolve dist-tags. Every tag that ListTags returns but
-	// ListFiles didn't cover (those are the canonical versions) is
-	// an alias. We resolve each alias by fetching its package.json
-	// via RefTag and matching the descriptor digest back against
-	// the canonical version we already know.
-	allTags, tagErr := scoped.ListTags(ctx, repo)
+	// Resolve dist-tags. The artifact layer filters canonical versions
+	// out of ListTags, so every returned tag is an alias we can resolve
+	// directly to its target version instead of inferring the target by
+	// reading package.json through the alias and matching blob digests.
+	allTags, tagErr := artifactPkg.ListTags(ctx)
 	if tagErr != nil && !errors.Is(tagErr, errdef.ErrNotFound) {
 		return nil, 0, tagErr
 	}
-	digestByVersion := map[string]string{}
-	for version, vf := range byVersion {
-		if vf.metaDigest != "" {
-			digestByVersion[vf.metaDigest] = version
-		}
-	}
 	for _, tag := range allTags {
-		if _, isCanonical := canonicalSet[tag]; isCanonical {
-			continue
-		}
-		aliasRF := &oci.RepoFile{
-			OwningRepo: repo,
-			RefTag:     tag,
-			Name:       versionMetaName,
-			MediaType:  "application/json",
-		}
-		desc, rc, err := scoped.ReadFile(ctx, aliasRF)
+		target, err := artifactPkg.ResolveTag(ctx, tag.Name)
 		if err != nil {
-			// Stray alias we can't resolve — skip rather than
-			// failing the whole packument.
 			continue
 		}
-		_ = rc.Close()
-		target := digestByVersion[desc.File.Digest.String()]
-		if target == "" {
+		if _, ok := canonicalSet[target.Name]; !ok {
 			continue
 		}
-		out.DistTags[tag] = target
+		out.DistTags[tag.Name] = target.Name
 	}
 
 	// No server-side fallback for an unset "latest" dist-tag. The
@@ -794,18 +775,14 @@ func (h *Handler) handleDistTagList(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	repo := packageOwningRepo(pkg)
-
-	tags, err := scoped.ListTags(ctx, repo)
+	artifactNS, err := h.artifactNamespaceFor(req)
 	if err != nil {
-		if errors.Is(err, errdef.ErrNotFound) {
-			http.Error(w, "package not found", http.StatusNotFound)
-			return
-		}
-		h.writeRegistryError(ctx, w, err, "failed to list tags")
+		h.writeRegistryError(ctx, w, err, "failed to resolve namespace")
 		return
 	}
-	files, err := scoped.ListFiles(ctx, repo)
+	artifactPkg := artifactNS.Package(packageOwningRepo(pkg))
+
+	files, err := artifactPkg.ListFiles(ctx, artifact.ListFilesOptions{})
 	if err != nil {
 		if errors.Is(err, errdef.ErrNotFound) {
 			http.Error(w, "package not found", http.StatusNotFound)
@@ -827,33 +804,30 @@ func (h *Handler) handleDistTagList(w http.ResponseWriter, req *http.Request) {
 	}
 
 	canonicalSet := map[string]struct{}{}
-	digestByVersion := map[string]string{}
 	for _, f := range files {
-		canonicalSet[f.OwningTag] = struct{}{}
-		if f.Name == versionMetaName {
-			digestByVersion[f.Digest] = f.OwningTag
+		canonicalSet[f.Version] = struct{}{}
+	}
+
+	tags, err := artifactPkg.ListTags(ctx)
+	if err != nil {
+		if errors.Is(err, errdef.ErrNotFound) {
+			http.Error(w, "package not found", http.StatusNotFound)
+			return
 		}
+		h.writeRegistryError(ctx, w, err, "failed to list tags")
+		return
 	}
 
 	out := map[string]string{}
 	for _, tag := range tags {
-		if _, isCanonical := canonicalSet[tag]; isCanonical {
-			continue
-		}
-		aliasRF := &oci.RepoFile{
-			OwningRepo: repo,
-			RefTag:     tag,
-			Name:       versionMetaName,
-			MediaType:  "application/json",
-		}
-		desc, rc, err := scoped.ReadFile(ctx, aliasRF)
+		target, err := artifactPkg.ResolveTag(ctx, tag.Name)
 		if err != nil {
 			continue
 		}
-		_ = rc.Close()
-		if v, ok := digestByVersion[desc.File.Digest.String()]; ok {
-			out[tag] = v
+		if _, ok := canonicalSet[target.Name]; !ok {
+			continue
 		}
+		out[tag.Name] = target.Name
 	}
 
 	w.Header().Set("Content-Type", distTagsMediaType)

--- a/pkg/handler/npm/namespace_test.go
+++ b/pkg/handler/npm/namespace_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/yolocs/ocifactory/pkg/artifact"
 	"github.com/yolocs/ocifactory/pkg/auth"
 	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
@@ -20,7 +21,7 @@ func TestNamespace_UnknownNamespace404(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	authMW := auth.Middleware(auth.AlwaysAnonymous)
 	h, err := NewHandler(reg, WithAuthMiddleware(authMW))
 	if err != nil {
@@ -56,7 +57,7 @@ func TestNamespace_InvalidNamespaceName400(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	authMW := auth.Middleware(auth.AlwaysAnonymous)
 	h, err := NewHandler(reg, WithAuthMiddleware(authMW))
 	if err != nil {
@@ -78,7 +79,7 @@ func TestNamespace_NotInReadersForbidden(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	putNamespace(t, store, testNS, namespace.Spec{Policy: namespace.Policy{
 		Readers: []namespace.SubjectMatcher{{Issuer: "https://accounts.google.com"}},
 		Writers: []namespace.SubjectMatcher{{Issuer: "https://accounts.google.com"}},
@@ -105,7 +106,7 @@ func TestNamespace_NotInWritersForbiddenOnPublish(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	putNamespace(t, store, testNS, namespace.Spec{Policy: namespace.Policy{
 		Readers: []namespace.SubjectMatcher{{Issuer: "anonymous"}},
 		Writers: []namespace.SubjectMatcher{{Issuer: "https://accounts.google.com"}},
@@ -130,7 +131,7 @@ func TestNamespace_CrossNamespaceIsolation(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	putNamespace(t, store, "alpha", namespace.Spec{Policy: allowAllPolicy()})
 	putNamespace(t, store, "beta", namespace.Spec{Policy: allowAllPolicy()})
 

--- a/pkg/handler/npm/proxy.go
+++ b/pkg/handler/npm/proxy.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/sync/singleflight"
 	"oras.land/oras-go/v2/errdef"
 
+	"github.com/yolocs/ocifactory/pkg/artifact"
 	"github.com/yolocs/ocifactory/pkg/auth"
 	"github.com/yolocs/ocifactory/pkg/handler"
 	"github.com/yolocs/ocifactory/pkg/logging"
@@ -161,7 +162,7 @@ func WithProxyL1IndexCacheTTL(d time.Duration) Option {
 	return func(c *handlerConfig) { c.proxyL1IndexCacheTTL = d }
 }
 
-func (h *Handler) dispatchProxy(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry) (*namespace.Spec, bool, bool) {
+func (h *Handler) dispatchProxy(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace) (*namespace.Spec, bool, bool) {
 	spec, err := scoped.Spec(req.Context())
 	if err != nil {
 		if handler.WriteNamespaceError(w, err) {
@@ -174,7 +175,7 @@ func (h *Handler) dispatchProxy(w http.ResponseWriter, req *http.Request, scoped
 	return spec, isProxy, true
 }
 
-func (h *Handler) handlePackumentProxy(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry, spec *namespace.Spec, pkg string) {
+func (h *Handler) handlePackumentProxy(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, spec *namespace.Spec, pkg string) {
 	ctx := req.Context()
 	if err := scoped.Authorize(ctx, auth.OpRead); err != nil {
 		if handler.WriteNamespaceError(w, err) {
@@ -205,7 +206,7 @@ func (h *Handler) handlePackumentProxy(w http.ResponseWriter, req *http.Request,
 	h.synthesizePackument(w, req, scoped, pkg, err)
 }
 
-func (h *Handler) handleDistTagListProxy(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry, spec *namespace.Spec, pkg string) {
+func (h *Handler) handleDistTagListProxy(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, spec *namespace.Spec, pkg string) {
 	ctx := req.Context()
 	if err := scoped.Authorize(ctx, auth.OpRead); err != nil {
 		if handler.WriteNamespaceError(w, err) {
@@ -250,7 +251,7 @@ type proxyPackumentResult struct {
 	contentType string
 }
 
-func (h *Handler) loadPackumentProxy(ctx context.Context, scoped *namespace.ScopedRegistry, spec *namespace.Spec, pkg string) (proxyPackumentResult, error) {
+func (h *Handler) loadPackumentProxy(ctx context.Context, scoped *artifact.ScopedNamespace, spec *namespace.Spec, pkg string) (proxyPackumentResult, error) {
 	logger := logging.FromContext(ctx)
 	ns := scoped.Namespace()
 	cacheKey := ns + "|" + pkg
@@ -333,7 +334,7 @@ type indexFlightResult struct {
 	contentType string
 }
 
-func (h *Handler) synthesizePackument(w http.ResponseWriter, req *http.Request, _ *namespace.ScopedRegistry, pkg string, upstreamErr error) {
+func (h *Handler) synthesizePackument(w http.ResponseWriter, req *http.Request, _ *artifact.ScopedNamespace, pkg string, upstreamErr error) {
 	ctx := req.Context()
 	artifactNS, nsErr := h.artifactNamespaceFor(req)
 	if nsErr != nil {
@@ -358,7 +359,7 @@ func (h *Handler) synthesizePackument(w http.ResponseWriter, req *http.Request, 
 	_ = json.NewEncoder(w).Encode(out)
 }
 
-func (h *Handler) handleTarballGetProxy(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry, spec *namespace.Spec, f *oci.RepoFile) {
+func (h *Handler) handleTarballGetProxy(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, spec *namespace.Spec, f *oci.RepoFile) {
 	ctx := req.Context()
 	logger := logging.FromContext(ctx)
 
@@ -550,7 +551,7 @@ type fileFlightResult struct {
 	filterName string
 }
 
-func (h *Handler) peekTarball(ctx context.Context, scoped *namespace.ScopedRegistry, f *oci.RepoFile) (bool, error) {
+func (h *Handler) peekTarball(ctx context.Context, scoped *artifact.ScopedNamespace, f *oci.RepoFile) (bool, error) {
 	_, rc, err := scoped.ReadFile(ctx, f)
 	if err != nil {
 		if errors.Is(err, errdef.ErrNotFound) {
@@ -562,7 +563,7 @@ func (h *Handler) peekTarball(ctx context.Context, scoped *namespace.ScopedRegis
 	return true, nil
 }
 
-func (h *Handler) tryServeTarballFromRegistry(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry, f *oci.RepoFile) bool {
+func (h *Handler) tryServeTarballFromRegistry(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, f *oci.RepoFile) bool {
 	ctx := req.Context()
 	logger := logging.FromContext(ctx)
 	if req.Method != http.MethodHead {

--- a/pkg/handler/npm/proxy.go
+++ b/pkg/handler/npm/proxy.go
@@ -333,9 +333,15 @@ type indexFlightResult struct {
 	contentType string
 }
 
-func (h *Handler) synthesizePackument(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry, pkg string, upstreamErr error) {
+func (h *Handler) synthesizePackument(w http.ResponseWriter, req *http.Request, _ *namespace.ScopedRegistry, pkg string, upstreamErr error) {
 	ctx := req.Context()
-	out, status, err := h.buildPackument(ctx, req, scoped, pkg)
+	artifactNS, nsErr := h.artifactNamespaceFor(req)
+	if nsErr != nil {
+		handler.WriteError(ctx, w, http.StatusServiceUnavailable, upstreamErr,
+			fmt.Sprintf("upstream unavailable and namespace lookup failed: %v", nsErr))
+		return
+	}
+	out, status, err := h.buildPackument(ctx, req, artifactNS.Package(packageOwningRepo(pkg)), pkg)
 	if err != nil {
 		if status == http.StatusNotFound {
 			handler.WriteError(ctx, w, http.StatusServiceUnavailable, upstreamErr, "upstream unavailable, no cached packument")

--- a/pkg/handler/npm/proxy.go
+++ b/pkg/handler/npm/proxy.go
@@ -162,8 +162,8 @@ func WithProxyL1IndexCacheTTL(d time.Duration) Option {
 	return func(c *handlerConfig) { c.proxyL1IndexCacheTTL = d }
 }
 
-func (h *Handler) dispatchProxy(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace) (*namespace.Spec, bool, bool) {
-	spec, err := scoped.Spec(req.Context())
+func (h *Handler) dispatchProxy(w http.ResponseWriter, req *http.Request, view *artifact.NamespaceView) (*namespace.Spec, bool, bool) {
+	spec, err := view.Spec(req.Context())
 	if err != nil {
 		if handler.WriteNamespaceError(w, err) {
 			return nil, false, false
@@ -175,9 +175,9 @@ func (h *Handler) dispatchProxy(w http.ResponseWriter, req *http.Request, scoped
 	return spec, isProxy, true
 }
 
-func (h *Handler) handlePackumentProxy(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, spec *namespace.Spec, pkg string) {
+func (h *Handler) handlePackumentProxy(w http.ResponseWriter, req *http.Request, view *artifact.NamespaceView, spec *namespace.Spec, pkg string) {
 	ctx := req.Context()
-	if err := scoped.Authorize(ctx, auth.OpRead); err != nil {
+	if err := view.Authorize(ctx, auth.OpRead); err != nil {
 		if handler.WriteNamespaceError(w, err) {
 			return
 		}
@@ -185,7 +185,7 @@ func (h *Handler) handlePackumentProxy(w http.ResponseWriter, req *http.Request,
 		return
 	}
 
-	result, err := h.loadPackumentProxy(ctx, scoped, spec, pkg)
+	result, err := h.loadPackumentProxy(ctx, view, spec, pkg)
 	if err == nil {
 		writeProxyPackumentBody(w, req, result.body, result.contentType)
 		return
@@ -203,12 +203,12 @@ func (h *Handler) handlePackumentProxy(w http.ResponseWriter, req *http.Request,
 		handler.WriteError(ctx, w, http.StatusInternalServerError, err, "proxy fetcher unavailable")
 		return
 	}
-	h.synthesizePackument(w, req, scoped, pkg, err)
+	h.synthesizePackument(w, req, view, pkg, err)
 }
 
-func (h *Handler) handleDistTagListProxy(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, spec *namespace.Spec, pkg string) {
+func (h *Handler) handleDistTagListProxy(w http.ResponseWriter, req *http.Request, view *artifact.NamespaceView, spec *namespace.Spec, pkg string) {
 	ctx := req.Context()
-	if err := scoped.Authorize(ctx, auth.OpRead); err != nil {
+	if err := view.Authorize(ctx, auth.OpRead); err != nil {
 		if handler.WriteNamespaceError(w, err) {
 			return
 		}
@@ -216,7 +216,7 @@ func (h *Handler) handleDistTagListProxy(w http.ResponseWriter, req *http.Reques
 		return
 	}
 
-	result, err := h.loadPackumentProxy(ctx, scoped, spec, pkg)
+	result, err := h.loadPackumentProxy(ctx, view, spec, pkg)
 	if err != nil {
 		switch {
 		case errors.Is(err, proxy.ErrNotFound):
@@ -251,9 +251,9 @@ type proxyPackumentResult struct {
 	contentType string
 }
 
-func (h *Handler) loadPackumentProxy(ctx context.Context, scoped *artifact.ScopedNamespace, spec *namespace.Spec, pkg string) (proxyPackumentResult, error) {
+func (h *Handler) loadPackumentProxy(ctx context.Context, view *artifact.NamespaceView, spec *namespace.Spec, pkg string) (proxyPackumentResult, error) {
 	logger := logging.FromContext(ctx)
-	ns := scoped.Namespace()
+	ns := view.Namespace()
 	cacheKey := ns + "|" + pkg
 	indexKey := proxyIndexCacheKey(pkg)
 
@@ -334,7 +334,7 @@ type indexFlightResult struct {
 	contentType string
 }
 
-func (h *Handler) synthesizePackument(w http.ResponseWriter, req *http.Request, _ *artifact.ScopedNamespace, pkg string, upstreamErr error) {
+func (h *Handler) synthesizePackument(w http.ResponseWriter, req *http.Request, _ *artifact.NamespaceView, pkg string, upstreamErr error) {
 	ctx := req.Context()
 	artifactNS, nsErr := h.artifactNamespaceFor(req)
 	if nsErr != nil {
@@ -359,11 +359,11 @@ func (h *Handler) synthesizePackument(w http.ResponseWriter, req *http.Request, 
 	_ = json.NewEncoder(w).Encode(out)
 }
 
-func (h *Handler) handleTarballGetProxy(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, spec *namespace.Spec, f *oci.RepoFile) {
+func (h *Handler) handleTarballGetProxy(w http.ResponseWriter, req *http.Request, view *artifact.NamespaceView, spec *namespace.Spec, f *oci.RepoFile) {
 	ctx := req.Context()
 	logger := logging.FromContext(ctx)
 
-	if h.tryServeTarballFromRegistry(w, req, scoped, f) {
+	if h.tryServeTarballFromRegistry(w, req, view, f) {
 		return
 	}
 
@@ -376,7 +376,7 @@ func (h *Handler) handleTarballGetProxy(w http.ResponseWriter, req *http.Request
 	filename := f.Name
 
 	if h.proxy.negCache != nil {
-		key := negativeKey(scoped.Namespace(), pkg, version, filename)
+		key := negativeKey(view.Namespace(), pkg, version, filename)
 		if h.proxy.negCache.IsKnownMissing(key) {
 			http.Error(w, "not found", http.StatusNotFound)
 			return
@@ -400,13 +400,13 @@ func (h *Handler) handleTarballGetProxy(w http.ResponseWriter, req *http.Request
 		return
 	}
 
-	key := scoped.Namespace() + "|" + f.OwningRepo + "|" + version + "|" + filename
+	key := view.Namespace() + "|" + f.OwningRepo + "|" + version + "|" + filename
 	isHead := req.Method == http.MethodHead
 	amLeader := false
 	var teeRef *tolerantWriter
 	resultV, err, _ := h.proxy.fileFlight.Do(key, func() (any, error) {
 		amLeader = true
-		if hit, hitErr := h.peekTarball(ctx, scoped, f); hitErr == nil && hit {
+		if hit, hitErr := h.peekTarball(ctx, view, f); hitErr == nil && hit {
 			return fileFlightResult{cached: true}, nil
 		}
 
@@ -427,7 +427,7 @@ func (h *Handler) handleTarballGetProxy(w http.ResponseWriter, req *http.Request
 		var rewrittenPackument []byte
 		packumentContentType := resp.PackumentContentType
 		if resp.Packument != nil {
-			if body, rerr := proxynpm.RewritePackument(resp.Packument, scoped.Namespace(), pkg); rerr == nil {
+			if body, rerr := proxynpm.RewritePackument(resp.Packument, view.Namespace(), pkg); rerr == nil {
 				rewrittenPackument = body
 			} else {
 				logger.DebugContext(ctx, "npm packument rewrite during tarball fill failed", "error", rerr)
@@ -450,14 +450,14 @@ func (h *Handler) handleTarballGetProxy(w http.ResponseWriter, req *http.Request
 			teeRef = &tolerantWriter{w: w}
 			body = io.TeeReader(body, teeRef)
 		}
-		if _, addErr := scoped.AddCachedFile(ctx, populated, body); addErr != nil {
+		if _, addErr := view.AddCachedFile(ctx, populated, body); addErr != nil {
 			if errors.Is(addErr, oci.ErrAlreadyExists) {
 				return fileFlightResult{cached: true}, nil
 			}
 			return fileFlightResult{}, addErr
 		}
 		if len(rewrittenPackument) > 0 {
-			h.cachePackument(ctx, scoped.Namespace(), pkg, rewrittenPackument, packumentContentType)
+			h.cachePackument(ctx, view.Namespace(), pkg, rewrittenPackument, packumentContentType)
 		}
 		if len(resp.Version) > 0 {
 			metaRF := &oci.RepoFile{
@@ -467,11 +467,11 @@ func (h *Handler) handleTarballGetProxy(w http.ResponseWriter, req *http.Request
 				MediaType:  "application/json",
 				Size:       int64(len(resp.Version)),
 			}
-			if _, addErr := scoped.AddCachedFile(ctx, metaRF, bytes.NewReader(resp.Version)); addErr != nil && !errors.Is(addErr, oci.ErrAlreadyExists) {
+			if _, addErr := view.AddCachedFile(ctx, metaRF, bytes.NewReader(resp.Version)); addErr != nil && !errors.Is(addErr, oci.ErrAlreadyExists) {
 				return fileFlightResult{}, addErr
 			}
 		}
-		if err := h.ensureIndexSentinel(ctx, scoped, pkg); err != nil {
+		if err := h.ensureIndexSentinel(ctx, view, pkg); err != nil {
 			logger.DebugContext(ctx, "npm proxy index sentinel write failed", "error", err)
 		}
 		return fileFlightResult{streamed: true}, nil
@@ -485,7 +485,7 @@ func (h *Handler) handleTarballGetProxy(w http.ResponseWriter, req *http.Request
 		switch {
 		case errors.Is(err, proxy.ErrNotFound):
 			if h.proxy.negCache != nil {
-				h.proxy.negCache.RecordMiss(negativeKey(scoped.Namespace(), pkg, version, filename))
+				h.proxy.negCache.RecordMiss(negativeKey(view.Namespace(), pkg, version, filename))
 			}
 			http.Error(w, "not found", http.StatusNotFound)
 		case errors.Is(err, proxy.ErrUpstreamMalformed):
@@ -509,7 +509,7 @@ func (h *Handler) handleTarballGetProxy(w http.ResponseWriter, req *http.Request
 	if result.streamed && amLeader && !isHead {
 		return
 	}
-	if h.tryServeTarballFromRegistry(w, req, scoped, f) {
+	if h.tryServeTarballFromRegistry(w, req, view, f) {
 		return
 	}
 	handler.WriteError(ctx, w, http.StatusBadGateway, nil, "proxy fill reported success but cache miss on re-read")
@@ -551,8 +551,8 @@ type fileFlightResult struct {
 	filterName string
 }
 
-func (h *Handler) peekTarball(ctx context.Context, scoped *artifact.ScopedNamespace, f *oci.RepoFile) (bool, error) {
-	_, rc, err := scoped.ReadFile(ctx, f)
+func (h *Handler) peekTarball(ctx context.Context, view *artifact.NamespaceView, f *oci.RepoFile) (bool, error) {
+	_, rc, err := view.ReadFile(ctx, f)
 	if err != nil {
 		if errors.Is(err, errdef.ErrNotFound) {
 			return false, nil
@@ -563,18 +563,18 @@ func (h *Handler) peekTarball(ctx context.Context, scoped *artifact.ScopedNamesp
 	return true, nil
 }
 
-func (h *Handler) tryServeTarballFromRegistry(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, f *oci.RepoFile) bool {
+func (h *Handler) tryServeTarballFromRegistry(w http.ResponseWriter, req *http.Request, view *artifact.NamespaceView, f *oci.RepoFile) bool {
 	ctx := req.Context()
 	logger := logging.FromContext(ctx)
 	if req.Method != http.MethodHead {
-		if redirectURL, err := scoped.BlobRedirectURL(ctx, f); err == nil && redirectURL != "" {
+		if redirectURL, err := view.BlobRedirectURL(ctx, f); err == nil && redirectURL != "" {
 			http.Redirect(w, req, redirectURL, http.StatusTemporaryRedirect)
 			return true
 		} else if err != nil {
 			logger.DebugContext(ctx, "npm tarball redirect probe failed; streaming", "error", err)
 		}
 	}
-	desc, rc, err := scoped.ReadFile(ctx, f)
+	desc, rc, err := view.ReadFile(ctx, f)
 	if err != nil {
 		if errors.Is(err, errdef.ErrNotFound) {
 			return false

--- a/pkg/handler/npm/proxy_test.go
+++ b/pkg/handler/npm/proxy_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/yolocs/ocifactory/pkg/artifact"
 	"github.com/yolocs/ocifactory/pkg/auth"
 	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
@@ -83,7 +84,7 @@ func newProxyTestHandler(t *testing.T, fetcher ProxyFetcher, spec namespace.Spec
 	t.Helper()
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 
 	if spec.Mode == "" {
 		spec.Mode = namespace.ModeProxy

--- a/pkg/handler/npm/testutil_test.go
+++ b/pkg/handler/npm/testutil_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/yolocs/ocifactory/pkg/artifact"
 	"github.com/yolocs/ocifactory/pkg/auth"
 	"github.com/yolocs/ocifactory/pkg/namespace"
 )
@@ -23,7 +24,7 @@ const testNS = "test-ns"
 
 // allowAllPolicy admits the anonymous-issuer AuthContext produced by
 // [auth.AlwaysAnonymous] (the authenticator newTestHandler wires up
-// by default so the namespace wrapper has a verified subject to
+// by default so the artifact data-plane wrapper has a verified subject to
 // authorize). Tests exercising specific policy behaviours pass a
 // custom spec to [putNamespace].
 func allowAllPolicy() namespace.Policy {
@@ -34,14 +35,14 @@ func allowAllPolicy() namespace.Policy {
 }
 
 // newTestHandler builds an npm [*Handler] wired to a
-// [*namespace.Registry] backed by inner. A "test-ns" namespace with
+// [*artifact.Store] backed by inner. A "test-ns" namespace with
 // an allow-all policy is registered; the auth middleware installs
 // the [auth.AlwaysAnonymous] AuthContext on every request so the
 // wrapper has a subject to authorize.
-func newTestHandler(t *testing.T, inner namespace.RegistryBackend, opts ...Option) (*Handler, *namespace.Store) {
+func newTestHandler(t *testing.T, inner artifact.Backend, opts ...Option) (*Handler, *namespace.Store) {
 	t.Helper()
 	store := namespace.NewStore(inner)
-	reg := namespace.NewRegistry(inner, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(inner, store, artifact.WithPolicyCacheTTL(0))
 	if err := store.Put(t.Context(), &namespace.Namespace{Name: testNS, Spec: namespace.Spec{Policy: allowAllPolicy()}}); err != nil {
 		t.Fatalf("Put namespace: %v", err)
 	}

--- a/pkg/handler/python/auth_test.go
+++ b/pkg/handler/python/auth_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/yolocs/ocifactory/pkg/artifact"
 	"github.com/yolocs/ocifactory/pkg/auth"
 	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
@@ -12,7 +13,7 @@ import (
 
 // TestMux_AuthGating wires a python handler with an auth middleware
 // that always 401s and confirms every namespaced route hits the gate
-// (i.e. the handler itself is NOT reached, and the namespace wrapper
+// (i.e. the handler itself is NOT reached, and the artifact data-plane wrapper
 // has no chance to deny first).
 func TestMux_AuthGating(t *testing.T) {
 	t.Parallel()
@@ -25,7 +26,7 @@ func TestMux_AuthGating(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	// A namespace registration is not even required — the denyAll
 	// middleware short-circuits before the wrapper sees the request.
 	h, err := NewHandler(reg, WithAuthMiddleware(denyAll))
@@ -60,7 +61,7 @@ func TestMux_AuthGating(t *testing.T) {
 // TestMux_NoAuthMiddleware confirms that omitting WithAuthMiddleware
 // leaves the chain ungated at the middleware layer — production
 // wiring (cmd/ocifactory serve) always supplies one. With no
-// AuthContext on the request the namespace wrapper denies the call
+// AuthContext on the request the artifact data-plane wrapper denies the call
 // at 403, which is what the test asserts here: the failure mode is
 // "no auth context" (403), NOT "auth middleware rejected" (401). The
 // AGENTS.md rule for adding new format handlers reminds authors to
@@ -70,7 +71,7 @@ func TestMux_NoAuthMiddleware(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	putNamespace(t, store, testNS, namespace.Spec{Policy: allowAllPolicy()})
 
 	h, err := NewHandler(reg)
@@ -82,7 +83,7 @@ func TestMux_NoAuthMiddleware(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.Mux().ServeHTTP(w, r)
 	if got := w.Code; got == http.StatusUnauthorized {
-		t.Errorf("status = 401 with no middleware configured; the namespace wrapper, not the middleware, should deny")
+		t.Errorf("status = 401 with no middleware configured; the artifact data-plane wrapper, not the middleware, should deny")
 	}
 	if got, want := w.Code, http.StatusForbidden; got != want {
 		t.Errorf("status = %d, want %d (no AuthContext → wrapper denies)", got, want)
@@ -101,7 +102,7 @@ func TestMux_AuthChainsBeforeHandler(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	putNamespace(t, store, testNS, namespace.Spec{Policy: allowAllPolicy()})
 
 	h, err := NewHandler(reg, WithAuthMiddleware(installer))

--- a/pkg/handler/python/handler.go
+++ b/pkg/handler/python/handler.go
@@ -19,7 +19,6 @@ import (
 	"github.com/yolocs/ocifactory/pkg/artifact"
 	"github.com/yolocs/ocifactory/pkg/handler"
 	"github.com/yolocs/ocifactory/pkg/logging"
-	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
 	"github.com/yolocs/ocifactory/pkg/proxy/indexcache"
 	"github.com/yolocs/ocifactory/pkg/renderer"
@@ -95,7 +94,6 @@ var (
 )
 
 type Handler struct {
-	registry       *namespace.Registry
 	artifacts      *artifact.Store
 	renderer       *renderer.Renderer
 	indexCache     *simpleIndexCache
@@ -197,12 +195,12 @@ func WithAuthMiddleware(mw func(http.Handler) http.Handler) Option {
 
 // NewHandler creates a new Handler.
 //
-// registry is the data-plane wrapper that hands out per-request
-// [*namespace.ScopedRegistry] views via [registry.For]. Every routed
+// artifacts is the data-plane wrapper that hands out per-request
+// [*artifact.ScopedNamespace] views via [artifact.Store.For]. Every routed
 // handler func resolves the namespace from the request URL
 // (`/{namespace}/...`) and obtains a scoped view at the top — call
 // sites otherwise stay identical to the pre-namespace code.
-func NewHandler(registry *namespace.Registry, opts ...Option) (*Handler, error) {
+func NewHandler(artifacts *artifact.Store, opts ...Option) (*Handler, error) {
 	cfg := handlerConfig{
 		simpleIndexCacheTTL: DefaultSimpleIndexCacheTTL,
 		maxUploadBytes:      DefaultMaxUploadBytes,
@@ -215,8 +213,7 @@ func NewHandler(registry *namespace.Registry, opts ...Option) (*Handler, error) 
 		return nil, fmt.Errorf("failed to create renderer: %w", err)
 	}
 	h := &Handler{
-		registry:       registry,
-		artifacts:      artifact.NewStore(registry),
+		artifacts:      artifacts,
 		renderer:       r,
 		indexCache:     newSimpleIndexCache(cfg.simpleIndexCacheTTL),
 		authMW:         cfg.authMW,
@@ -230,7 +227,7 @@ func NewHandler(registry *namespace.Registry, opts ...Option) (*Handler, error) 
 //
 // Every route lives under a `/{namespace}` subrouter so the handler
 // resolves the namespace from the URL on each request and routes the
-// backend op through the namespace-scoped registry view. The leading
+// backend op through the namespace-scoped artifact view. The leading
 // segment is rejected by [namespace.ValidateName] at namespace-Put
 // time, not here — a request to an unregistered namespace produces a
 // 404 from the wrapper.
@@ -269,12 +266,12 @@ func (h *Handler) Mux() http.Handler {
 	return router
 }
 
-// scopedFor returns the per-request [*namespace.ScopedRegistry] for
+// scopedFor returns the per-request [*artifact.ScopedNamespace] for
 // the namespace in req's URL. The view is cheap to construct (a small
 // struct, no I/O) so handlers obtain it per call rather than caching
 // across requests.
-func (h *Handler) scopedFor(req *http.Request) *namespace.ScopedRegistry {
-	return h.registry.For(mux.Vars(req)["namespace"])
+func (h *Handler) scopedFor(req *http.Request) *artifact.ScopedNamespace {
+	return h.artifacts.For(mux.Vars(req)["namespace"])
 }
 
 func (h *Handler) artifactNamespaceFor(req *http.Request) (artifact.Namespace, error) {
@@ -521,7 +518,7 @@ func (h *Handler) handleFilePut(w http.ResponseWriter, req *http.Request) {
 
 // ensureIndexSentinel marks the normalized package name in the
 // per-format namespace index.
-func (h *Handler) ensureIndexSentinel(ctx context.Context, scoped *namespace.ScopedRegistry, normalizedName string) error {
+func (h *Handler) ensureIndexSentinel(ctx context.Context, scoped *artifact.ScopedNamespace, normalizedName string) error {
 	return scoped.Index(packageIndexName).Mark(ctx, normalizedName)
 }
 

--- a/pkg/handler/python/handler.go
+++ b/pkg/handler/python/handler.go
@@ -196,9 +196,9 @@ func WithAuthMiddleware(mw func(http.Handler) http.Handler) Option {
 // NewHandler creates a new Handler.
 //
 // artifacts is the data-plane wrapper that hands out per-request
-// [*artifact.ScopedNamespace] views via [artifact.Store.For]. Every routed
+// [*artifact.NamespaceView] views via [artifact.Store.View]. Every routed
 // handler func resolves the namespace from the request URL
-// (`/{namespace}/...`) and obtains a scoped view at the top — call
+// (`/{namespace}/...`) and obtains a view view at the top — call
 // sites otherwise stay identical to the pre-namespace code.
 func NewHandler(artifacts *artifact.Store, opts ...Option) (*Handler, error) {
 	cfg := handlerConfig{
@@ -227,7 +227,7 @@ func NewHandler(artifacts *artifact.Store, opts ...Option) (*Handler, error) {
 //
 // Every route lives under a `/{namespace}` subrouter so the handler
 // resolves the namespace from the URL on each request and routes the
-// backend op through the namespace-scoped artifact view. The leading
+// backend op through the namespace-view artifact view. The leading
 // segment is rejected by [namespace.ValidateName] at namespace-Put
 // time, not here — a request to an unregistered namespace produces a
 // 404 from the wrapper.
@@ -266,12 +266,12 @@ func (h *Handler) Mux() http.Handler {
 	return router
 }
 
-// scopedFor returns the per-request [*artifact.ScopedNamespace] for
+// namespaceViewFor returns the per-request [*artifact.NamespaceView] for
 // the namespace in req's URL. The view is cheap to construct (a small
 // struct, no I/O) so handlers obtain it per call rather than caching
 // across requests.
-func (h *Handler) scopedFor(req *http.Request) *artifact.ScopedNamespace {
-	return h.artifacts.For(mux.Vars(req)["namespace"])
+func (h *Handler) namespaceViewFor(req *http.Request) *artifact.NamespaceView {
+	return h.artifacts.View(mux.Vars(req)["namespace"])
 }
 
 func (h *Handler) artifactNamespaceFor(req *http.Request) (artifact.Namespace, error) {
@@ -282,16 +282,16 @@ func (h *Handler) artifactNamespaceFor(req *http.Request) (artifact.Namespace, e
 // package the registry knows about. The namespace index carries one
 // tag per already-normalized package name.
 func (h *Handler) handleSimpleIndex(w http.ResponseWriter, req *http.Request) {
-	scoped := h.scopedFor(req)
-	spec, isProxy, ok := h.dispatchProxy(w, req, scoped)
+	view := h.namespaceViewFor(req)
+	spec, isProxy, ok := h.dispatchProxy(w, req, view)
 	if !ok {
 		return
 	}
 	if isProxy {
-		h.handleSimpleIndexProxy(w, req, scoped, spec)
+		h.handleSimpleIndexProxy(w, req, view, spec)
 		return
 	}
-	tags, err := scoped.Index(packageIndexName).List(req.Context())
+	tags, err := view.Index(packageIndexName).List(req.Context())
 	if err != nil {
 		if handler.WriteNamespaceError(w, err) {
 			return
@@ -336,13 +336,13 @@ func (h *Handler) handleSimpleIndex(w http.ResponseWriter, req *http.Request) {
 func (h *Handler) handleFilePut(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	logger := logging.FromContext(ctx)
-	scoped := h.scopedFor(req)
+	view := h.namespaceViewFor(req)
 
 	// Upload onto a proxy namespace is not meaningful — proxy
 	// caches fill on read, not via twine. Reject early with 405 so
 	// clients fail fast instead of confusing the multipart walker
 	// with an authentication or storage failure.
-	if _, isProxy, ok := h.dispatchProxy(w, req, scoped); !ok {
+	if _, isProxy, ok := h.dispatchProxy(w, req, view); !ok {
 		return
 	} else if isProxy {
 		w.Header().Set("Allow", "GET, HEAD")
@@ -476,7 +476,7 @@ func (h *Handler) handleFilePut(w http.ResponseWriter, req *http.Request) {
 	// same call /simple/ already makes on the read side), so we
 	// trade an extra round-trip per upload for a clean immutable
 	// AddFile contract.
-	if err := h.ensureIndexSentinel(ctx, scoped, normalizedName); err != nil {
+	if err := h.ensureIndexSentinel(ctx, view, normalizedName); err != nil {
 		logger.DebugContext(ctx, "failed to ensure index sentinel", "error", err)
 		if handler.WriteNamespaceError(w, err) {
 			return
@@ -512,14 +512,14 @@ func (h *Handler) handleFilePut(w http.ResponseWriter, req *http.Request) {
 		_ = p.Close()
 	}
 
-	h.indexCache.invalidate(scoped.Namespace() + "/" + normalizedName)
+	h.indexCache.invalidate(view.Namespace() + "/" + normalizedName)
 	w.WriteHeader(http.StatusCreated)
 }
 
 // ensureIndexSentinel marks the normalized package name in the
 // per-format namespace index.
-func (h *Handler) ensureIndexSentinel(ctx context.Context, scoped *artifact.ScopedNamespace, normalizedName string) error {
-	return scoped.Index(packageIndexName).Mark(ctx, normalizedName)
+func (h *Handler) ensureIndexSentinel(ctx context.Context, view *artifact.NamespaceView, normalizedName string) error {
+	return view.Index(packageIndexName).Mark(ctx, normalizedName)
 }
 
 // errFieldTooLarge is returned by readTextPart when a non-file form
@@ -609,13 +609,13 @@ func (h *Handler) handleFileGet(w http.ResponseWriter, req *http.Request) {
 		MediaType:  detectMediaType(filename),
 	}
 
-	scoped := h.scopedFor(req)
-	spec, isProxy, ok := h.dispatchProxy(w, req, scoped)
+	view := h.namespaceViewFor(req)
+	spec, isProxy, ok := h.dispatchProxy(w, req, view)
 	if !ok {
 		return
 	}
 	if isProxy {
-		h.handleFileGetProxy(w, req, scoped, spec, f)
+		h.handleFileGetProxy(w, req, view, spec, f)
 		return
 	}
 	artifactNS, err := h.artifactNamespaceFor(req)
@@ -646,13 +646,13 @@ func (h *Handler) handlePackageIndex(w http.ResponseWriter, req *http.Request) {
 	}
 	pkg = normalize(pkg)
 
-	scoped := h.scopedFor(req)
-	spec, isProxy, ok := h.dispatchProxy(w, req, scoped)
+	view := h.namespaceViewFor(req)
+	spec, isProxy, ok := h.dispatchProxy(w, req, view)
 	if !ok {
 		return
 	}
 	if isProxy {
-		h.handlePackageIndexProxy(w, req, scoped, spec, pkg)
+		h.handlePackageIndexProxy(w, req, view, spec, pkg)
 		return
 	}
 
@@ -714,8 +714,8 @@ func (h *Handler) handlePackageIndex(w http.ResponseWriter, req *http.Request) {
 // resolvePackageFiles enumerates a package's files. The returned slice
 // is what goes into the simple-index cache; both HTML and JSON
 // renderers pivot off it.
-func (h *Handler) resolvePackageFiles(ctx context.Context, scoped handler.Registry, pkg string) ([]cachedFile, error) {
-	rawFiles, err := scoped.ListFiles(ctx, packageOwningRepo(pkg))
+func (h *Handler) resolvePackageFiles(ctx context.Context, view handler.Registry, pkg string) ([]cachedFile, error) {
+	rawFiles, err := view.ListFiles(ctx, packageOwningRepo(pkg))
 	if err != nil {
 		return nil, err
 	}
@@ -760,14 +760,14 @@ func renderedFileURL(req *http.Request, ns, pkg string, f cachedFile) string {
 	return u.String()
 }
 
-func (h *Handler) handleGet(w http.ResponseWriter, req *http.Request, scoped handler.Registry, f *oci.RepoFile) {
+func (h *Handler) handleGet(w http.ResponseWriter, req *http.Request, view handler.Registry, f *oci.RepoFile) {
 	logger := logging.FromContext(req.Context())
 
 	// HEAD wants headers only — never redirect. The redirect path is
 	// only worth taking when the response would otherwise transfer
 	// bytes; HEAD has no egress to save.
 	if req.Method != http.MethodHead {
-		if redirectURL, err := scoped.BlobRedirectURL(req.Context(), f); err == nil && redirectURL != "" {
+		if redirectURL, err := view.BlobRedirectURL(req.Context(), f); err == nil && redirectURL != "" {
 			logger.DebugContext(req.Context(), "redirecting blob fetch to backend", "url", redirectURL)
 			http.Redirect(w, req, redirectURL, http.StatusTemporaryRedirect)
 			return
@@ -780,7 +780,7 @@ func (h *Handler) handleGet(w http.ResponseWriter, req *http.Request, scoped han
 		}
 	}
 
-	desc, r, err := scoped.ReadFile(req.Context(), f)
+	desc, r, err := view.ReadFile(req.Context(), f)
 	if err != nil {
 		logger.DebugContext(req.Context(), "failed to read file", "error", err)
 		if handler.WriteNamespaceError(w, err) {

--- a/pkg/handler/python/handler.go
+++ b/pkg/handler/python/handler.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/yolocs/ocifactory/pkg/artifact"
 	"github.com/yolocs/ocifactory/pkg/handler"
 	"github.com/yolocs/ocifactory/pkg/logging"
 	"github.com/yolocs/ocifactory/pkg/namespace"
@@ -95,6 +96,7 @@ var (
 
 type Handler struct {
 	registry       *namespace.Registry
+	artifacts      *artifact.Store
 	renderer       *renderer.Renderer
 	indexCache     *simpleIndexCache
 	authMW         func(http.Handler) http.Handler
@@ -214,6 +216,7 @@ func NewHandler(registry *namespace.Registry, opts ...Option) (*Handler, error) 
 	}
 	h := &Handler{
 		registry:       registry,
+		artifacts:      artifact.NewStore(registry),
 		renderer:       r,
 		indexCache:     newSimpleIndexCache(cfg.simpleIndexCacheTTL),
 		authMW:         cfg.authMW,
@@ -272,6 +275,10 @@ func (h *Handler) Mux() http.Handler {
 // across requests.
 func (h *Handler) scopedFor(req *http.Request) *namespace.ScopedRegistry {
 	return h.registry.For(mux.Vars(req)["namespace"])
+}
+
+func (h *Handler) artifactNamespaceFor(req *http.Request) (artifact.Namespace, error) {
+	return h.artifacts.Namespace(req.Context(), mux.Vars(req)["namespace"])
 }
 
 // handleSimpleIndex renders the root simple index — the list of every
@@ -442,13 +449,19 @@ func (h *Handler) handleFilePut(w http.ResponseWriter, req *http.Request) {
 
 	normalizedName := normalize(pkgName)
 
-	wheelRF := &oci.RepoFile{
-		OwningRepo: packageOwningRepo(normalizedName),
-		OwningTag:  versionNum,
-		Name:       contentName,
-		MediaType:  detectMediaType(contentName),
+	artifactNS, err := h.artifactNamespaceFor(req)
+	if err != nil {
+		if handler.WriteNamespaceError(w, err) {
+			return
+		}
+		handler.WriteError(ctx, w, http.StatusInternalServerError, err, "internal error")
+		return
 	}
-	if !h.streamAddFile(ctx, scoped, w, wheelRF, contentPart) {
+	wheel := artifact.FilePut{
+		Name:      contentName,
+		MediaType: detectMediaType(contentName),
+	}
+	if !h.streamPutFile(ctx, artifactNS.Package(packageOwningRepo(normalizedName)), versionNum, w, wheel, contentPart) {
 		return
 	}
 
@@ -544,7 +557,7 @@ func writeMultipartReadError(w http.ResponseWriter, err error, logger *slog.Logg
 	}
 }
 
-// streamAddFile wraps registry.AddFile with the standard error → HTTP
+// streamPutFile wraps package.PutFile with the standard error → HTTP
 // translation used by the upload path. It returns true on success and
 // writes the appropriate error response (and returns false) on
 // failure. Callers are expected to short-circuit subsequent steps on
@@ -553,9 +566,9 @@ func writeMultipartReadError(w http.ResponseWriter, err error, logger *slog.Logg
 // MaxBytesError is detected inline so a request body that overflows
 // h.maxUploadBytes mid-stream (e.g. while AddFile is reading the wheel
 // body) returns 413 instead of a generic 500.
-func (h *Handler) streamAddFile(ctx context.Context, scoped handler.Registry, w http.ResponseWriter, f *oci.RepoFile, content io.Reader) bool {
+func (h *Handler) streamPutFile(ctx context.Context, pkg artifact.Package, version string, w http.ResponseWriter, file artifact.FilePut, content io.Reader) bool {
 	logger := logging.FromContext(ctx)
-	desc, err := scoped.AddFile(ctx, f, content)
+	desc, err := pkg.PutFile(ctx, version, file, content)
 	if err != nil {
 		logger.DebugContext(ctx, "failed to add file", "error", err)
 		if handler.WriteNamespaceError(w, err) {
@@ -608,7 +621,23 @@ func (h *Handler) handleFileGet(w http.ResponseWriter, req *http.Request) {
 		h.handleFileGetProxy(w, req, scoped, spec, f)
 		return
 	}
-	h.handleGet(w, req, scoped, f)
+	artifactNS, err := h.artifactNamespaceFor(req)
+	if err != nil {
+		if handler.WriteNamespaceError(w, err) {
+			return
+		}
+		handler.WriteError(req.Context(), w, http.StatusInternalServerError, err, "internal error")
+		return
+	}
+	handle, err := artifactNS.Package(packageOwningRepo(pkg)).GetFile(req.Context(), version, filename)
+	if err != nil {
+		if handler.WriteNamespaceError(w, err) {
+			return
+		}
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	h.handleArtifactGet(w, req, handle, detectMediaType(filename))
 }
 
 func (h *Handler) handlePackageIndex(w http.ResponseWriter, req *http.Request) {
@@ -638,7 +667,15 @@ func (h *Handler) handlePackageIndex(w http.ResponseWriter, req *http.Request) {
 	files, ok := h.indexCache.get(cacheKey)
 	if !ok {
 		var err error
-		files, err = h.resolvePackageFiles(req.Context(), scoped, pkg)
+		artifactNS, nsErr := h.artifactNamespaceFor(req)
+		if nsErr != nil {
+			if handler.WriteNamespaceError(w, nsErr) {
+				return
+			}
+			handler.WriteError(req.Context(), w, http.StatusInternalServerError, nsErr, "internal error")
+			return
+		}
+		files, err = h.resolveArtifactPackageFiles(req.Context(), artifactNS.Package(packageOwningRepo(pkg)))
 		if err != nil {
 			if handler.WriteNamespaceError(w, err) {
 				return
@@ -691,6 +728,23 @@ func (h *Handler) resolvePackageFiles(ctx context.Context, scoped handler.Regist
 		entries = append(entries, cachedFile{
 			Filename:  f.Name,
 			OwningTag: f.OwningTag,
+			Sha256:    strings.TrimPrefix(f.Digest, "sha256:"),
+		})
+	}
+	return entries, nil
+}
+
+func (h *Handler) resolveArtifactPackageFiles(ctx context.Context, pkg artifact.Package) ([]cachedFile, error) {
+	rawFiles, err := pkg.ListFiles(ctx, artifact.ListFilesOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	entries := make([]cachedFile, 0, len(rawFiles))
+	for _, f := range rawFiles {
+		entries = append(entries, cachedFile{
+			Filename:  f.Name,
+			OwningTag: f.Version,
 			Sha256:    strings.TrimPrefix(f.Digest, "sha256:"),
 		})
 	}
@@ -756,6 +810,56 @@ func (h *Handler) handleGet(w http.ResponseWriter, req *http.Request, scoped han
 	w.Header().Set("Content-Type", f.MediaType)
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", desc.File.Size))
 	w.Header().Set("X-Checksum-Sha256", desc.File.Digest.String())
+	if req.Method == http.MethodHead {
+		return
+	}
+
+	if _, err := io.Copy(w, r); err != nil {
+		handler.WriteError(req.Context(), w, http.StatusInternalServerError, err, "internal error")
+		return
+	}
+}
+
+func (h *Handler) handleArtifactGet(w http.ResponseWriter, req *http.Request, file artifact.FileHandle, mediaType string) {
+	logger := logging.FromContext(req.Context())
+
+	if req.Method != http.MethodHead {
+		if redirectURL, err := file.DownloadURL(req.Context()); err == nil && redirectURL != "" {
+			logger.DebugContext(req.Context(), "redirecting blob fetch to backend", "url", redirectURL)
+			http.Redirect(w, req, redirectURL, http.StatusTemporaryRedirect)
+			return
+		} else if err != nil {
+			logger.DebugContext(req.Context(), "blob redirect probe failed; falling back to streaming", "error", err)
+		}
+	}
+
+	r, err := file.Open(req.Context())
+	if err != nil {
+		logger.DebugContext(req.Context(), "failed to read file", "error", err)
+		if handler.WriteNamespaceError(w, err) {
+			return
+		}
+		if errors.Is(err, errdef.ErrNotFound) {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		if oci.HasCode(err, http.StatusUnauthorized) {
+			http.Error(w, err.Error(), http.StatusUnauthorized)
+			return
+		}
+		if oci.HasCode(err, http.StatusForbidden) {
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return
+		}
+		handler.WriteError(req.Context(), w, http.StatusInternalServerError, err, "internal error")
+		return
+	}
+	defer r.Close()
+
+	info := file.Info()
+	w.Header().Set("Content-Type", mediaType)
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", info.Size))
+	w.Header().Set("X-Checksum-Sha256", info.Digest)
 	if req.Method == http.MethodHead {
 		return
 	}

--- a/pkg/handler/python/handler_test.go
+++ b/pkg/handler/python/handler_test.go
@@ -475,7 +475,7 @@ func TestPackageIndexCache(t *testing.T) {
 			t.Fatalf("seed upload: status=%d", code)
 		}
 		// Reset the counters after seeding so the assertion measures
-		// the simple-index path only — the upload + namespace wrapper
+		// the simple-index path only — the upload + artifact data-plane wrapper
 		// each touch ListFiles/ListTags for their own bookkeeping.
 		listFilesAfterSeed := reg.listFiles.Load()
 

--- a/pkg/handler/python/namespace_test.go
+++ b/pkg/handler/python/namespace_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/yolocs/ocifactory/pkg/artifact"
 	"github.com/yolocs/ocifactory/pkg/auth"
 	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
@@ -21,7 +22,7 @@ func TestNamespace_UnknownNamespace404(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	authMW := auth.Middleware(auth.AlwaysAnonymous)
 	h, err := NewHandler(reg, WithAuthMiddleware(authMW))
 	if err != nil {
@@ -58,7 +59,7 @@ func TestNamespace_InvalidNamespaceName400(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	authMW := auth.Middleware(auth.AlwaysAnonymous)
 	h, err := NewHandler(reg, WithAuthMiddleware(authMW))
 	if err != nil {
@@ -95,13 +96,13 @@ func TestNamespace_AuthzErrorFailsClosed(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store,
-		namespace.WithAuthzFactory(func(_ namespace.Policy) (auth.Authorizer, error) {
+	reg := artifact.NewStore(fake, store,
+		artifact.WithAuthzFactory(func(_ namespace.Policy) (auth.Authorizer, error) {
 			return auth.AuthorizerFunc(func(_ context.Context, _ *auth.AuthContext, _ auth.Op) error {
 				return errors.New("transient backend lookup failure")
 			}), nil
 		}),
-		namespace.WithPolicyCacheTTL(0),
+		artifact.WithPolicyCacheTTL(0),
 	)
 	putNamespace(t, store, testNS, namespace.Spec{Policy: allowAllPolicy()})
 
@@ -126,7 +127,7 @@ func TestNamespace_UnknownNamespaceUpload404(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	authMW := auth.Middleware(auth.AlwaysAnonymous)
 	h, err := NewHandler(reg, WithAuthMiddleware(authMW))
 	if err != nil {
@@ -145,7 +146,7 @@ func TestNamespace_NotInReadersForbiddenOnGet(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	// Subject is "anonymous"; the policy only admits a different issuer.
 	putNamespace(t, store, testNS, namespace.Spec{Policy: namespace.Policy{
 		Readers: []namespace.SubjectMatcher{{Issuer: "https://accounts.google.com"}},
@@ -173,7 +174,7 @@ func TestNamespace_NotInWritersForbiddenOnPost(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	putNamespace(t, store, testNS, namespace.Spec{Policy: namespace.Policy{
 		// Readers allow our anonymous subject, but writers do not.
 		Readers: []namespace.SubjectMatcher{{Issuer: "anonymous"}},
@@ -207,7 +208,7 @@ func TestNamespace_CrossNamespaceIsolation(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	putNamespace(t, store, "alpha", namespace.Spec{Policy: allowAllPolicy()})
 	putNamespace(t, store, "beta", namespace.Spec{Policy: allowAllPolicy()})
 
@@ -260,7 +261,7 @@ func TestNamespace_PackageIndexCacheIsolation(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	putNamespace(t, store, "alpha", namespace.Spec{Policy: allowAllPolicy()})
 	putNamespace(t, store, "beta", namespace.Spec{Policy: allowAllPolicy()})
 
@@ -299,9 +300,9 @@ func TestNamespace_NoAuthForbiddenAtWrapper(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store,
-		namespace.WithAuthzFactory(func(_ namespace.Policy) (auth.Authorizer, error) { return auth.AllowAll, nil }),
-		namespace.WithPolicyCacheTTL(0),
+	reg := artifact.NewStore(fake, store,
+		artifact.WithAuthzFactory(func(_ namespace.Policy) (auth.Authorizer, error) { return auth.AllowAll, nil }),
+		artifact.WithPolicyCacheTTL(0),
 	)
 	putNamespace(t, store, testNS, namespace.Spec{Policy: allowAllPolicy()})
 

--- a/pkg/handler/python/proxy.go
+++ b/pkg/handler/python/proxy.go
@@ -183,8 +183,8 @@ func (p *proxyState) fetcherFor(upstream string) (ProxyFetcher, error) {
 // namespace and whether the request should be served via the proxy
 // path. When the namespace is unknown or malformed, it writes the
 // matching error response and returns ok=false so the caller stops.
-func (h *Handler) dispatchProxy(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace) (*namespace.Spec, bool, bool) {
-	spec, err := scoped.Spec(req.Context())
+func (h *Handler) dispatchProxy(w http.ResponseWriter, req *http.Request, view *artifact.NamespaceView) (*namespace.Spec, bool, bool) {
+	spec, err := view.Spec(req.Context())
 	if err != nil {
 		if handler.WriteNamespaceError(w, err) {
 			return nil, false, false
@@ -210,14 +210,14 @@ func (h *Handler) dispatchProxy(w http.ResponseWriter, req *http.Request, scoped
 //
 // Concurrent first-misses for the same (ns, pkg, version, filename)
 // collapse onto one upstream fetch via the file-singleflight group.
-func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, spec *namespace.Spec, f *oci.RepoFile) {
+func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, view *artifact.NamespaceView, spec *namespace.Spec, f *oci.RepoFile) {
 	ctx := req.Context()
 	logger := logging.FromContext(ctx)
 
 	// Cache-hit fast path. ReadFile authorizes for read and serves
 	// from OCI just like the hosted path; on miss we bubble through
 	// to the upstream resolver.
-	if h.tryServeFromRegistry(w, req, scoped, f) {
+	if h.tryServeFromRegistry(w, req, view, f) {
 		return
 	}
 
@@ -226,7 +226,7 @@ func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, s
 	filename := f.Name
 
 	if h.proxy.negCache != nil {
-		negKey := negativeKey(scoped.Namespace(), pkg, version, filename)
+		negKey := negativeKey(view.Namespace(), pkg, version, filename)
 		if h.proxy.negCache.IsKnownMissing(negKey) {
 			http.Error(w, "not found", http.StatusNotFound)
 			return
@@ -266,7 +266,7 @@ func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, s
 	// and simultaneously tees the bytes onto its own ResponseWriter.
 	// Followers observe a "streamed" outcome and re-read the now-cached
 	// file from OCI to serve their own clients.
-	key := scoped.Namespace() + "|" + f.OwningRepo + "|" + version + "|" + filename
+	key := view.Namespace() + "|" + f.OwningRepo + "|" + version + "|" + filename
 	isHead := req.Method == http.MethodHead
 	amLeader := false
 	// teeRef captures the leader's tee writer so the outer error branch
@@ -282,7 +282,7 @@ func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, s
 
 		// Re-check the registry inside the singleflight — a peer
 		// may have populated the cache while we were waiting.
-		if hit, hitErr := h.peekRegistry(ctx, scoped, f); hitErr == nil && hit {
+		if hit, hitErr := h.peekRegistry(ctx, view, f); hitErr == nil && hit {
 			return fileFlightResult{cached: true}, nil
 		}
 
@@ -377,7 +377,7 @@ func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, s
 		// before singleflight could; probeExistingFile reports it
 		// before reading the body, so no client bytes were written and
 		// the follower path can serve from the cache the peer wrote.
-		if _, addErr := scoped.AddCachedFile(ctx, populated, body); addErr != nil {
+		if _, addErr := view.AddCachedFile(ctx, populated, body); addErr != nil {
 			if errors.Is(addErr, oci.ErrAlreadyExists) {
 				return fileFlightResult{cached: true}, nil
 			}
@@ -403,7 +403,7 @@ func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, s
 		switch {
 		case errors.Is(err, proxy.ErrNotFound):
 			if h.proxy.negCache != nil {
-				h.proxy.negCache.RecordMiss(negativeKey(scoped.Namespace(), pkg, version, filename))
+				h.proxy.negCache.RecordMiss(negativeKey(view.Namespace(), pkg, version, filename))
 			}
 			http.Error(w, "not found", http.StatusNotFound)
 		case errors.Is(err, proxy.ErrUpstreamMalformed):
@@ -434,7 +434,7 @@ func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, s
 	// HEAD that needs the headers written, or we hit ErrAlreadyExists
 	// mid-flight. All three serve the canonical headers + body from
 	// the cache the leader just populated.
-	if h.tryServeFromRegistry(w, req, scoped, f) {
+	if h.tryServeFromRegistry(w, req, view, f) {
 		return
 	}
 	handler.WriteError(ctx, w, http.StatusBadGateway, nil, "proxy fill reported success but cache miss on re-read")
@@ -494,8 +494,8 @@ type fileFlightResult struct {
 // "peer wrote the file, re-serve from cache" and "peer failed, do
 // our own fetch". Returns (true, nil) on hit, (false, nil) on miss,
 // non-nil error on backend trouble.
-func (h *Handler) peekRegistry(ctx context.Context, scoped *artifact.ScopedNamespace, f *oci.RepoFile) (bool, error) {
-	desc, rc, err := scoped.ReadFile(ctx, f)
+func (h *Handler) peekRegistry(ctx context.Context, view *artifact.NamespaceView, f *oci.RepoFile) (bool, error) {
+	desc, rc, err := view.ReadFile(ctx, f)
 	if err != nil {
 		if errors.Is(err, errdef.ErrNotFound) {
 			return false, nil
@@ -511,12 +511,12 @@ func (h *Handler) peekRegistry(ctx context.Context, scoped *artifact.ScopedNames
 // flow. Returns true on success (response written), false on miss so
 // the caller continues with the proxy fetch. Errors other than
 // not-found are written as the appropriate HTTP status and return true.
-func (h *Handler) tryServeFromRegistry(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, f *oci.RepoFile) bool {
+func (h *Handler) tryServeFromRegistry(w http.ResponseWriter, req *http.Request, view *artifact.NamespaceView, f *oci.RepoFile) bool {
 	ctx := req.Context()
 	logger := logging.FromContext(ctx)
 
 	if req.Method != http.MethodHead {
-		if redirectURL, err := scoped.BlobRedirectURL(ctx, f); err == nil && redirectURL != "" {
+		if redirectURL, err := view.BlobRedirectURL(ctx, f); err == nil && redirectURL != "" {
 			http.Redirect(w, req, redirectURL, http.StatusTemporaryRedirect)
 			return true
 		} else if err != nil {
@@ -524,7 +524,7 @@ func (h *Handler) tryServeFromRegistry(w http.ResponseWriter, req *http.Request,
 		}
 	}
 
-	desc, r, err := scoped.ReadFile(ctx, f)
+	desc, r, err := view.ReadFile(ctx, f)
 	if err != nil {
 		if errors.Is(err, errdef.ErrNotFound) {
 			return false
@@ -571,21 +571,21 @@ func (h *Handler) tryServeFromRegistry(w http.ResponseWriter, req *http.Request,
 //
 // Concurrent refreshes for the same (namespace, pkg) collapse onto
 // one upstream fetch via the index-singleflight group.
-func (h *Handler) handlePackageIndexProxy(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, spec *namespace.Spec, pkg string) {
-	h.serveProxyIndex(w, req, scoped, spec, pkg)
+func (h *Handler) handlePackageIndexProxy(w http.ResponseWriter, req *http.Request, view *artifact.NamespaceView, spec *namespace.Spec, pkg string) {
+	h.serveProxyIndex(w, req, view, spec, pkg)
 }
 
 // handleSimpleIndexProxy serves /{ns}/simple/ in proxy mode. Same
 // flow as the per-package path with cache key pkg="" and synthesis
 // fallback through the per-format namespace index.
-func (h *Handler) handleSimpleIndexProxy(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, spec *namespace.Spec) {
-	h.serveProxyIndex(w, req, scoped, spec, "")
+func (h *Handler) handleSimpleIndexProxy(w http.ResponseWriter, req *http.Request, view *artifact.NamespaceView, spec *namespace.Spec) {
+	h.serveProxyIndex(w, req, view, spec, "")
 }
 
-func (h *Handler) serveProxyIndex(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, spec *namespace.Spec, pkg string) {
+func (h *Handler) serveProxyIndex(w http.ResponseWriter, req *http.Request, view *artifact.NamespaceView, spec *namespace.Spec, pkg string) {
 	ctx := req.Context()
 	logger := logging.FromContext(ctx)
-	ns := scoped.Namespace()
+	ns := view.Namespace()
 	cacheKey := ns + "|" + pkg
 
 	// L1 in-memory cache fast path.
@@ -688,7 +688,7 @@ func (h *Handler) serveProxyIndex(w http.ResponseWriter, req *http.Request, scop
 		return
 	}
 
-	h.synthesizeIndex(w, req, scoped, pkg, err)
+	h.synthesizeIndex(w, req, view, pkg, err)
 }
 
 type indexFlightResult struct {
@@ -706,13 +706,13 @@ type indexFlightResult struct {
 // (namespace, package) either — 503, since serving a literal empty
 // index would have pip conclude the package was unyanked, which is
 // worse than a clear "we're degraded" signal.
-func (h *Handler) synthesizeIndex(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, pkg string, upstreamErr error) {
+func (h *Handler) synthesizeIndex(w http.ResponseWriter, req *http.Request, view *artifact.NamespaceView, pkg string, upstreamErr error) {
 	ctx := req.Context()
 	logger := logging.FromContext(ctx)
-	ns := scoped.Namespace()
+	ns := view.Namespace()
 
 	if pkg == "" {
-		tags, err := scoped.Index(packageIndexName).List(ctx)
+		tags, err := view.Index(packageIndexName).List(ctx)
 		if err != nil {
 			handler.WriteError(ctx, w, http.StatusServiceUnavailable, upstreamErr,
 				fmt.Sprintf("upstream unavailable and synthesis failed: %v", err))
@@ -742,7 +742,7 @@ func (h *Handler) synthesizeIndex(w http.ResponseWriter, req *http.Request, scop
 		return
 	}
 
-	files, err := h.resolvePackageFiles(ctx, scoped, pkg)
+	files, err := h.resolvePackageFiles(ctx, view, pkg)
 	if err != nil && !errors.Is(err, errdef.ErrNotFound) {
 		handler.WriteError(ctx, w, http.StatusServiceUnavailable, upstreamErr,
 			fmt.Sprintf("upstream unavailable and synthesis failed: %v", err))

--- a/pkg/handler/python/proxy.go
+++ b/pkg/handler/python/proxy.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/yolocs/ocifactory/pkg/artifact"
 	"golang.org/x/sync/singleflight"
 	"oras.land/oras-go/v2/errdef"
 
@@ -182,7 +183,7 @@ func (p *proxyState) fetcherFor(upstream string) (ProxyFetcher, error) {
 // namespace and whether the request should be served via the proxy
 // path. When the namespace is unknown or malformed, it writes the
 // matching error response and returns ok=false so the caller stops.
-func (h *Handler) dispatchProxy(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry) (*namespace.Spec, bool, bool) {
+func (h *Handler) dispatchProxy(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace) (*namespace.Spec, bool, bool) {
 	spec, err := scoped.Spec(req.Context())
 	if err != nil {
 		if handler.WriteNamespaceError(w, err) {
@@ -209,7 +210,7 @@ func (h *Handler) dispatchProxy(w http.ResponseWriter, req *http.Request, scoped
 //
 // Concurrent first-misses for the same (ns, pkg, version, filename)
 // collapse onto one upstream fetch via the file-singleflight group.
-func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry, spec *namespace.Spec, f *oci.RepoFile) {
+func (h *Handler) handleFileGetProxy(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, spec *namespace.Spec, f *oci.RepoFile) {
 	ctx := req.Context()
 	logger := logging.FromContext(ctx)
 
@@ -493,7 +494,7 @@ type fileFlightResult struct {
 // "peer wrote the file, re-serve from cache" and "peer failed, do
 // our own fetch". Returns (true, nil) on hit, (false, nil) on miss,
 // non-nil error on backend trouble.
-func (h *Handler) peekRegistry(ctx context.Context, scoped *namespace.ScopedRegistry, f *oci.RepoFile) (bool, error) {
+func (h *Handler) peekRegistry(ctx context.Context, scoped *artifact.ScopedNamespace, f *oci.RepoFile) (bool, error) {
 	desc, rc, err := scoped.ReadFile(ctx, f)
 	if err != nil {
 		if errors.Is(err, errdef.ErrNotFound) {
@@ -510,7 +511,7 @@ func (h *Handler) peekRegistry(ctx context.Context, scoped *namespace.ScopedRegi
 // flow. Returns true on success (response written), false on miss so
 // the caller continues with the proxy fetch. Errors other than
 // not-found are written as the appropriate HTTP status and return true.
-func (h *Handler) tryServeFromRegistry(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry, f *oci.RepoFile) bool {
+func (h *Handler) tryServeFromRegistry(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, f *oci.RepoFile) bool {
 	ctx := req.Context()
 	logger := logging.FromContext(ctx)
 
@@ -570,18 +571,18 @@ func (h *Handler) tryServeFromRegistry(w http.ResponseWriter, req *http.Request,
 //
 // Concurrent refreshes for the same (namespace, pkg) collapse onto
 // one upstream fetch via the index-singleflight group.
-func (h *Handler) handlePackageIndexProxy(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry, spec *namespace.Spec, pkg string) {
+func (h *Handler) handlePackageIndexProxy(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, spec *namespace.Spec, pkg string) {
 	h.serveProxyIndex(w, req, scoped, spec, pkg)
 }
 
 // handleSimpleIndexProxy serves /{ns}/simple/ in proxy mode. Same
 // flow as the per-package path with cache key pkg="" and synthesis
 // fallback through the per-format namespace index.
-func (h *Handler) handleSimpleIndexProxy(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry, spec *namespace.Spec) {
+func (h *Handler) handleSimpleIndexProxy(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, spec *namespace.Spec) {
 	h.serveProxyIndex(w, req, scoped, spec, "")
 }
 
-func (h *Handler) serveProxyIndex(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry, spec *namespace.Spec, pkg string) {
+func (h *Handler) serveProxyIndex(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, spec *namespace.Spec, pkg string) {
 	ctx := req.Context()
 	logger := logging.FromContext(ctx)
 	ns := scoped.Namespace()
@@ -705,7 +706,7 @@ type indexFlightResult struct {
 // (namespace, package) either — 503, since serving a literal empty
 // index would have pip conclude the package was unyanked, which is
 // worse than a clear "we're degraded" signal.
-func (h *Handler) synthesizeIndex(w http.ResponseWriter, req *http.Request, scoped *namespace.ScopedRegistry, pkg string, upstreamErr error) {
+func (h *Handler) synthesizeIndex(w http.ResponseWriter, req *http.Request, scoped *artifact.ScopedNamespace, pkg string, upstreamErr error) {
 	ctx := req.Context()
 	logger := logging.FromContext(ctx)
 	ns := scoped.Namespace()

--- a/pkg/handler/python/proxy_test.go
+++ b/pkg/handler/python/proxy_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/yolocs/ocifactory/pkg/artifact"
 	"github.com/yolocs/ocifactory/pkg/auth"
 	"github.com/yolocs/ocifactory/pkg/namespace"
 	"github.com/yolocs/ocifactory/pkg/oci"
@@ -128,7 +129,7 @@ func newProxyTestHandler(t *testing.T, fetcher ProxyFetcher, extraSpec namespace
 	t.Helper()
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 
 	if extraSpec.Mode == "" {
 		extraSpec.Mode = namespace.ModeProxy
@@ -176,7 +177,7 @@ func TestProxy_AuthGating(t *testing.T) {
 
 	fake := oci.NewFakeRegistry()
 	store := namespace.NewStore(fake)
-	reg := namespace.NewRegistry(fake, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(fake, store, artifact.WithPolicyCacheTTL(0))
 	if err := store.Put(t.Context(), &namespace.Namespace{
 		Name: testNS,
 		Spec: namespace.Spec{
@@ -244,12 +245,10 @@ func TestProxy_FileCacheHit_NoUpstream(t *testing.T) {
 		Name:       "requests-2.31.0-py3-none-any.whl",
 		MediaType:  "application/x-wheel+zip",
 	}
-	scoped := namespace.NewRegistry(backing, namespace.NewStore(backing), namespace.WithPolicyCacheTTL(0))
-	_ = scoped
 	// Use a direct AddFile against the fake; bypasses authz which
 	// is fine because the fake registry doesn't authorize on its
-	// own — namespace.Registry does. We address the fake at the
-	// post-prefix path the namespace wrapper would have produced.
+	// own — artifact.Store does. We address the fake at the
+	// post-prefix path the artifact data-plane wrapper would have produced.
 	if _, err := backing.AddFile(t.Context(), &oci.RepoFile{
 		OwningRepo: testNS + "/packages/requests",
 		OwningTag:  rf.OwningTag,
@@ -888,7 +887,7 @@ func TestProxy_FileAddFileFailureAfterTeeDoesNotCorruptBody(t *testing.T) {
 	}
 	fake.files[fileURL] = []byte(bodyBytes)
 
-	// Build a namespace.Registry wrapping a backend whose AddFile
+	// Build an artifact.Store wrapping a backend whose AddFile
 	// reads the full body (so the tee writes through) and then errors.
 	backing := oci.NewFakeRegistry()
 	wrapped := &addFileFailingBackend{
@@ -897,7 +896,7 @@ func TestProxy_FileAddFileFailureAfterTeeDoesNotCorruptBody(t *testing.T) {
 		failRepoSuffix: "/packages/x",
 	}
 	store := namespace.NewStore(wrapped)
-	reg := namespace.NewRegistry(wrapped, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(wrapped, store, artifact.WithPolicyCacheTTL(0))
 	if err := store.Put(t.Context(), &namespace.Namespace{Name: testNS, Spec: namespace.Spec{
 		Mode:   namespace.ModeProxy,
 		Proxy:  namespace.Proxy{Upstream: "https://pypi.org"},

--- a/pkg/handler/python/proxy_test.go
+++ b/pkg/handler/python/proxy_test.go
@@ -959,6 +959,9 @@ func (b *addFileFailingBackend) BlobRedirectURL(ctx context.Context, f *oci.Repo
 func (b *addFileFailingBackend) ListTags(ctx context.Context, repo string) ([]string, error) {
 	return b.inner.ListTags(ctx, repo)
 }
+func (b *addFileFailingBackend) ResolveTag(ctx context.Context, repo, tag string) (string, error) {
+	return b.inner.ResolveTag(ctx, repo, tag)
+}
 func (b *addFileFailingBackend) ListFiles(ctx context.Context, repo string) ([]*oci.RepoFile, error) {
 	return b.inner.ListFiles(ctx, repo)
 }

--- a/pkg/handler/python/testutil_test.go
+++ b/pkg/handler/python/testutil_test.go
@@ -3,6 +3,7 @@ package python
 import (
 	"testing"
 
+	"github.com/yolocs/ocifactory/pkg/artifact"
 	"github.com/yolocs/ocifactory/pkg/auth"
 	"github.com/yolocs/ocifactory/pkg/namespace"
 )
@@ -27,15 +28,15 @@ func allowAllPolicy() namespace.Policy {
 }
 
 // newTestHandler builds a python [*Handler] wired to a
-// [*namespace.Registry] backed by inner. A "test-ns" namespace with an
+// [*artifact.Store] backed by inner. A "test-ns" namespace with an
 // allow-all policy is registered; the auth middleware installs the
 // [auth.AlwaysAnonymous] AuthContext on every request so the wrapper
 // has a subject to authorize. Tests that need a different namespace /
 // policy / authenticator construct the plumbing inline.
-func newTestHandler(t *testing.T, inner namespace.RegistryBackend, opts ...Option) (*Handler, *namespace.Store) {
+func newTestHandler(t *testing.T, inner artifact.Backend, opts ...Option) (*Handler, *namespace.Store) {
 	t.Helper()
 	store := namespace.NewStore(inner)
-	reg := namespace.NewRegistry(inner, store, namespace.WithPolicyCacheTTL(0))
+	reg := artifact.NewStore(inner, store, artifact.WithPolicyCacheTTL(0))
 	if err := store.Put(t.Context(), &namespace.Namespace{Name: testNS, Spec: namespace.Spec{Policy: allowAllPolicy()}}); err != nil {
 		t.Fatalf("Put namespace: %v", err)
 	}

--- a/pkg/namespace/namespace.go
+++ b/pkg/namespace/namespace.go
@@ -22,6 +22,11 @@ const CurrentSchemaVersion = 1
 // operator-facing message clear.
 var ErrUnsupportedSchemaVersion = errors.New("unsupported namespace schema_version")
 
+// ErrInvalidOwningRepo is returned when an artifact owning-repo string is
+// malformed or attempts to escape the namespace it was scoped to. Handlers
+// should map this to 400.
+var ErrInvalidOwningRepo = errors.New("invalid owning repo")
+
 // Namespace is a namespace and its spec. Name is the identifier as
 // it appears in URLs; validation rules live on [ValidateName].
 type Namespace struct {

--- a/pkg/namespace/registry.go
+++ b/pkg/namespace/registry.go
@@ -84,6 +84,7 @@ type RegistryBackend interface {
 	ReadFile(ctx context.Context, f *oci.RepoFile) (*oci.FileDescriptor, io.ReadCloser, error)
 	BlobRedirectURL(ctx context.Context, f *oci.RepoFile) (string, error)
 	ListTags(ctx context.Context, repo string) ([]string, error)
+	ResolveTag(ctx context.Context, repo string, tag string) (string, error)
 	ListFiles(ctx context.Context, repo string) ([]*oci.RepoFile, error)
 	AppendRefs(ctx context.Context, repo string, canonicalTag string, refs ...string) error
 	DeleteRepoFiles(ctx context.Context, repo string) error
@@ -485,6 +486,19 @@ func (s *ScopedRegistry) ListTags(ctx context.Context, repo string) ([]string, e
 		return nil, err
 	}
 	return s.parent.inner.ListTags(ctx, scoped)
+}
+
+// ResolveTag authorizes the bound namespace for read and returns the
+// canonical version tag identified by tag within repo.
+func (s *ScopedRegistry) ResolveTag(ctx context.Context, repo, tag string) (string, error) {
+	if err := s.parent.authorize(ctx, s.namespace, auth.OpRead); err != nil {
+		return "", err
+	}
+	scoped, err := s.parent.resolveRepo(s.namespace, repo)
+	if err != nil {
+		return "", err
+	}
+	return s.parent.inner.ResolveTag(ctx, scoped, tag)
 }
 
 // ListFiles authorizes the bound namespace for read and returns

--- a/pkg/namespace/registry_test.go
+++ b/pkg/namespace/registry_test.go
@@ -836,6 +836,44 @@ func TestScopedRegistry_AppendRefs_Forwards(t *testing.T) {
 	}
 }
 
+func TestScopedRegistry_ResolveTag(t *testing.T) {
+	t.Parallel()
+
+	_, reg, store := setup(t)
+	putNamespace(t, store, "alpha", allowAllSpec())
+	ctx := aliceCtx(t)
+	scoped := reg.For("alpha")
+
+	if _, err := scoped.AddFile(ctx, newRepoFile(repoFoo, "1.0.0", "f.txt"), strings.NewReader(defaultBody)); err != nil {
+		t.Fatalf("AddFile: %v", err)
+	}
+	if err := scoped.AppendRefs(ctx, repoFoo, "1.0.0", "latest"); err != nil {
+		t.Fatalf("AppendRefs: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		tag  string
+		want string
+	}{
+		{name: "canonical", tag: "1.0.0", want: "1.0.0"},
+		{name: "alias", tag: "latest", want: "1.0.0"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := scoped.ResolveTag(ctx, repoFoo, tc.tag)
+			if err != nil {
+				t.Fatalf("ResolveTag: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("ResolveTag = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestScopedRegistry_DeleteRepoFiles_SweepsBackendIndex verifies
 // BOTH the in-process indexed marker AND the backend
 // ocifactory-packages tag are cleared.

--- a/pkg/oci/fake.go
+++ b/pkg/oci/fake.go
@@ -199,6 +199,19 @@ func (r *FakeRegistry) ListTags(ctx context.Context, repo string) ([]string, err
 	return tags, nil
 }
 
+// ResolveTag resolves a canonical or alias tag to its canonical version.
+func (r *FakeRegistry) ResolveTag(ctx context.Context, repo, tag string) (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if slices.Contains(r.Tags[repo], tag) {
+		return tag, nil
+	}
+	if canonical, ok := r.Aliases[aliasKey(repo, tag)]; ok {
+		return canonical, nil
+	}
+	return "", fmt.Errorf("tag %q not found in repo %q: %w", tag, repo, errdef.ErrNotFound)
+}
+
 // ListFiles enumerates files keyed under the repo, ignoring alias tags
 // (alias resolution would double-count files that already appear under
 // their canonical version). Digest is computed from the stored content

--- a/pkg/oci/registry.go
+++ b/pkg/oci/registry.go
@@ -915,6 +915,39 @@ func (r *Registry) ListTags(ctx context.Context, repo string) ([]string, error) 
 	return out, nil
 }
 
+// ResolveTag resolves tag within repo to the canonical version tag it
+// identifies. Canonical version tags resolve to themselves; alias tags
+// resolve through their AliasTargetAnnotation.
+func (r *Registry) ResolveTag(ctx context.Context, repo, tag string) (string, error) {
+	if tag == "" {
+		return "", fmt.Errorf("tag must not be empty")
+	}
+	backend, err := r.newBackendFunc(ctx, &RepoFile{OwningRepo: repo})
+	if err != nil {
+		return "", err
+	}
+	desc, err := backend.Resolve(ctx, tag)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve tag %q: %w", tag, err)
+	}
+	var manifest ocispec.Manifest
+	if err := fetchManifestJSON(ctx, backend, desc, &manifest); err != nil {
+		return "", fmt.Errorf("failed to fetch tag manifest %q: %w", tag, err)
+	}
+	switch manifest.ArtifactType {
+	case r.versionArtifactType:
+		return tag, nil
+	case r.aliasArtifactType:
+		canonical := manifest.Annotations[AliasTargetAnnotation]
+		if canonical == "" {
+			return "", fmt.Errorf("alias manifest %q is missing %s annotation", tag, AliasTargetAnnotation)
+		}
+		return canonical, nil
+	default:
+		return "", fmt.Errorf("%w: tag %q has artifactType %q", ErrAliasCollision, tag, manifest.ArtifactType)
+	}
+}
+
 // ListFiles enumerates all files across all canonical versions in repo.
 // Aliases are skipped by checking each tag's manifest artifactType so the
 // same file isn't reported twice. The blob digest comes from the

--- a/pkg/oci/registry_test.go
+++ b/pkg/oci/registry_test.go
@@ -427,6 +427,24 @@ func TestAddReadRoundtrip(t *testing.T) {
 		t.Fatalf("AppendRefs() error = %v", err)
 	}
 
+	tests := []struct {
+		name string
+		tag  string
+		want string
+	}{
+		{name: "canonical", tag: "v0", want: "v0"},
+		{name: "alias", tag: "tag1", want: "v0"},
+	}
+	for _, tc := range tests {
+		got, err := r.ResolveTag(ctx, "foobar", tc.tag)
+		if err != nil {
+			t.Fatalf("ResolveTag %s: %v", tc.name, err)
+		}
+		if got != tc.want {
+			t.Errorf("ResolveTag %s = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+
 	// Read by ref tag.
 	if gotDesc, body, err := r.ReadFile(ctx, &RepoFile{
 		OwningRepo: "foobar",

--- a/pkg/proxy/indexcache/indexcache.go
+++ b/pkg/proxy/indexcache/indexcache.go
@@ -81,7 +81,7 @@ const (
 // the package name. The `ocifactory-` prefix matches the in-tree
 // convention for registry-internal repos (compare
 // [pkg/namespace.indexRepoSegment] = "ocifactory-namespaces" and
-// [pkg/namespace.Registry] / "ocifactory-packages"), keeping cache
+// [pkg/artifact.Store] / "ocifactory-packages"), keeping cache
 // repos visually distinct from real `<namespace>/packages/...`
 // storage when an operator lists the OCI registry. The literal here
 // is a single OCI distribution name component followed by

--- a/pkg/proxy/python/python.go
+++ b/pkg/proxy/python/python.go
@@ -12,7 +12,7 @@
 // pointed at (typically files.pythonhosted.org). The fetcher does not
 // know about OCI: it returns response bodies and the caller (the
 // python handler's proxy path) tees them through
-// [pkg/artifact.ScopedNamespace.AddFile] while serving the client.
+// [pkg/artifact.NamespaceView.AddFile] while serving the client.
 //
 // There is no shared Fetcher interface — see the design issue
 // (#118) for why. The handler holds a concrete *Fetcher and calls the

--- a/pkg/proxy/python/python.go
+++ b/pkg/proxy/python/python.go
@@ -12,7 +12,7 @@
 // pointed at (typically files.pythonhosted.org). The fetcher does not
 // know about OCI: it returns response bodies and the caller (the
 // python handler's proxy path) tees them through
-// [pkg/namespace.ScopedRegistry.AddFile] while serving the client.
+// [pkg/artifact.ScopedNamespace.AddFile] while serving the client.
 //
 // There is no shared Fetcher interface — see the design issue
 // (#118) for why. The handler holds a concrete *Fetcher and calls the


### PR DESCRIPTION
## Motivation
Format handlers still interact with OCI storage through raw repo strings and oci.RepoFile. This PR starts the refactor toward a namespace-scoped artifact API centered on package, version, tag, and file nouns.

Closes #134

## Summary
- Adds pkg/artifact with Namespace, Package, Version, Tag, FilePut, FileInfo, and FileHandle types backed by namespace.ScopedRegistry.
- Adds ResolveTag at the OCI, namespace, and artifact layers; canonical tags resolve to themselves and alias tags resolve to their target Version.
- Adds behavior tests covering namespace resolution, package file put/get/list, tag aliases, invalid package paths, and download URL fallback.
- Migrates Python hosted upload/download/package-index file listing paths onto artifact.Package/FileHandle.
- Migrates npm publish writes, dist-tag writes, packument dist-tag resolution, and dist-tag reads onto artifact.Package/ResolveTag.
- Leaves proxy cache-fill paths and Maven for follow-up slices.

## Tests
- go test -short ./...
- go test -race -short ./...